### PR TITLE
harden(auth): enforce password-change cutoff on session cache-hit path

### DIFF
--- a/packages/gateway/src/services/ui-session.test.ts
+++ b/packages/gateway/src/services/ui-session.test.ts
@@ -222,6 +222,23 @@ describe('UI Session Service', () => {
       });
       expect(await validateSession('legacy-session-token')).toBe(true);
     });
+
+    it('cache-hit path also enforces the password-change cutoff (no DB lookup)', async () => {
+      // No cutoff at creation time → the warmed-cache session is initially valid.
+      mockSettingsRepo.get.mockReturnValue(null);
+      mockUiSessionsRepo.createSession.mockResolvedValue(undefined);
+      const session = await createSession();
+      expect(await validateSession(session.token)).toBe(true);
+
+      // Simulate a password change AFTER this session was created. The cache
+      // still holds the (now-stale) session; the cache-hit path must reject it
+      // without falling back to the DB. mockReturnValueOnce so the numeric
+      // value is consumed by this single lookup and doesn't leak into later
+      // tests (vi.clearAllMocks does not reset mockReturnValue).
+      mockSettingsRepo.get.mockReturnValueOnce(Date.now() + 60_000);
+      expect(await validateSession(session.token)).toBe(false);
+      expect(mockUiSessionsRepo.getByTokenHash).toHaveBeenCalledTimes(0);
+    });
   });
 
   describe('invalidateSession', () => {

--- a/packages/gateway/src/services/ui-session.ts
+++ b/packages/gateway/src/services/ui-session.ts
@@ -24,6 +24,9 @@ const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 interface CachedSession {
   expiresAt: Date;
+  /** When the underlying session was created — used to enforce the
+   *  password-change cutoff on the cache-hit path (see validateSession). */
+  createdAt: Date;
 }
 
 /**
@@ -103,7 +106,7 @@ export async function createSession(): Promise<{ token: string; expiresAt: Date 
   const expiresAt = new Date(now.getTime() + getSessionTtlMs());
 
   await uiSessionsRepo.createSession(tokenHash, 'ui', 'default', expiresAt);
-  sessionCache.set(token, { expiresAt }, getSessionTtlMs());
+  sessionCache.set(token, { expiresAt, createdAt: now }, getSessionTtlMs());
   log.info('Session created');
 
   return { token, expiresAt };
@@ -121,7 +124,7 @@ export async function createMcpSession(): Promise<{ token: string; expiresAt: Da
   const expiresAt = new Date(now.getTime() + ttlMs);
 
   await uiSessionsRepo.createSession(tokenHash, 'mcp', 'default', expiresAt);
-  sessionCache.set(token, { expiresAt }, ttlMs);
+  sessionCache.set(token, { expiresAt, createdAt: now }, ttlMs);
   log.info('MCP session created');
 
   return { token, expiresAt };
@@ -138,11 +141,21 @@ export async function validateSession(token: string): Promise<boolean> {
   // 1. Cache hit path — no hashing
   const cached = sessionCache.get(token);
   if (cached) {
-    if (cached.expiresAt.getTime() > Date.now()) {
-      return true;
+    if (cached.expiresAt.getTime() <= Date.now()) {
+      sessionCache.invalidate(token);
+      return false;
     }
-    sessionCache.invalidate(token);
-    return false;
+    // Enforce the password-change cutoff here too. Without it, a session cached
+    // before a password change would keep validating until the cache TTL
+    // expires (~5 min) even though the DB path rejects it. Holds the invariant
+    // "a session created before the current password never validates" at the
+    // validation layer, independent of whether a caller cleared the cache.
+    const hashCreatedAt = getPasswordHashCreatedAt();
+    if (hashCreatedAt && cached.createdAt.getTime() < hashCreatedAt) {
+      sessionCache.invalidate(token);
+      return false;
+    }
+    return true;
   }
 
   // 2. Cache miss — hash and query DB
@@ -161,7 +174,7 @@ export async function validateSession(token: string): Promise<boolean> {
   }
 
   // 4. Populate cache by raw token so the next call hits the fast path
-  sessionCache.set(token, { expiresAt: record.expiresAt });
+  sessionCache.set(token, { expiresAt: record.expiresAt, createdAt: record.createdAt });
   return true;
 }
 


### PR DESCRIPTION
## Summary

Defense-in-depth for UI session validation. `validateSession`'s cache-hit fast path returned `true` for any non-expired cached session, **skipping the password-change cutoff** that the cache-miss/DB path enforces (reject sessions created before the last password change). `setPasswordHash` also doesn't clear the read cache.

Today the change-password route compensates with `invalidateAllSessions()`, but the invariant *"a session created before the current password must never validate"* should hold at the validation layer rather than depend on every caller clearing the cache. Without this, a session cached just before a password change keeps validating for up to the cache TTL (~5 min).

## Change
- Store `createdAt` in the cached session entry.
- Enforce the `hashCreatedAt` cutoff on the cache-hit path (invalidate + reject if `createdAt < hashCreatedAt`).

Strictly more restrictive — it can only reject, never accept, so it **cannot introduce an auth bypass**. A legitimate post-change session has `createdAt > hashCreatedAt` and is unaffected.

## Test plan
- New regression test: cache-hit path rejects a session created before a simulated password change, without a DB lookup.
- `src/services/ui-session.test.ts` + `middleware/ui-session.test.ts` + `routes/ui-auth.test.ts`: **79 passed**; gateway `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)