### PR TITLE
fix: resolve 5 failing tests in core package

### DIFF
--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -365,12 +365,15 @@ describe('Agent', () => {
     it('rejects when already processing', async () => {
       const agent = new Agent(createTestConfig());
 
-      // Manually set processing state using internal state manipulation
-      // We'll test this by calling chat when provider is not ready
+      // Set isProcessing to true via internal state to simulate an in-flight request
+      (agent as any)['state'] = { ...(agent as any)['state'], isProcessing: true };
+
       const result = await agent.chat('Hello');
 
-      // Should return validation error since no actual API
       expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.message).toContain('already processing');
+      }
     });
 
     it('rejects when provider not ready', async () => {

--- a/packages/core/src/agent/tools/file-system.test.ts
+++ b/packages/core/src/agent/tools/file-system.test.ts
@@ -34,6 +34,16 @@ vi.mock('../../security/self-protection.js', () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Mock node:dns/promises to prevent real DNS lookups in SSRF protection
+// ---------------------------------------------------------------------------
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async () => {
+    // Return a public IP for any hostname in tests
+    return [{ address: '93.184.216.34', family: 4 }];
+  }),
+}));
+
+// ---------------------------------------------------------------------------
 // Import SUT after mocks are registered
 // ---------------------------------------------------------------------------
 import {


### PR DESCRIPTION
- agent.test.ts: Fix "rejects when already processing" test by properly
  setting isProcessing state before calling chat(), matching the test's intent
- file-system.test.ts: Add node:dns/promises mock to prevent real DNS lookups
  in downloadFileExecutor tests, which caused 4 timeouts due to SSRF protection

https://claude.ai/code/session_01MYhaSC3uFt1bNhWETnowde