### PR TITLE
fix(security): close redirect-based SSRF in RSS feed fetches

### DIFF
--- a/packages/gateway/src/plugins/init.test.ts
+++ b/packages/gateway/src/plugins/init.test.ts
@@ -431,6 +431,14 @@ vi.mock('../services/log.js', () => ({
 // Global fetch mock for RSS tool executors
 vi.stubGlobal('fetch', vi.fn());
 
+// The RSS executors fetch feeds via safeFetch (SSRF-safe). Its real SSRF/DNS
+// checks are covered by safe-fetch.test.ts; here we delegate to the stubbed
+// global fetch so these tests exercise the feed-parsing logic, not networking.
+vi.mock('../utils/safe-fetch.js', () => ({
+  safeFetch: (url: string, opts?: RequestInit) => (globalThis.fetch as typeof fetch)(url, opts),
+  DEFAULT_MAX_REQUEST_BODY_SIZE: 10 * 1024 * 1024,
+}));
+
 // =============================================================================
 // Imports (after mocks)
 // =============================================================================

--- a/packages/gateway/src/plugins/init.ts
+++ b/packages/gateway/src/plugins/init.ts
@@ -34,6 +34,7 @@ import { buildMatrixChannelPlugin } from '../channels/plugins/matrix/index.js';
 import { buildGatewayPlugin } from './gateway-plugin.js';
 import { buildComposioPlugin } from './composio.js';
 import { getLog } from '../services/log.js';
+import { safeFetch } from '../utils/safe-fetch.js';
 
 const log = getLog('Plugins');
 
@@ -217,9 +218,12 @@ function buildNewsRssPlugin(): BuiltinPluginEntry {
         let itemCount = 0;
         let feedTitle = feedUrl;
         try {
-          const response = await fetch(feedUrl, {
+          // SSRF: safeFetch re-validates every redirect hop (with a fresh DNS
+          // lookup) — a bare fetch would follow a 302 from a public feed URL to
+          // a private/metadata address (169.254.169.254) despite the pre-check.
+          const response = await safeFetch(feedUrl, {
             headers: { 'User-Agent': 'OwnPilot RSS Reader/1.0' },
-            signal: AbortSignal.timeout(10000),
+            timeoutMs: 10000,
           });
           const xml = await response.text();
 
@@ -398,9 +402,12 @@ function buildNewsRssPlugin(): BuiltinPluginEntry {
         }
 
         try {
-          const response = await fetch(feedUrl, {
+          // SSRF: safeFetch re-validates every redirect hop (with a fresh DNS
+          // lookup) — a bare fetch would follow a 302 from a public feed URL to
+          // a private/metadata address (169.254.169.254) despite the pre-check.
+          const response = await safeFetch(feedUrl, {
             headers: { 'User-Agent': 'OwnPilot RSS Reader/1.0' },
-            signal: AbortSignal.timeout(10000),
+            timeoutMs: 10000,
           });
           const xml = await response.text();
           const items = parseRssItems(xml);


### PR DESCRIPTION
## Summary

`news_add_feed` / `news_refresh_feed` validated the feed URL once (`isBlockedUrl` + `isPrivateUrlAsync`) then used a **bare `fetch()` with default redirect-follow**. A public feed URL that 302-redirects to a private/metadata address (`169.254.169.254`, `127.0.0.1`, internal hosts) bypassed the pre-check — a classic redirect-based SSRF, reachable whenever the agent is induced (e.g. via prompt injection in a channel message) to add or refresh an attacker-chosen feed.

## Fix
Route both fetches through `safeFetch`, which re-validates **every redirect hop** (`isBlockedUrl` + cached and fresh-DNS private-IP checks) and caps redirects. The entry-URL pre-checks are kept as defense-in-depth for early, clean errors.

## Test plan
- `init.test.ts` mocks `safe-fetch.js` → stubbed global fetch so feed-parsing tests stay network-free.
- `safe-fetch.test.ts` already covers the redirect/SSRF behavior (7 cases) the fix inherits.
- **138 tests pass** (init + safe-fetch); gateway `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)