### PR TITLE
security: remediate Critical RCEs + High/Medium findings (scan 2026-06-01)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,18 +28,18 @@ jobs:
         node-version: [22]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
 
       - name: Cache Turbo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
@@ -102,12 +102,12 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: 'pnpm'

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -25,10 +25,10 @@ jobs:
         working-directory: website
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'npm'
@@ -41,10 +41,10 @@ jobs:
         run: npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: website/dist
 
@@ -57,4 +57,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,20 +19,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Use Node.js 22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: 'pnpm'
 
       - name: Cache Turbo
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .turbo
           key: turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
@@ -59,10 +59,10 @@ jobs:
         run: TURBO_FORCE=true pnpm test
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/ownpilot/ownpilot
           tags: |
@@ -79,7 +79,7 @@ jobs:
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true
@@ -90,6 +90,6 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           generate_release_notes: true

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -22,6 +22,11 @@ services:
       - '127.0.0.1:${POSTGRES_PORT:-25432}:5432'
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-ownpilot}
+      # SECURITY (DOCK-003): `ownpilot_secret` is a committed, publicly-known
+      # fallback intended ONLY for local development. The port above is bound to
+      # 127.0.0.1, so the DB is never exposed beyond this host. For any shared,
+      # remote, or production use you MUST set POSTGRES_PASSWORD in your .env to
+      # a strong secret (the gateway reads the same value).
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-ownpilot_secret}
       POSTGRES_DB: ${POSTGRES_DB:-ownpilot}
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,8 +86,13 @@ services:
     container_name: ownpilot-mosquitto
     restart: unless-stopped
     ports:
-      - '${MQTT_PORT:-1883}:1883'
-      - '${MQTT_WS_PORT:-9001}:9001'
+      # SECURITY (DOCK-004/IAC-002): bind to IPv4 loopback only. The broker
+      # ships with allow_anonymous=true, so exposing these ports on 0.0.0.0
+      # would give any host on the LAN full read/write on all MQTT topics
+      # (including edge-device control + agent messaging). Other containers
+      # still reach the broker over the compose network by service name.
+      - '127.0.0.1:${MQTT_PORT:-1883}:1883'
+      - '127.0.0.1:${MQTT_WS_PORT:-9001}:9001'
     volumes:
       - ./packages/gateway/docker/mosquitto/config:/mosquitto/config:ro
       - mosquitto-data:/mosquitto/data

--- a/packages/core/src/credentials/index.ts
+++ b/packages/core/src/credentials/index.ts
@@ -218,7 +218,10 @@ function deriveKey(masterKey: string, salt?: Buffer): Buffer {
   if (salt) {
     return pbkdf2Sync(masterKey, salt, PBKDF2_ITERATIONS, 32, 'sha256');
   }
-  // Legacy fallback — single SHA-256 (no brute-force resistance)
+  // Legacy fallback — single SHA-256 (no brute-force resistance). Retained
+  // ONLY to read pre-salt entries; those are re-encrypted with PBKDF2+salt on
+  // first read via migrateLegacyEntryIfNeeded (CRYPTO-004), so this path is
+  // self-healing and a no-salt entry should not persist past one read.
   return createHash('sha256').update(masterKey).digest();
 }
 
@@ -337,6 +340,25 @@ export class UserCredentialStore {
   }
 
   /**
+   * CRYPTO-004: lazily upgrade legacy (no-salt, single-SHA-256) entries to the
+   * PBKDF2+salt scheme the first time they are successfully decrypted, so the
+   * weak O(1) key derivation never survives a read. Non-fatal on failure — a
+   * migration error must never break a credential read.
+   */
+  private async migrateLegacyEntryIfNeeded(
+    entry: CredentialEntry,
+    plaintext: string
+  ): Promise<void> {
+    if (entry.salt) return;
+    try {
+      const { encrypted, iv, salt } = encryptValue(plaintext, this.config.encryptionKey);
+      await this.backend.set({ ...entry, encryptedValue: encrypted, iv, salt });
+    } catch {
+      // best-effort; keep serving the decrypted value
+    }
+  }
+
+  /**
    * Get a credential for use
    */
   async get(userId: string, provider: CredentialProvider): Promise<Credential | null> {
@@ -358,6 +380,9 @@ export class UserCredentialStore {
       this.config.encryptionKey,
       entry.salt
     );
+
+    // CRYPTO-004: upgrade legacy no-salt entries on read.
+    await this.migrateLegacyEntryIfNeeded(entry, value);
 
     // Update usage
     await this.updateUsage(entry);
@@ -393,6 +418,9 @@ export class UserCredentialStore {
       this.config.encryptionKey,
       entry.salt
     );
+
+    // CRYPTO-004: upgrade legacy no-salt entries on read.
+    await this.migrateLegacyEntryIfNeeded(entry, value);
 
     // Update usage
     await this.updateUsage(entry);

--- a/packages/core/src/sandbox/code-validator.test.ts
+++ b/packages/core/src/sandbox/code-validator.test.ts
@@ -122,6 +122,24 @@ describe('new dangerous patterns', () => {
     expect(result.valid).toBe(false);
     expect(result.errors).toContain('Atomics is not allowed (timing attack vector)');
   });
+
+  // RCE-001 regression: the constructor-walk escape relies on splitting the
+  // word "constructor" across string-concat to evade the literal-token check.
+  // Every single split point must be caught. (Defense-in-depth; the VM sandbox
+  // itself no longer injects host objects, so even a 3-way split cannot escape.)
+  it.each([
+    `Math['constructo'+'r']('return process')`,
+    `Math['construct'+'or']('x')`,
+    `Math['con'+'structor']('x')`,
+    `Math['constr'+'uctor']('x')`,
+    `Math['constru'+'ctor']('x')`,
+    `obj['co'+'nstructor']`,
+    `obj['constructo' + 'r']`,
+  ])('blocks split-string constructor access: %s', (code) => {
+    const result = validateToolCode(code);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('string-concat constructor access is not allowed');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/sandbox/code-validator.ts
+++ b/packages/core/src/sandbox/code-validator.ts
@@ -106,15 +106,21 @@ export const DANGEROUS_CODE_PATTERNS: ReadonlyArray<CodeValidationPattern> = [
     pattern: /[.[]\s*['"]?\s*constructor\b/,
     message: 'constructor property access is not allowed',
   },
-  // String-concat bypass — `obj['construct'+'or']` evades the literal-token
+  // String-concat bypass — `obj['constructo'+'r']` evades the literal-token
   // check above. Legitimate code does not assemble the word "constructor"
-  // from fragments. Catch the common splits explicitly.
+  // from fragments. These two patterns cover EVERY single split point of the
+  // word (left prefix immediately followed by `+`, or `+` immediately followed
+  // by a right suffix). NOTE: this is defense-in-depth only — the real fix is
+  // that the VM sandbox no longer injects any host-realm object, so even a
+  // multi-fragment split that evades these regexes can only reach the
+  // context-realm Function constructor, which `codeGeneration.strings:false`
+  // disables. See services/extension/sandbox.ts (RCE-001).
   {
-    pattern: /(['"]construct['"]|['"]constr['"]|['"]con['"]).*\+/,
+    pattern: /['"](?:co|con|cons|const|constr|constru|construc|construct|constructo)['"]\s*\+/,
     message: 'string-concat constructor access is not allowed',
   },
   {
-    pattern: /\+.*?(['"]uctor['"]|['"]ructor['"]|['"]tor['"]|['"]structor['"])/,
+    pattern: /\+\s*['"](?:r|or|tor|ctor|uctor|ructor|tructor|structor|nstructor|onstructor)['"]/,
     message: 'string-concat constructor access is not allowed',
   },
   { pattern: /\bgetPrototypeOf\b/, message: 'getPrototypeOf is not allowed' },

--- a/packages/gateway/src/channels/service-impl.ts
+++ b/packages/gateway/src/channels/service-impl.ts
@@ -6,7 +6,7 @@
  * through EventBus, handles verification, and manages sessions.
  */
 
-import { timingSafeEqual } from 'node:crypto';
+import { timingSafeEqual, randomInt } from 'node:crypto';
 import {
   type IChannelService,
   type ChannelOutgoingMessage,
@@ -1430,8 +1430,10 @@ export class ChannelServiceImpl implements IChannelService {
     senderUserId: string,
     _ownerUserId: string
   ): Promise<string> {
-    // Generate 6-digit code
-    const code = String(Math.floor(100000 + Math.random() * 900000));
+    // Generate 6-digit code. SECURITY (EXPOSE-004): use a CSPRNG — Math.random()
+    // is a non-cryptographic PRNG whose internal state can be recovered from a
+    // few observed outputs, making pairing codes predictable/brute-forceable.
+    const code = String(randomInt(100000, 1000000));
 
     // Store in verification_tokens
     await this.dmPairingRequests.create({

--- a/packages/gateway/src/db/repositories/logs.test.ts
+++ b/packages/gateway/src/db/repositories/logs.test.ts
@@ -178,6 +178,18 @@ describe('LogsRepository', () => {
       expect(params[18]).toBeNull(); // userAgent
     });
 
+    it('truncates an oversized error stack to the cap (EXPOSE-001)', async () => {
+      mockAdapter.execute.mockResolvedValueOnce({ changes: 1 });
+      mockAdapter.queryOne.mockResolvedValueOnce(makeLogRow());
+
+      const hugeStack = 'Error: boom\n' + '    at frame\n'.repeat(5000);
+      await repo.log({ type: 'chat', errorStack: hugeStack });
+
+      const params = mockAdapter.execute.mock.calls[0]![1] as unknown[];
+      expect((params[16] as string).length).toBe(2000); // persisted stack capped
+      expect(params[16]).toBe(hugeStack.slice(0, 2000));
+    });
+
     it('should return a fallback log entry when insert fails', async () => {
       mockAdapter.execute.mockRejectedValueOnce(new Error('DB connection lost'));
 

--- a/packages/gateway/src/db/repositories/logs.ts
+++ b/packages/gateway/src/db/repositories/logs.ts
@@ -9,6 +9,12 @@ import { getLog } from '../../services/log.js';
 
 const log = getLog('LogsRepo');
 
+// EXPOSE-001: bound how much of a JS error stack we persist. Full stacks leak
+// internal file paths / code structure into request_logs (which is included in
+// per-user DB exports) and bloat the table. Keep the top frames (enough to
+// debug) and drop the rest.
+const MAX_ERROR_STACK_LEN = 2000;
+
 // =====================================================
 // TYPES
 // =====================================================
@@ -152,6 +158,7 @@ export class LogsRepository extends BaseRepository {
   async log(input: CreateLogInput): Promise<RequestLog> {
     const id = crypto.randomUUID();
     const now = new Date().toISOString();
+    const errorStack = input.errorStack ? input.errorStack.slice(0, MAX_ERROR_STACK_LEN) : null;
 
     try {
       await this.execute(
@@ -177,7 +184,7 @@ export class LogsRepository extends BaseRepository {
           input.totalTokens || null,
           input.durationMs || null,
           input.error || null,
-          input.errorStack || null,
+          errorStack,
           input.ipAddress || null,
           input.userAgent || null,
           now,
@@ -207,7 +214,7 @@ export class LogsRepository extends BaseRepository {
         totalTokens: input.totalTokens || null,
         durationMs: input.durationMs || null,
         error: input.error || null,
-        errorStack: input.errorStack || null,
+        errorStack,
         ipAddress: input.ipAddress || null,
         userAgent: input.userAgent || null,
         createdAt: new Date(now),

--- a/packages/gateway/src/routes/chat/index.test.ts
+++ b/packages/gateway/src/routes/chat/index.test.ts
@@ -96,7 +96,17 @@ vi.mock('../../services/usage-tracking.js', () => ({
   usageTracker: {
     record: vi.fn(),
   },
+  budgetManager: {
+    canSpend: vi.fn(async () => ({ allowed: true })),
+    on: vi.fn(),
+  },
 }));
+
+// Pull the SAME budgetManager reference that the route under test sees, so
+// we can override canSpend per-test. `vi.mock` is hoisted above this import
+// (vitest's auto-hoist) and replaces the module's exports; importing here
+// gets the mocked object, not the real one.
+import { budgetManager as mockBudgetManager } from '../../services/usage-tracking.js';
 
 vi.mock('../../audit/index.js', () => ({
   logChatEvent: vi.fn(async () => {}),
@@ -149,6 +159,19 @@ vi.mock('../../tools/index.js', () => ({
   executePlanTool: vi.fn(),
   SOUL_COMMUNICATION_TOOLS: [],
   executeSoulCommunicationTool: vi.fn(),
+}));
+
+// Mock the usage-tracking service so tests can flip budget decisions per-case.
+// (mockBudgetManager is imported once at the top of the file — see line ~104.)
+
+vi.mock('../../db/repositories/model-configs.js', () => ({
+  modelConfigsRepo: {
+    getModel: vi.fn(async () => null),
+    saveModel: vi.fn(),
+    listModels: vi.fn(async () => []),
+    deleteModel: vi.fn(),
+  },
+  ModelConfigsRepository: vi.fn(),
 }));
 
 vi.mock('../../tools/config-tools.js', () => ({
@@ -256,6 +279,19 @@ vi.mock('@ownpilot/core', () => ({
     computeMemoryMaxTokens: vi.fn(() => 8192),
     calculateCost: vi.fn(() => 0),
   }),
+  // BUDGET-001: chat route's pre-spend check uses these from @ownpilot/core.
+  // Returning a tiny positive cost keeps the budget check on the happy path
+  // in the pre-existing tests; the dedicated budget tests mock canSpend
+  // directly to override the result.
+  estimateCost: vi.fn((_provider: string, _model: string, text: string, outTokens = 500) => ({
+    provider: _provider,
+    model: _model,
+    estimatedInputTokens: Math.ceil((text ?? '').length / 4),
+    estimatedOutputTokens: outTokens,
+    estimatedCost: 0.001,
+    withinBudget: true,
+  })),
+  formatCost: vi.fn((n: number) => `${n.toFixed(4)}`),
 }));
 
 vi.mock('../../services/memory-service.js', () => ({
@@ -1746,5 +1782,116 @@ describe('Chat Routes', () => {
       const res = await app.request('/chat/fetch-url?url=https%3A%2F%2Fexample.com');
       expect(res.status).toBe(400);
     });
+  });
+});
+
+// =====================================================================
+// Budget enforcement (BUDGET-001)
+//
+// Verifies the chat route consults BudgetManager.canSpend() before any
+// LLM call is dispatched, and that:
+//   - allowed=true   → request proceeds (no extra header, no audit noise)
+//   - allowed=false  → request is rejected with 429 and a structured body
+//   - canSpend() throws → request is allowed through (fail-open) and a
+//                          warning is logged. We don't assert on the log.
+// =====================================================================
+describe('Chat route — pre-spend budget enforcement', () => {
+  const baseBody = {
+    message: 'hello world',
+    provider: 'openai',
+    model: 'gpt-4o',
+  };
+
+  // Local Hono app — the outer describe('Chat Routes') owns its own `app`
+  // and these tests need to be runnable in isolation as well.
+  let app: Hono;
+
+  beforeEach(() => {
+    (mockBudgetManager.canSpend as ReturnType<typeof vi.fn>).mockReset();
+    app = new Hono();
+    app.onError(errorHandler);
+    app.route('/chat', chatRoutes);
+    // Make sure demo mode is off — the chat route short-circuits in demo
+    // mode, which would mask the budget check.
+    vi.mocked(isDemoMode).mockResolvedValue(false);
+  });
+
+  it('allows the request when budgetManager.canSpend returns allowed=true', async () => {
+    (mockBudgetManager.canSpend as ReturnType<typeof vi.fn>).mockResolvedValue({
+      allowed: true,
+    });
+    const res = await app.request('/chat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseBody),
+    });
+    expect(res.status).toBe(200);
+    // canSpend must have been called with a positive estimate
+    expect(mockBudgetManager.canSpend).toHaveBeenCalledTimes(1);
+    const est = (mockBudgetManager.canSpend as ReturnType<typeof vi.fn>).mock.calls[0][0] as number;
+    expect(est).toBeGreaterThan(0);
+    // No X-Budget-* headers when allowed
+    expect(res.headers.get('X-Budget-Blocked')).toBeNull();
+    expect(res.headers.get('X-Budget-Warning')).toBeNull();
+  });
+
+  it('blocks the request with 429 when canSpend returns allowed=false', async () => {
+    (mockBudgetManager.canSpend as ReturnType<typeof vi.fn>).mockResolvedValue({
+      allowed: false,
+      reason: 'Daily budget exceeded ($5.10 > $5.00)',
+      recommendation: 'Wait until tomorrow or increase daily limit',
+    });
+    const res = await app.request('/chat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseBody),
+    });
+    expect(res.status).toBe(429);
+    expect(res.headers.get('X-Budget-Blocked')).toBe('true');
+    expect(res.headers.get('X-Budget-Reason')).toContain('Daily budget exceeded');
+    const body = await res.json();
+    expect(body.error.message).toContain('Daily budget exceeded');
+    expect(body.error.recommendation).toContain('Wait until tomorrow');
+  });
+
+  it('emits an X-Budget-Warning header (but does not block) on warn-mode overage', async () => {
+    (mockBudgetManager.canSpend as ReturnType<typeof vi.fn>).mockResolvedValue({
+      allowed: true,
+      reason: 'Daily budget exceeded but soft limit is on',
+    });
+    const res = await app.request('/chat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseBody),
+    });
+    // allowed=true ⇒ no block, but the reason is surfaced so the client can warn
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-Budget-Blocked')).toBeNull();
+    expect(res.headers.get('X-Budget-Warning')).toContain('soft limit');
+  });
+
+  it('fails open (allows the request) when canSpend throws', async () => {
+    (mockBudgetManager.canSpend as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('budget service unavailable')
+    );
+    const res = await app.request('/chat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(baseBody),
+    });
+    // Fail-open: a misconfigured budget must not break the chat API.
+    expect(res.status).toBe(200);
+  });
+
+  it('does not consult the budget manager for CLI providers (no real spend)', async () => {
+    (mockBudgetManager.canSpend as ReturnType<typeof vi.fn>).mockClear();
+    const res = await app.request('/chat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...baseBody, provider: 'cli-claude', model: 'cli-default' }),
+    });
+    expect(res.status).toBe(200);
+    // CLI providers have no cost — the budget gate must skip them entirely
+    expect(mockBudgetManager.canSpend).not.toHaveBeenCalled();
   });
 });

--- a/packages/gateway/src/routes/chat/index.ts
+++ b/packages/gateway/src/routes/chat/index.ts
@@ -53,6 +53,8 @@ import { getLog } from '../../services/log.js';
 import { PUBLIC_BASE_URL, MS_PER_MINUTE } from '../../config/defaults.js';
 import { createLoginThrottle } from '../../utils/login-throttle.js';
 import { getClientIp } from '../../utils/client-ip.js';
+import { budgetManager } from '../../services/usage-tracking.js';
+import { estimateCost, formatCost, type AIProvider } from '@ownpilot/core';
 
 // RATE-003: per-IP throttle for the chat endpoint. /chat is the single
 // most expensive endpoint — every request hits a paid LLM provider
@@ -329,6 +331,47 @@ chatRoutes.post('/', async (c) => {
     userContextWindow = userConfig?.contextWindow ?? undefined;
   } catch {
     // Fall back to pricing defaults if DB lookup fails
+  }
+
+  // Pre-spend budget check (BUDGET-001): a configured daily/weekly/monthly or
+  // per-request budget MUST be enforced before any LLM call is dispatched, or
+  // a buggy agent loop / runaway client can burn through the operator's
+  // monthly LLM budget in minutes. We estimate cost from the user message
+  // text + a conservative output budget; `budgetManager.canSpend()` already
+  // consults perRequestLimit, dailyLimit, weeklyLimit, monthlyLimit and
+  // respects `limitAction` (warn vs block). We only block when allowed=false
+  // AND limitAction=block. With limitAction=warn we surface a header so the
+  // client can show a soft warning but the request still goes through.
+  // Skip in demo mode (no real spend) and on errors from the budget manager
+  // (fail-open: a misconfigured budget should not break the API).
+  if (provider && model && !provider.startsWith('cli-')) {
+    try {
+      const estimate = estimateCost(provider as AIProvider, model, body.message ?? '', 1000);
+      const decision = await budgetManager.canSpend(estimate.estimatedCost);
+      if (!decision.allowed) {
+        log.warn(
+          `[Chat] Blocked by budget: ${decision.reason} (est. ${formatCost(estimate.estimatedCost)})`
+        );
+        c.header('X-Budget-Blocked', 'true');
+        c.header('X-Budget-Reason', decision.reason ?? 'budget_exceeded');
+        return apiError(
+          c,
+          {
+            code: ERROR_CODES.RATE_LIMITED,
+            message: decision.reason ?? 'Request blocked by budget policy.',
+            ...(decision.recommendation && { recommendation: decision.recommendation }),
+          },
+          429
+        );
+      }
+      if (decision.reason) {
+        // warn-mode overage — proceed but signal it to the client
+        c.header('X-Budget-Warning', decision.reason);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn(`[Chat] Budget check failed (allowing request): ${msg}`);
+    }
   }
 
   // Get agent based on agentId or provider/model from request

--- a/packages/gateway/src/routes/costs.test.ts
+++ b/packages/gateway/src/routes/costs.test.ts
@@ -72,6 +72,11 @@ const mockUsageTracker = {
 const mockBudgetManager = {
   getStatus: vi.fn(async () => mockBudgetStatus),
   configure: vi.fn(),
+  // BUDGET-002: usage-tracking.ts calls budgetManager.on('alert', ...) on
+  // module load. The real BudgetManager extends EventEmitter; the mock just
+  // needs an on() that swallows the registration.
+  on: vi.fn(),
+  emit: vi.fn(),
 };
 
 vi.mock('@ownpilot/core', async (importOriginal) => {

--- a/packages/gateway/src/routes/database/shared.ts
+++ b/packages/gateway/src/routes/database/shared.ts
@@ -76,8 +76,12 @@ export const EXPORT_TABLES = [
   'local_models',
   // Edge
   'edge_devices',
-  // System
-  'system_settings',
+  // SECURITY (EXPOSE-002): `system_settings` is intentionally NOT exportable.
+  // It holds only regenerable runtime secrets (gateway API keys, JWT secret,
+  // channel pairing/ownership keys) — never user data — so dumping it into a
+  // portable, unencrypted backup/CSV leaked auth secrets to anyone with the
+  // export. Removing it from this allowlist blocks export, CSV download, and
+  // import of the table. Secrets are recreated by the gateway on next start.
 ];
 
 // --- SQL Injection Protection ---

--- a/packages/gateway/src/routes/extensions/install.test.ts
+++ b/packages/gateway/src/routes/extensions/install.test.ts
@@ -24,6 +24,11 @@ vi.mock('../../paths/index.js', () => ({
   getDataDirectoryInfo: vi.fn(() => ({ root: '/tmp/ownpilot-test' })),
 }));
 
+// PATH-001: install path must be within an allowed scan directory.
+vi.mock('../../services/extension/scanner.js', () => ({
+  getAllScanDirectories: () => ['/allowed'],
+}));
+
 const mockExistsSync = vi.fn(() => true);
 const mockMkdirSync = vi.fn();
 const mockReaddirSync = vi.fn(() => [] as unknown[]);
@@ -378,7 +383,7 @@ describe('POST /ext/install — from file path', () => {
 
     const res = await app.request('/ext/install', {
       method: 'POST',
-      body: JSON.stringify({ path: '/home/user/my-skill/SKILL.md' }),
+      body: JSON.stringify({ path: '/allowed/my-skill/SKILL.md' }),
       headers: { 'Content-Type': 'application/json' },
     });
     expect(res.status).toBe(201);
@@ -391,7 +396,7 @@ describe('POST /ext/install — from file path', () => {
 
     const res = await app.request('/ext/install', {
       method: 'POST',
-      body: JSON.stringify({ path: '/missing/SKILL.md' }),
+      body: JSON.stringify({ path: '/allowed/missing/SKILL.md' }),
       headers: { 'Content-Type': 'application/json' },
     });
     expect(res.status).toBe(400);
@@ -404,9 +409,21 @@ describe('POST /ext/install — from file path', () => {
 
     const res = await app.request('/ext/install', {
       method: 'POST',
-      body: JSON.stringify({ path: '/some/path' }),
+      body: JSON.stringify({ path: '/allowed/some/path' }),
       headers: { 'Content-Type': 'application/json' },
     });
     expect(res.status).toBe(500);
+  });
+
+  it('rejects a path outside the allowed scan directories (PATH-001)', async () => {
+    const res = await app.request('/ext/install', {
+      method: 'POST',
+      body: JSON.stringify({ path: '/etc/shadow' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error.message).toContain('extensions or skills directory');
+    expect(mockExtService.install).not.toHaveBeenCalled();
   });
 });

--- a/packages/gateway/src/routes/extensions/install.ts
+++ b/packages/gateway/src/routes/extensions/install.ts
@@ -26,6 +26,7 @@ import {
   normalizeArchiveEntryPath,
   sanitizeFilenameSegment,
 } from '../../utils/file-safety.js';
+import { getAllScanDirectories } from '../../services/extension/scanner.js';
 import { createLoginThrottle } from '../../utils/login-throttle.js';
 import { getClientIp } from '../../utils/client-ip.js';
 import { MS_PER_MINUTE } from '../../config/defaults.js';
@@ -182,9 +183,26 @@ installRoutes.post('/install', async (c) => {
     );
   }
 
+  // SECURITY (PATH-001): install() does readFileSync(path) with no containment.
+  // Without this guard any authenticated caller could read arbitrary files on
+  // the host (e.g. /etc/shadow, ~/.ssh/id_rsa). Restrict the path to the known
+  // extensions/skills scan directories — the only legitimate install sources.
+  const requestedPath = (body as { path: string }).path;
+  const allowedRoots = getAllScanDirectories();
+  if (!allowedRoots.some((root) => isWithinDirectory(root, requestedPath))) {
+    return apiError(
+      c,
+      {
+        code: ERROR_CODES.VALIDATION_ERROR,
+        message: 'path must be inside an extensions or skills directory',
+      },
+      400
+    );
+  }
+
   try {
     const service = getExtService();
-    const record = await service.install((body as { path: string }).path, userId);
+    const record = await service.install(requestedPath, userId);
     wsGateway.broadcast('data:changed', { entity: 'extension', action: 'created', id: record.id });
     // Audit extension install — registers new code, tools, and triggers
     // in the runtime, plus any permissions the manifest declared.

--- a/packages/gateway/src/routes/extensions/integration.test.ts
+++ b/packages/gateway/src/routes/extensions/integration.test.ts
@@ -94,6 +94,11 @@ vi.mock('../../services/extension/types.js', () => ({
   validateManifest: vi.fn(() => ({ valid: true, errors: [] })),
 }));
 
+// PATH-001: install path must be within an allowed scan directory.
+vi.mock('../../services/extension/scanner.js', () => ({
+  getAllScanDirectories: () => ['/path/to'],
+}));
+
 vi.mock('@ownpilot/core', () => ({
   createProvider: vi.fn(() => ({ complete: mockComplete })),
   getProviderConfig: vi.fn(() => null),

--- a/packages/gateway/src/routes/openapi.test.ts
+++ b/packages/gateway/src/routes/openapi.test.ts
@@ -5,7 +5,7 @@
  * fake API endpoints and verifies the served spec covers them.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { Hono } from 'hono';
 import { registerOpenApiRoutes } from './openapi.js';
 
@@ -59,5 +59,33 @@ describe('OpenAPI routes', () => {
     const html = await res.text();
     expect(html).toContain('swagger-ui');
     expect(html).toContain('/openapi.json');
+  });
+
+  describe('API-001 production gate', () => {
+    const prevEnv = process.env.NODE_ENV;
+    const prevFlag = process.env.ENABLE_API_DOCS;
+    afterEach(() => {
+      process.env.NODE_ENV = prevEnv;
+      if (prevFlag === undefined) delete process.env.ENABLE_API_DOCS;
+      else process.env.ENABLE_API_DOCS = prevFlag;
+    });
+
+    it('does not register docs in production by default', async () => {
+      process.env.NODE_ENV = 'production';
+      delete process.env.ENABLE_API_DOCS;
+      const prod = new Hono();
+      registerOpenApiRoutes(prod);
+      expect((await prod.request('/openapi.json')).status).toBe(404);
+      expect((await prod.request('/docs')).status).toBe(404);
+    });
+
+    it('registers docs in production when ENABLE_API_DOCS=true', async () => {
+      process.env.NODE_ENV = 'production';
+      process.env.ENABLE_API_DOCS = 'true';
+      const prod = new Hono();
+      registerOpenApiRoutes(prod);
+      expect((await prod.request('/openapi.json')).status).toBe(200);
+      expect((await prod.request('/docs')).status).toBe(200);
+    });
   });
 });

--- a/packages/gateway/src/routes/openapi.ts
+++ b/packages/gateway/src/routes/openapi.ts
@@ -15,6 +15,16 @@ import { SWAGGER_UI_HTML } from '../openapi/swagger-html.js';
 import { VERSION } from '@ownpilot/core';
 
 export function registerOpenApiRoutes(app: Hono): void {
+  // API-001: the OpenAPI spec and Swagger UI disclose the entire API surface to
+  // anonymous callers. They are a development aid, so they are disabled in
+  // production unless an operator explicitly opts in via ENABLE_API_DOCS=true.
+  // Outside production they remain on for convenience. This deliberately avoids
+  // wiring docs into the session-auth model (which has had IDOR/login-loop
+  // regressions) — a hard on/off switch is the lower-risk control.
+  const docsEnabled =
+    process.env.NODE_ENV !== 'production' || process.env.ENABLE_API_DOCS === 'true';
+  if (!docsEnabled) return;
+
   let cached: OpenApiSpec | null = null;
 
   app.get('/openapi.json', (c) => {

--- a/packages/gateway/src/services/agent/runner-utils.test.ts
+++ b/packages/gateway/src/services/agent/runner-utils.test.ts
@@ -122,6 +122,12 @@ vi.mock('../log.js', () => ({
   }),
 }));
 
+// BIZ-001: budget pre-spend check in executeAgentPipeline.
+const mockCanSpend = vi.hoisted(() => vi.fn());
+vi.mock('../usage-tracking.js', () => ({
+  budgetManager: { canSpend: mockCanSpend },
+}));
+
 // ============================================================================
 // Import after mocks
 // ============================================================================
@@ -136,6 +142,8 @@ import {
   calculateExecutionCost,
   registerAllToolSources,
   createConfiguredAgent,
+  executeAgentPipeline,
+  BudgetExceededError,
 } from './runner-utils.js';
 
 // ============================================================================
@@ -621,4 +629,55 @@ afterEach(async () => {
   resetHeartbeatService();
   resetPulseMetricsService();
   resetServiceRegistrySync();
+});
+
+describe('executeAgentPipeline() — budget enforcement (BIZ-001)', () => {
+  beforeEach(() => {
+    mockCanSpend.mockReset();
+  });
+
+  it('throws BudgetExceededError and never calls the LLM when budget blocks', async () => {
+    mockCanSpend.mockResolvedValueOnce({ allowed: false, reason: 'daily limit reached' });
+    const chat = vi.fn();
+    await expect(
+      executeAgentPipeline('anthropic', 'claude-3-opus', {
+        agent: { chat } as never,
+        message: 'do something expensive',
+        timeoutMs: 5000,
+        agentId: 'claw-1',
+      })
+    ).rejects.toBeInstanceOf(BudgetExceededError);
+    expect(mockCanSpend).toHaveBeenCalledTimes(1);
+    expect(chat).not.toHaveBeenCalled();
+  });
+
+  it('proceeds (fail-open) when the budget subsystem throws', async () => {
+    mockCanSpend.mockRejectedValueOnce(new Error('db down'));
+    const chat = vi.fn().mockResolvedValue({
+      ok: true,
+      value: { content: 'ok', usage: { promptTokens: 1, completionTokens: 1 } },
+    });
+    const res = await executeAgentPipeline('anthropic', 'claude-3-opus', {
+      agent: { chat } as never,
+      message: 'hi',
+      timeoutMs: 5000,
+      agentId: 'claw-1',
+    });
+    expect(chat).toHaveBeenCalledTimes(1);
+    expect(res.content).toBe('ok');
+  });
+
+  it('skips the budget check for cli- providers', async () => {
+    const chat = vi
+      .fn()
+      .mockResolvedValue({ ok: true, value: { content: 'cli', usage: undefined } });
+    await executeAgentPipeline('cli-claude', 'sonnet', {
+      agent: { chat } as never,
+      message: 'hi',
+      timeoutMs: 5000,
+      agentId: 'claw-1',
+    });
+    expect(mockCanSpend).not.toHaveBeenCalled();
+    expect(chat).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/gateway/src/services/agent/runner-utils.ts
+++ b/packages/gateway/src/services/agent/runner-utils.ts
@@ -28,7 +28,8 @@ import { getLog } from '../log.js';
 import { resolveForProcess } from '../llm/model-routing.js';
 import { getProviderApiKey, loadProviderConfig, NATIVE_PROVIDERS } from './cache.js';
 import { resolveAuthForRequest } from '../auth/oauth-flow.js';
-import { getLLMRouter, getConfigCenter } from '@ownpilot/core';
+import { getLLMRouter, getConfigCenter, estimateCost } from '@ownpilot/core';
+import { budgetManager } from '../usage-tracking.js';
 import {
   registerGatewayTools,
   registerDynamicTools,
@@ -587,12 +588,54 @@ function createCancellationPromise(signal: AbortSignal): {
  * - Building the message
  * - Mapping `AgentPipelineResult` to its own domain result type
  */
+/**
+ * Thrown when a pre-spend budget check blocks an autonomous LLM call (BIZ-001).
+ * Distinct type so the fail-open catch around the budget subsystem does not
+ * swallow an intentional block, and so runners can recognise it.
+ */
+export class BudgetExceededError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = 'BudgetExceededError';
+  }
+}
+
 export async function executeAgentPipeline(
   provider: string,
   model: string,
   opts: AgentPipelineOptions
 ): Promise<AgentPipelineResult> {
   const startTime = Date.now();
+
+  // Pre-spend budget enforcement (BIZ-001): the chat HTTP route enforces the
+  // operator's budget before dispatching an LLM call, but autonomous runners
+  // (Claw continuous/interval, Soul heartbeat, Subagent) went straight to
+  // agent.chat() — a runaway loop could blow the daily/weekly/monthly budget.
+  // executeAgentPipeline is the shared chokepoint for all of them. Fail open on
+  // any budget-subsystem error so a misconfiguration never wedges autonomous
+  // execution; only an explicit "not allowed" decision blocks.
+  if (provider && model && !provider.startsWith('cli-')) {
+    try {
+      const messageText = typeof opts.message === 'string' ? opts.message : '';
+      const estimate = estimateCost(provider as AIProvider, model, messageText, 1000);
+      const decision = await budgetManager.canSpend(estimate.estimatedCost);
+      if (!decision.allowed) {
+        log.warn(
+          `[AgentPipeline] Blocked by budget for ${
+            opts.agentId ?? opts.timeoutLabel ?? 'agent'
+          }: ${decision.reason}`
+        );
+        throw new BudgetExceededError(decision.reason ?? 'Request blocked by budget policy.');
+      }
+    } catch (err) {
+      if (err instanceof BudgetExceededError) throw err;
+      log.debug(
+        `[AgentPipeline] Budget check skipped (fail-open): ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
 
   // Collect tool calls via callback
   const collector = createToolCallCollector();

--- a/packages/gateway/src/services/extension/sandbox.ts
+++ b/packages/gateway/src/services/extension/sandbox.ts
@@ -156,61 +156,78 @@ function workerMain() {
       };
       port.on('message', responseHandler);
 
-      // Build the sandbox context
-      // NOTE: Do NOT pass host constructors (Object, Array, Map, Set, String, Number, Boolean, Promise).
-      // vm.createContext() creates its own V8 built-ins per context.
-      // Passing host constructors shares prototype chains, enabling prototype pollution attacks.
-      const sandboxGlobals = {
-        console: consoleMethods,
-        JSON,
-        Math,
-        Date,
-        URL,
-        URLSearchParams,
-        // Safe constructors only — RegExp, Error, etc. are fine as they're stateless
-        RegExp,
-        Error,
-        TypeError,
-        RangeError,
-        parseInt,
-        parseFloat,
-        isNaN,
-        isFinite,
-        encodeURIComponent,
-        decodeURIComponent,
-        encodeURI,
-        decodeURI,
-        // H-S5 defense-in-depth: wrap timers in narrow shims so the sandbox
-        // never holds a reference to the host setTimeout directly. The
-        // code-validator regex catches `.constructor`/`[constructor]` access
-        // statically, but a frozen wrapper also denies casual prototype
-        // walking at runtime if any new exposure pattern slips past the
-        // validator. We intentionally don't return the host timer handle —
-        // callers can only cancel via `clearTimeout(id)` with the integer id
-        // returned here. Tools that need long sleeps should call the host via
-        // utils.callTool() instead.
-        setTimeout: Object.freeze((cb: () => void, ms: number): number => {
+      // Build the sandbox context.
+      //
+      // SECURITY (RCE-001): do NOT inject ANY host-realm value into the context.
+      // vm.createContext() already provides every ECMAScript intrinsic (JSON,
+      // Math, Date, Object, Array, RegExp, Error, parseInt, ...) as *context-realm*
+      // builtins, whose `.constructor` resolves to the context's own Function —
+      // which is disabled by `codeGeneration.strings:false`. Injecting the HOST
+      // copies instead let an extension walk e.g.
+      //   Math['con'+'structor']('return process')()
+      // up to the HOST Function constructor (not bound by this context's codegen
+      // flag) and execute arbitrary code in the gateway process — full escape.
+      // This was empirically reproducible; the static code-validator alone cannot
+      // close it because string-concat property access (`x['con'+'structor']`,
+      // `x[a+b]`) is unbounded.
+      //
+      // The few capabilities the SDK needs that are NOT context intrinsics
+      // (console, timers, args, utils.callTool) are host functions, so they are
+      // passed under a single `__host` global and immediately re-wrapped as
+      // context-realm functions by the bootstrap below, after which `__host` is
+      // deleted. The wrappers close over the host refs (unreachable via any
+      // property path) and their OWN `.constructor` is the blocked context
+      // Function. callTool results and args are deep-cloned through the context's
+      // JSON so no host-realm object ever leaks back into the sandbox.
+      const hostBridge = {
+        log: consoleMethods.log,
+        warn: consoleMethods.warn,
+        error: consoleMethods.error,
+        callTool: callToolBridge,
+        listTools: () => callToolBridge('__list_tools__', {}),
+        // Narrow timer shims — never hand the sandbox a real host timer handle.
+        setTimeout: (cb: () => void, ms: number): number => {
           const h = globalThis.setTimeout(cb, ms);
-          // Return a numeric id (in Node, timers are objects with Symbol.toPrimitive).
           return typeof h === 'object' && h !== null ? Number(h) : (h as unknown as number);
-        }),
-        clearTimeout: Object.freeze((id: number): void => {
+        },
+        clearTimeout: (id: number): void => {
           globalThis.clearTimeout(id as unknown as NodeJS.Timeout);
-        }),
-        // Extension SDK
-        args,
-        utils: {
-          callTool: callToolBridge,
-          listTools: () => callToolBridge('__list_tools__', {}),
         },
       };
 
-      const vmContext = createContext(sandboxGlobals, {
-        name: `ext-sandbox:${extensionId}:${toolName}`,
-        codeGeneration: { strings: false, wasm: false },
-      });
+      const vmContext = createContext(
+        { __host: hostBridge, __argsJson: JSON.stringify(args ?? {}) },
+        {
+          name: `ext-sandbox:${extensionId}:${toolName}`,
+          codeGeneration: { strings: false, wasm: false },
+        }
+      );
 
-      // Wrap the tool code
+      // Bootstrap: rebuild a safe, context-realm SDK from __host, then sever
+      // every host reference. Compiled as a Script (allowed) and run before any
+      // extension code. After this runs, `__host`/`__argsJson` are unreachable.
+      const BOOTSTRAP = `(() => {
+        const h = __host;
+        const clone = (v) => (v === undefined ? undefined : JSON.parse(JSON.stringify(v)));
+        globalThis.console = Object.freeze({
+          log: (...a) => h.log(...a.map(String)),
+          warn: (...a) => h.warn(...a.map(String)),
+          error: (...a) => h.error(...a.map(String)),
+        });
+        globalThis.setTimeout = (cb, ms) => h.setTimeout(cb, ms);
+        globalThis.clearTimeout = (id) => h.clearTimeout(id);
+        globalThis.utils = Object.freeze({
+          callTool: async (name, toolArgs) => clone(await h.callTool(name, clone(toolArgs) ?? {})),
+          listTools: async () => clone(await h.listTools()),
+        });
+        globalThis.args = JSON.parse(__argsJson);
+        delete globalThis.__host;
+        delete globalThis.__argsJson;
+      })();`;
+      new Script(BOOTSTRAP, { filename: `ext-bootstrap:${extensionId}` }).runInContext(vmContext);
+
+      // Wrap the tool code. `args` and `utils` are read from the context globals
+      // established by the bootstrap (NOT passed in as host objects).
       const wrappedCode = `(async () => {
         const module = { exports: {} };
         ${code}

--- a/packages/gateway/src/services/usage-tracking.ts
+++ b/packages/gateway/src/services/usage-tracking.ts
@@ -18,6 +18,34 @@ const log = getLog('UsageTracking');
 export const usageTracker = new UsageTracker();
 export const budgetManager = new BudgetManager(usageTracker);
 
+// BUDGET-002: surface budget alerts beyond a log line. Without this hook the
+// `alert` event fires, the event bus sees it, and no one acts on it — the
+// operator only finds out a threshold was crossed when they read logs.
+// We log at warn level and try to write an audit entry so the operator gets
+// a structured record. The audit import is dynamic to avoid a circular
+// dep (audit/ → services/ would be bad form from services/).
+budgetManager.on('alert', (alert: unknown) => {
+  const a = alert as { type: string; threshold: number; currentSpend: number; limit?: number };
+  const message = `Budget ${a.type} hit ${a.threshold}% (${a.currentSpend.toFixed(4)} / ${(a.limit ?? 0).toFixed(2)})`;
+  log.warn(`[Budget] ${message}`);
+  // Fire-and-forget audit write; failures must not break usage tracking.
+  void (async () => {
+    try {
+      const { getAuditLogger } = await import('../audit/index.js');
+      await getAuditLogger().log({
+        type: 'config.change',
+        severity: 'warning',
+        actor: { type: 'system', id: 'budget-manager' },
+        resource: { type: 'budget', id: a.type, name: `${a.type} budget` },
+        outcome: 'success',
+        details: { alert: a, message },
+      });
+    } catch {
+      // Audit module may not be wired in test env — that's fine.
+    }
+  })();
+});
+
 // Wire DB persistence — fire-and-forget, errors are logged below.
 async function wireUsageRepository(): Promise<void> {
   try {

--- a/packages/gateway/src/services/usage-tracking.ts
+++ b/packages/gateway/src/services/usage-tracking.ts
@@ -34,7 +34,7 @@ budgetManager.on('alert', (alert: unknown) => {
       const { getAuditLogger } = await import('../audit/index.js');
       await getAuditLogger().log({
         type: 'config.change',
-        severity: 'warning',
+        severity: 'warn',
         actor: { type: 'system', id: 'budget-manager' },
         resource: { type: 'budget', id: a.type, name: `${a.type} budget` },
         outcome: 'success',

--- a/packages/gateway/src/services/workflow/executors/tool-llm-code.ts
+++ b/packages/gateway/src/services/workflow/executors/tool-llm-code.ts
@@ -20,7 +20,7 @@ import { createProvider, type ProviderConfig, type IToolService } from '@ownpilo
 import { getErrorMessage } from '../../../utils/common.js';
 import { NATIVE_PROVIDERS, loadProviderConfig, getProviderApiKey } from '../../agent/cache.js';
 import { resolveDefaultProviderAndModel } from '../../app-settings.js';
-import { resolveTemplates } from '../template-resolver.js';
+import { resolveTemplates, resolveCodeTemplates } from '../template-resolver.js';
 import type { ToolExecutionResult } from '../types.js';
 import { log, safeVmEval, toToolExecResult, resolveWorkflowToolName } from './utils.js';
 
@@ -271,8 +271,10 @@ export async function executeCodeNode(
       };
     }
 
-    const resolvedCode = resolveTemplates({ _code: data.code }, nodeOutputs, variables)
-      ._code as string;
+    // SECURITY (RCE-002): encode interpolated upstream values as JS literals so
+    // attacker-influenced node output (HTTP/LLM/webhook data) cannot break out
+    // of a data position into executable code.
+    const resolvedCode = resolveCodeTemplates(data.code ?? '', nodeOutputs, variables);
 
     const toolMap: Record<string, string> = {
       javascript: 'execute_javascript',
@@ -325,8 +327,9 @@ export function executeTransformerNode(
   try {
     const data = node.data as TransformerNodeData;
 
-    const resolvedExpr = resolveTemplates({ _expr: data.expression }, nodeOutputs, variables)
-      ._expr as string;
+    // SECURITY (RCE-002): JS-literal encode interpolated values; the expression
+    // already gets upstream data via the bound `data`/nodeId context below.
+    const resolvedExpr = resolveCodeTemplates(data.expression ?? '', nodeOutputs, variables);
 
     const evalContext: Record<string, unknown> = { ...variables };
     let lastOutput: unknown = undefined;

--- a/packages/gateway/src/services/workflow/executors/utils.test.ts
+++ b/packages/gateway/src/services/workflow/executors/utils.test.ts
@@ -1,0 +1,60 @@
+/**
+ * safeVmEval — security + functionality regression tests.
+ *
+ * Covers RCE-001/RCE-003: the expression evaluator must not let user-supplied
+ * expressions escape the VM via the host Function constructor reached through an
+ * injected (host-realm) context value's prototype chain.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { safeVmEval } from './utils.js';
+
+describe('safeVmEval — sandbox escape resistance', () => {
+  it('blocks constructor-walk escape via an injected context object (split-string)', () => {
+    // `data` is an attacker-influenced upstream node output. Before the fix this
+    // reached the host `process` (host-realm object → host Function).
+    const expr = `data['constructo'+'r']['constructo'+'r']('return process')()`;
+    expect(() => safeVmEval(expr, { data: { x: 1 } }, 2000)).toThrow();
+  });
+
+  it('blocks direct constructor-walk escape', () => {
+    const expr = `data.constructor.constructor('return process')()`;
+    expect(() => safeVmEval(expr, { data: { x: 1 } }, 2000)).toThrow();
+  });
+
+  it('does not expose host process even if the escape were to run', () => {
+    // Sanity: the bound `data` must be a plain context-realm object, so reaching
+    // a Function constructor that actually compiles code is impossible.
+    let leaked: unknown;
+    try {
+      leaked = safeVmEval(
+        `(() => { try { return data['constructo'+'r']['constructo'+'r']('return process')().pid; } catch (e) { return 'blocked'; } })()`,
+        { data: {} },
+        2000
+      );
+    } catch {
+      leaked = 'threw';
+    }
+    expect(leaked === 'blocked' || leaked === 'threw').toBe(true);
+  });
+});
+
+describe('safeVmEval — functionality preserved', () => {
+  it('evaluates a simple arithmetic expression', () => {
+    expect(safeVmEval('data.x + 1', { data: { x: 5 } }, 2000)).toBe(6);
+  });
+
+  it('reads workflow variables', () => {
+    expect(safeVmEval('variables.y * 10', { variables: { y: 4 } }, 2000)).toBe(40);
+  });
+
+  it('returns object literals', () => {
+    expect(
+      safeVmEval('({ sum: data.x + variables.y })', { data: { x: 1 }, variables: { y: 2 } }, 2000)
+    ).toEqual({ sum: 3 });
+  });
+
+  it('rejects expressions over the length limit', () => {
+    expect(() => safeVmEval('1'.repeat(10_001), {}, 2000)).toThrow(/maximum length/);
+  });
+});

--- a/packages/gateway/src/services/workflow/executors/utils.ts
+++ b/packages/gateway/src/services/workflow/executors/utils.ts
@@ -28,8 +28,13 @@ const MAX_EXPRESSION_LENGTH = 10_000;
  *
  * Defenses:
  * - `codeGeneration.strings: false` blocks dynamic-code constructors inside the sandbox
- * - Dangerous globals (`process`, `require`, `global`, `globalThis`) are frozen as undefined
- * - Timeout prevents infinite loops
+ * - SECURITY (RCE-001/RCE-003): context values are serialized to JSON and
+ *   re-parsed INSIDE the vm, so every binding the expression can reach is a
+ *   *context-realm* object whose `.constructor` is the context Function (blocked
+ *   by the codegen flag). The previous implementation injected `structuredClone`
+ *   results, which are HOST-realm objects — `data['con'+'structor']['con'+'structor']('return process')()`
+ *   walked their constructor chain to the host Function and escaped the sandbox.
+ * - Timeout prevents infinite loops.
  */
 export function safeVmEval(
   expression: string,
@@ -45,28 +50,31 @@ export function safeVmEval(
     throw new Error(`Expression blocked: ${validation.errors.join('; ')}`);
   }
 
-  const cloneContext = new Map<string, unknown>();
-  for (const [k, v] of Object.entries(context)) {
-    if (typeof v === 'object' && v !== null) {
-      try {
-        cloneContext.set(k, structuredClone(v));
-      } catch {
-        throw new Error(
-          `Transformer input "${k}" must be JSON-serializable. Functions, Symbols, and non-cloneable values are not supported.`
-        );
-      }
-    } else {
-      cloneContext.set(k, v);
-    }
+  // Serialize the whole context to JSON. Functions/Symbols are dropped and
+  // circular structures throw — both surfaced as the JSON-serializable error,
+  // matching the documented contract.
+  let ctxJson: string | undefined;
+  try {
+    ctxJson = JSON.stringify(context ?? {});
+  } catch {
+    throw new Error(
+      'Transformer input must be JSON-serializable. Functions, Symbols, and circular values are not supported.'
+    );
   }
+  if (ctxJson === undefined) ctxJson = '{}';
 
-  const dangerous = ['process', 'require', 'global', 'globalThis', 'Function', 'eval', 'import'];
-  const sandbox: Record<string, unknown> = { ...Object.fromEntries(cloneContext) };
-  for (const key of dangerous) sandbox[key] = undefined;
+  const vmContext = vm.createContext(
+    { __ctxJson: ctxJson },
+    { codeGeneration: { strings: false, wasm: false } }
+  );
 
-  const vmContext = vm.createContext(sandbox, {
-    codeGeneration: { strings: false, wasm: false },
-  });
+  // Bootstrap: re-parse the context inside the vm (values become context-realm),
+  // bind each key as a global, then sever the raw JSON payload.
+  vm.runInContext(
+    `(() => { const c = JSON.parse(__ctxJson); for (const k of Object.keys(c)) globalThis[k] = c[k]; delete globalThis.__ctxJson; })();`,
+    vmContext
+  );
+
   return vm.runInContext(expression, vmContext, { timeout: timeoutMs });
 }
 

--- a/packages/gateway/src/services/workflow/node-executors.test.ts
+++ b/packages/gateway/src/services/workflow/node-executors.test.ts
@@ -31,6 +31,7 @@ const mockToolService = {
 
 vi.mock('./template-resolver.js', () => ({
   resolveTemplates: vi.fn((args: Record<string, unknown>) => args),
+  resolveCodeTemplates: vi.fn((code: string) => code),
 }));
 
 vi.mock('../../utils/ssrf.js', () => ({
@@ -155,7 +156,7 @@ import {
   executeDataStoreNode,
   executeAggregateNode,
 } from './node-executors.js';
-import { resolveTemplates } from './template-resolver.js';
+import { resolveTemplates, resolveCodeTemplates } from './template-resolver.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -181,6 +182,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   // Reset resolveTemplates mock to pass-through
   vi.mocked(resolveTemplates).mockImplementation((args) => args);
+  vi.mocked(resolveCodeTemplates).mockImplementation((code) => code);
 });
 
 // ============================================================================
@@ -578,7 +580,7 @@ describe('executeCodeNode', () => {
   });
 
   it('resolves templates in the code string', async () => {
-    vi.mocked(resolveTemplates).mockReturnValue({ _code: 'console.log("resolved-value")' });
+    vi.mocked(resolveCodeTemplates).mockReturnValue('console.log("resolved-value")');
     mockToolService.execute.mockResolvedValue({ content: '"ok"', isError: false });
 
     const node = makeNode('code1', 'codeNode', {
@@ -588,8 +590,10 @@ describe('executeCodeNode', () => {
     const nodeOutputs = { prev: makeResult('prev', 'resolved-value') };
     await executeCodeNode(node, nodeOutputs, {}, 'user1', mockToolService);
 
-    expect(resolveTemplates).toHaveBeenCalledWith(
-      { _code: 'console.log("{{prev.output}}")' },
+    // SECURITY (RCE-002): code nodes use resolveCodeTemplates (JS-literal
+    // encoding), not the raw resolveTemplates path.
+    expect(resolveCodeTemplates).toHaveBeenCalledWith(
+      'console.log("{{prev.output}}")',
       nodeOutputs,
       {}
     );

--- a/packages/gateway/src/services/workflow/template-resolver.ts
+++ b/packages/gateway/src/services/workflow/template-resolver.ts
@@ -60,6 +60,33 @@ export function resolveStringTemplates(
   });
 }
 
+/**
+ * Resolve templates destined for a CODE body (codeNode / expression fields).
+ *
+ * SECURITY (RCE-002): unlike resolveTemplates(), which splices resolved values
+ * into the string RAW, this encodes every substituted value as a JS/JSON
+ * *literal*. Upstream data (HTTP response bodies, LLM output, webhook payloads)
+ * therefore always lands in a data position — it can never break out into
+ * executable code. `{{node.output}}` used as `const x = {{node.output}}` still
+ * works (object/array/number/string become valid literals); the unsafe pattern
+ * `"{{node.text}}"` (manually quoted) must drop the quotes after this change.
+ */
+export function resolveCodeTemplates(
+  code: string,
+  nodeOutputs: Record<string, NodeResult>,
+  variables: Record<string, unknown>,
+  aliasMap?: Map<string, string>
+): string {
+  return code.replace(/\{\{(.+?)\}\}/g, (_match, path: string) => {
+    const val = resolveTemplatePathWithFallback(path.trim(), nodeOutputs, variables, aliasMap);
+    if (val === undefined) return 'undefined';
+    // JSON.stringify yields a safe, non-executable JS literal for any
+    // serializable value. Fall back to `undefined` for non-serializable inputs.
+    const encoded = JSON.stringify(val);
+    return encoded === undefined ? 'undefined' : encoded;
+  });
+}
+
 export function resolveTemplatePath(
   path: string,
   nodeOutputs: Record<string, NodeResult>,

--- a/packages/gateway/src/tools/claw/lifecycle-executors.ts
+++ b/packages/gateway/src/tools/claw/lifecycle-executors.ts
@@ -342,24 +342,40 @@ export async function executeCreateTool(args: Record<string, unknown>): Promise<
     const vm = await import('node:vm');
 
     const logs: string[] = [];
-    const sandbox: Record<string, unknown> = {
-      args: invokeArgs,
-      module: { exports: {} as Record<string, unknown> },
-      exports: {} as Record<string, unknown>,
-      __result: undefined,
-      console: {
-        log: (...a: unknown[]) => logs.push(a.map(String).join(' ')),
-        error: (...a: unknown[]) => logs.push('[err] ' + a.map(String).join(' ')),
-      },
-      // Block sandbox escape vectors
-      require: undefined,
-      process: undefined,
-      global: undefined,
-      globalThis: undefined,
-      Function: undefined,
-      eval: undefined,
-      import: undefined,
+
+    // SECURITY (TS-001 / RCE-001): never inject host-realm objects (console,
+    // args, module, ...) into the vm context. Any host function reachable from
+    // the sandbox exposes the HOST Function constructor via `.constructor`,
+    // which `codeGeneration.strings:false` does NOT disable — a full escape, and
+    // this code runs in the MAIN gateway thread. Instead we pass host fns under
+    // a single `__host` global, rebuild context-realm equivalents in a bootstrap,
+    // then sever `__host`. After that the only Function reachable is the
+    // context's own, which is blocked. See services/extension/sandbox.ts for the
+    // canonical (worker-isolated) version.
+    const hostBridge = {
+      log: (...a: unknown[]) => logs.push(a.map(String).join(' ')),
+      error: (...a: unknown[]) => logs.push('[err] ' + a.map(String).join(' ')),
     };
+
+    const vmCtx = vm.createContext(
+      { __host: hostBridge, __argsJson: JSON.stringify(invokeArgs ?? {}) },
+      { codeGeneration: { strings: false, wasm: false } }
+    );
+
+    const BOOTSTRAP = `(() => {
+      const h = __host;
+      globalThis.console = Object.freeze({
+        log: (...a) => h.log(...a.map(String)),
+        error: (...a) => h.error(...a.map(String)),
+      });
+      globalThis.args = JSON.parse(__argsJson);
+      globalThis.module = { exports: {} };
+      globalThis.exports = globalThis.module.exports;
+      globalThis.__result = undefined;
+      delete globalThis.__host;
+      delete globalThis.__argsJson;
+    })();`;
+    vm.runInContext(BOOTSTRAP, vmCtx);
 
     const wrappedCode = `
 ${code}
@@ -371,9 +387,6 @@ const __fn = typeof ${name} === 'function'
 __result = typeof __fn === 'function' ? __fn(args) : { error: "No function named '${name}' found. Define: function ${name}(args) { ... }" };
 `;
 
-    const vmCtx = vm.createContext(sandbox, {
-      codeGeneration: { strings: false, wasm: false },
-    });
     vm.runInContext(wrappedCode, vmCtx, { timeout: 10_000 });
 
     // Resolve promises (sync vm can't await, but we can resolve simple thenables)

--- a/packages/gateway/src/tools/overrides/image.test.ts
+++ b/packages/gateway/src/tools/overrides/image.test.ts
@@ -39,6 +39,12 @@ const mockFetch = vi.hoisted(() => vi.fn());
 // Module mocks
 // ---------------------------------------------------------------------------
 
+// SSRF-001: image.ts downloads provider-returned image URLs via safeFetch.
+// Route it to the same fetch mock so tests don't perform real DNS/SSRF checks.
+vi.mock('../../utils/safe-fetch.js', () => ({
+  safeFetch: (...args: unknown[]) => mockFetch(...args),
+}));
+
 vi.mock('../../db/repositories/config-services.js', () => ({
   configServicesRepo: {
     getFieldValue: (...args: unknown[]) => mockGetFieldValue(...args),

--- a/packages/gateway/src/tools/overrides/image.ts
+++ b/packages/gateway/src/tools/overrides/image.ts
@@ -18,6 +18,7 @@ import {
 import { configServicesRepo } from '../../db/repositories/config-services.js';
 import { getLog } from '../../services/log.js';
 import { getErrorMessage } from '../../utils/common.js';
+import { safeFetch } from '../../utils/safe-fetch.js';
 
 const log = getLog('ImageOverrides');
 
@@ -382,7 +383,10 @@ async function callFalImageGen(
   // FAL returns URLs — download to base64
   const results: ImageGenResult[] = [];
   for (const img of data.images) {
-    const imgResp = await fetch(img.url);
+    // SECURITY (SSRF-001): img.url comes from the provider's JSON response and
+    // must not be fetched with bare fetch() — a spoofed/compromised response
+    // could point at 169.254.169.254 or other internal addresses.
+    const imgResp = await safeFetch(img.url);
     const buffer = Buffer.from(await imgResp.arrayBuffer());
     results.push({ base64: buffer.toString('base64') });
   }
@@ -418,7 +422,9 @@ async function callReplicateImageGen(
   const data = (await response.json()) as { output: string[] };
   const results: ImageGenResult[] = [];
   for (const imgUrl of data.output ?? []) {
-    const imgResp = await fetch(imgUrl);
+    // SECURITY (SSRF-001): imgUrl comes from the provider response — fetch via
+    // the SSRF guard, not bare fetch().
+    const imgResp = await safeFetch(imgUrl);
     const buffer = Buffer.from(await imgResp.arrayBuffer());
     results.push({ base64: buffer.toString('base64') });
   }

--- a/packages/gateway/src/ws/server.test.ts
+++ b/packages/gateway/src/ws/server.test.ts
@@ -422,6 +422,29 @@ describe('WSGateway', () => {
       expect(socket.close).not.toHaveBeenCalled();
     });
 
+    it('allows the gateway https self-origin over TLS (WS-001)', async () => {
+      const prevPort = process.env.PORT;
+      process.env.PORT = '9443'; // self-origin derives from PORT
+      try {
+        const gw = new WSGateway({ allowedOrigins: [] });
+        gw.start();
+
+        const handler = getConnectionHandler();
+        const socket = createMockSocket();
+        const request = createMockRequest('/', {
+          origin: 'https://localhost:9443',
+        });
+
+        await handler(socket, request);
+
+        expect(mockSessionManager.create).toHaveBeenCalled();
+        expect(socket.close).not.toHaveBeenCalled();
+      } finally {
+        if (prevPort === undefined) delete process.env.PORT;
+        else process.env.PORT = prevPort;
+      }
+    });
+
     it('rejects when no origin header even with empty allowlist (CSWSH defense)', async () => {
       const gw = new WSGateway({ allowedOrigins: [] });
       gw.start();

--- a/packages/gateway/src/ws/server.ts
+++ b/packages/gateway/src/ws/server.ts
@@ -175,15 +175,35 @@ const DEFAULT_LOCALHOST_WS_ORIGINS = [
 ];
 
 /**
+ * The gateway's own origin(s), derived from PORT. A WebSocket upgrade whose
+ * Origin matches the server that served the page is same-origin and can never
+ * be a cross-site hijack, so these are always allowed — including when the
+ * gateway serves the built UI on its own port (e.g. http://127.0.0.1:8200).
+ * Production deployments behind a domain still need WS_ALLOWED_ORIGINS.
+ */
+function getGatewaySelfOrigins(): string[] {
+  const port = process.env.PORT ?? String(WS_PORT);
+  // WS-001: include https:// variants so a gateway served over TLS on its own
+  // port still recognises its same-origin (the http:// only list rejected it).
+  return [
+    `http://localhost:${port}`,
+    `http://127.0.0.1:${port}`,
+    `https://localhost:${port}`,
+    `https://127.0.0.1:${port}`,
+  ];
+}
+
+/**
  * Validate WebSocket origin against allowed origins.
  * - Always requires the browser to send an `Origin` header (CSWSH defense).
  * - Empty configured allowlist falls back to localhost-only, never allow-all.
+ * - The gateway's own same-origin is always permitted (UI served by gateway).
  */
 function isOriginAllowed(origin: string | undefined, allowedOrigins: string[]): boolean {
   const effective = allowedOrigins.length > 0 ? allowedOrigins : DEFAULT_LOCALHOST_WS_ORIGINS;
   // No origin header — reject. Browsers always send Origin on WS upgrades.
   if (!origin) return false;
-  return effective.some((allowed) => origin === allowed);
+  return effective.includes(origin) || getGatewaySelfOrigins().includes(origin);
 }
 
 /**
@@ -1346,6 +1366,14 @@ const _wsAllowedOrigins = sanitizeCorsOriginsFromEnv(_rawWsOrigins);
 if (_rawWsOrigins && _rawWsOrigins.includes('*')) {
   log.warn(
     '[WARN] WS: origins env contains "*" — stripped. WS connections will use the configured non-wildcard origins (or localhost defaults).'
+  );
+}
+// WS-001: in production with no explicit allowlist, the gateway falls back to
+// localhost-only origins, so WS upgrades from a real domain are rejected. Warn
+// loudly rather than failing silently.
+if (process.env.NODE_ENV === 'production' && _wsAllowedOrigins.length === 0) {
+  log.warn(
+    '[WARN] WS: no WS_ALLOWED_ORIGINS/CORS_ORIGINS set in production — WebSocket connections from your domain will be rejected (localhost-only fallback). Set WS_ALLOWED_ORIGINS to your site origin(s).'
   );
 }
 

--- a/packages/ui/Dockerfile.dev
+++ b/packages/ui/Dockerfile.dev
@@ -4,12 +4,23 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 
 WORKDIR /app
 
-COPY package.json ./
+# SECURITY (DOCK-001): run as the image's built-in non-root `node` user instead
+# of root, matching the production Dockerfiles (which use a dedicated ownpilot
+# user). Ownership is handed to `node` before dependency install so pnpm can
+# write node_modules without root.
+RUN chown -R node:node /app
+USER node
+
+COPY --chown=node:node package.json ./
 
 RUN pnpm install
 
-COPY . .
+COPY --chown=node:node . .
 
 EXPOSE 3000
+
+# Basic liveness check for the Vite dev server.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:3000/ >/dev/null 2>&1 || exit 1
 
 CMD ["pnpm", "dev", "--host", "0.0.0.0", "--port", "3000"]

--- a/security-report/REMEDIATION.md
+++ b/security-report/REMEDIATION.md
@@ -1,0 +1,86 @@
+# Security Remediation Log
+
+**Date:** 2026-06-02
+**Scope:** Fixes for the Critical + High findings from `SECURITY-REPORT.md` (scan 2026-06-01).
+**Verification:** `@ownpilot/core` + `@ownpilot/gateway` typecheck clean; 1,720 tests pass across all touched suites (incl. new regressions). core full suite 9,377 pass.
+
+---
+
+## Fixed — Critical
+
+### RCE-001 — VM sandbox escape (3 sinks)
+Root cause: host-realm objects injected into a `node:vm` context expose the host
+`Function` constructor via `.constructor`, which `codeGeneration:{strings:false}`
+does **not** disable. Empirically reproduced on Node v24:
+`Math.max['constructo'+'r']('return process')()` returned the host `process`.
+
+Fix pattern (canonical): never inject host-realm values; pass host fns under one
+`__host` global + data as `__argsJson`, run a bootstrap Script that rebuilds
+context-realm wrappers / `JSON.parse`s data into the context realm, then
+`delete globalThis.__host`. The context's own intrinsics (JSON/Math/Date/…) are
+used instead — their Function IS blocked.
+
+- `packages/gateway/src/services/extension/sandbox.ts` — worker sandbox (extensions, `claw_execute`)
+- `packages/gateway/src/tools/claw/lifecycle-executors.ts` — `claw_create_tool` (ran in main thread)
+- `packages/gateway/src/services/workflow/executors/utils.ts` — `safeVmEval` (was `structuredClone` → host-realm leak; verifier under-rated this as RCE-003 Medium, but it was escapable)
+- `packages/core/src/sandbox/code-validator.ts` — split-`constructor` regexes hardened (defense-in-depth)
+
+### RCE-002 — Workflow code/expression template injection
+Upstream node output (HTTP/LLM/webhook data) was spliced **raw** into code before
+execution. Fix: new `resolveCodeTemplates` JS-literal-encodes every substituted
+value, so data can never break into a code position.
+
+- `packages/gateway/src/services/workflow/template-resolver.ts` — new `resolveCodeTemplates`
+- `packages/gateway/src/services/workflow/executors/tool-llm-code.ts` — code node + transformer use it
+
+**Regression tests:** `packages/gateway/src/services/workflow/executors/utils.test.ts` (new — live escape attempts), `packages/core/src/sandbox/code-validator.test.ts` (split-string cases).
+
+---
+
+## Fixed — High
+
+| Finding | File(s) | Fix |
+|---|---|---|
+| EXPOSE-004 / TS-002 (weak PRNG) | `channels/service-impl.ts` | DM pairing code `Math.random()` → `crypto.randomInt(100000, 1000000)` |
+| SSRF-001 | `tools/overrides/image.ts` | Provider-returned image URLs fetched via `safeFetch` (SSRF guard) |
+| PATH-001 | `routes/extensions/install.ts` | `/install` path confined to `getAllScanDirectories()` via `isWithinDirectory` (+ rejection test) |
+| EXPOSE-002 | `routes/database/shared.ts` | `system_settings` (gateway API keys, JWT secret, pairing keys) removed from `EXPORT_TABLES` → not exportable/CSV/importable |
+| CRYPTO-004 | `core/credentials/index.ts` | Legacy no-salt entries lazily re-encrypted to PBKDF2+salt on read (`migrateLegacyEntryIfNeeded`) |
+| DOCK-004 / IAC-002 | `docker-compose.yml` | MQTT broker ports bound to `127.0.0.1` (no LAN exposure; broker still ships `allow_anonymous true`) |
+| BIZ-001 | `services/agent/runner-utils.ts` | Pre-spend budget check added to `executeAgentPipeline` (shared chokepoint for Claw/Soul/Subagent), fail-open, new `BudgetExceededError` + 3 tests |
+| CICD-002 | `.github/workflows/release.yml` | All 9 actions pinned to full-length commit SHAs (version in trailing comment). SHAs resolved via `git ls-remote` on 2026-06-02 |
+| DOCK-001 / IAC-001 | `packages/ui/Dockerfile.dev` | Runs as built-in non-root `node` user (matches prod Dockerfiles) + adds a HEALTHCHECK. Not wired into the shipped compose, so no bind-mount uid impact |
+| DOCK-003 / IAC-004 | `docker-compose.db.yml` | Default DB password documented as local-dev-only with an explicit "set POSTGRES_PASSWORD for shared/prod" warning. Residual accepted: port is already bound to 127.0.0.1, so the DB is never LAN/remote-exposed |
+| CICD-001 | `.github/workflows/ci.yml`, `deploy-website.yml` | All actions pinned to commit SHAs (completes the action-pinning started in CICD-002) |
+| EXPOSE-001 | `db/repositories/logs.ts` | Persisted error stacks capped at 2000 chars (bounds internal-path disclosure in per-user `request_logs` exports + DB bloat). Fuller path-redaction / prod-gating left as a product decision |
+| WS-001 | `ws/server.ts` | Gateway `https://` self-origins added (TLS same-origin WS upgrades were rejected) + startup warning when production has no `WS_ALLOWED_ORIGINS`/`CORS_ORIGINS` configured |
+| API-001 | `routes/openapi.ts` | OpenAPI spec + Swagger UI disabled in production unless `ENABLE_API_DOCS=true` (hard on/off switch — deliberately avoids the delicate session-auth path). Dev unchanged |
+
+## Reviewed — intentionally NOT fixed (false-positive in context / already-correct)
+
+- **SESS-001** (session cookie `Secure` flag). Already correct: `isSecureCookie()` sets `Secure` whenever the connection is HTTPS (incl. behind a trusted proxy via `X-Forwarded-Proto`); over plain HTTP `Secure` is impossible anyway. No change.
+- **MASS-003** (autonomy decision `modifications` spread). No mass-assignment: the body is a strict `z.object` (unknown keys stripped), ownership is enforced (403 on mismatch), and `processDecision` only merges into `action.params` (the owner's own pending tool args, then re-assesses risk) — never into ownership/status. NB: it also revealed a *functional* bug (API field `modifications` vs manager field `modifiedParams` → modify-with-params is a silent no-op); that's a behavior fix, out of security scope.
+
+
+- **SSRF-002** (`tools/overrides/image.ts`, `audio.ts` — provider `base_url`/TTS/STT first-hop fetch). Wrapping these in `safeFetch` was attempted and **reverted**: `safeFetch` blocks private/localhost addresses, but (a) the local Whisper/Piper diagnostic + transcription paths legitimately hit `localhost`, and (b) this is a *privacy-first* platform where the admin-configured provider `base_url` may legitimately point at a **local** model server (OpenAI-compatible at 127.0.0.1). The `base_url` is admin-controlled, so this is self-SSRF (the verifier already rated it Medium for that reason). Forcing `safeFetch` would break local/self-hosted AI providers — a core use case. Only SSRF-001 (fetching URLs returned **inside** provider response bodies, which are always public CDN URLs) warrants the guard, and that is fixed.
+
+---
+
+## NOT changed — needs maintainer decision (ops trade-offs)
+
+- **mosquitto.conf `allow_anonymous true`** — left as the documented local-dev default; LAN exposure already removed by the loopback port binding above. For production, set `allow_anonymous false` + `password_file` (already documented in the conf).
+- **Medium / Low backlog** — see `verified-findings.md`.
+
+---
+
+## Committing note
+
+Two fixed files contain **pre-existing uncommitted work** that predates this
+remediation and must not be bundled into a security commit:
+
+- `services/extension/sandbox.ts` — RCE-001 fix (in `workerMain()`) is mixed with prior `ExtensionSandboxManager` trusted-identity (EXT-002) changes.
+- `routes/database/shared.ts` — EXPOSE-002 one-line removal is mixed with prior per-user export filtering (CSV-002).
+
+Suggested grouping when committing (use `git add -p` for the two mixed files):
+1. `fix(security): close vm sandbox escape (RCE-001) + workflow template injection (RCE-002)`
+2. `fix(security): SSRF guard, path containment, secret export, weak PRNG, KDF migration, MQTT bind, budget on autonomous runners`


### PR DESCRIPTION
Remediates the Critical and High findings from the 2026-06-01 security scan (full report in `security-report/`), plus the clean Medium items.

## Critical
- **RCE-001** — `node:vm` sandbox escape closed in 3 sinks (extension sandbox, `claw_create_tool`, workflow `safeVmEval`). Host-realm objects exposed the host `Function` constructor via `.constructor`, which `codeGeneration:{strings:false}` does not disable (reproduced on Node v24: `Math.max['constructo'+'r']('return process')()` returned host `process`). Fixed by passing host fns under a `__host` global, rebuilding context-realm wrappers in a bootstrap, then severing it; rely on the context's own intrinsics. `code-validator` split-regexes hardened (defense-in-depth).
- **RCE-002** — workflow code node + transformer no longer splice upstream output raw into code; new `resolveCodeTemplates` JS-literal-encodes interpolated values.

## High
- **EXPOSE-004** DM pairing code → `crypto.randomInt` (was `Math.random`)
- **SSRF-001** provider *response-body* image URLs fetched via `safeFetch`
- **PATH-001** extension `/install` path confined to allowed scan directories
- **EXPOSE-002** `system_settings` (gateway keys, JWT secret, pairing keys) removed from DB export/CSV/import allowlist
- **CRYPTO-004** legacy no-salt credential entries lazily re-encrypted to PBKDF2+salt on read
- **DOCK-004/IAC-002** MQTT broker ports bound to `127.0.0.1`
- **BIZ-001** pre-spend budget enforcement added to `executeAgentPipeline` (shared chokepoint for Claw/Soul/Subagent), fail-open
- **CICD-002** release workflow actions pinned to commit SHAs
- **DOCK-001/003** dev UI container runs non-root + healthcheck; DB password documented as dev-only with warning

## Medium
- **CICD-001** ci.yml + deploy-website.yml actions pinned to SHAs
- **EXPOSE-001** persisted error stacks capped at 2000 chars

## Reviewed → intentionally not changed
- **SSRF-002** is a false-positive in context: wrapping provider/audio `base_url` in `safeFetch` was implemented, caught by tests, and reverted — `safeFetch` blocks localhost, but this privacy-first platform legitimately supports local model servers and local Whisper/Piper. `base_url` is admin-controlled (self-SSRF). See `security-report/REMEDIATION.md`.
- Remaining Mediums (cost-endpoint authz / multi-user model, cookie SameSite/Secure, rate-limit policy, OpenAPI auth, ACP command allowlist) need product/deployment decisions and were left for maintainer direction.

## Verification
core + gateway typecheck clean; new regression tests for the sandbox escapes, path containment, budget enforcement, and stack-trace cap; all touched suites pass.

## Note
This branch also carries 3 pre-existing commits that were not yet on `origin/main` (mcp PUT validation, server install-service refactor, chat budget pre-spend) — included because they were already on the local main line this branch was cut from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)