### PR TITLE
harden(permission-gate): fail-closed filesystem-scope check for unverifiable paths

### DIFF
--- a/packages/gateway/src/services/permission/gate.test.ts
+++ b/packages/gateway/src/services/permission/gate.test.ts
@@ -319,6 +319,23 @@ describe('evaluateAutonomyPolicy (pure)', () => {
     expect(d.type).toBe('deny');
   });
 
+  it('fails closed when a file tool under scope exposes no recognizable path arg', () => {
+    // Path supplied under an unrecognized key (not in PATH_ARG_KEYS) — the gate
+    // cannot verify containment, so it must require approval rather than allow.
+    const d = evaluateAutonomyPolicy(
+      'core.write_file',
+      { unknown_key: '/etc/shadow', content: 'x' },
+      policy(),
+      '/ws'
+    );
+    expect(d.type).toBe('require_approval');
+  });
+
+  it('still allows recognized path args inside scope (no false positive)', () => {
+    const d = evaluateAutonomyPolicy('core.write_file', { path: 'sub/a.txt' }, policy(), '/ws');
+    expect(d.type).toBe('allow');
+  });
+
   it('treats a shell script with rm -rf as destructive', () => {
     const d = evaluateAutonomyPolicy(
       'claw_run_script',

--- a/packages/gateway/src/services/permission/gate.ts
+++ b/packages/gateway/src/services/permission/gate.ts
@@ -283,7 +283,20 @@ export function evaluateAutonomyPolicy(
     if (workspaceDir) roots.push(resolveAgainst('', workspaceDir));
     for (const s of scopes) roots.push(resolveAgainst(workspaceDir ?? '', s));
     if (roots.length > 0) {
-      for (const p of extractPaths(args)) {
+      const paths = extractPaths(args);
+      // Fail-closed: a known file tool is operating under filesystem containment
+      // but exposes no recognizable path argument (PATH_ARG_KEYS), so we cannot
+      // verify it stays within scope. Require approval rather than silently allow
+      // it. No built-in file tool hits this — they all use recognized path keys —
+      // so this is a no-op today; it guards future/custom file tools whose path
+      // argument uses an unrecognized key from becoming a silent scope bypass.
+      if (paths.length === 0) {
+        return {
+          type: 'require_approval',
+          reason: `File tool "${base}" runs under a filesystem scope but exposes no verifiable path argument`,
+        };
+      }
+      for (const p of paths) {
         const resolved = resolveAgainst(workspaceDir ?? '', p);
         if (!roots.some((r) => isWithin(resolved, r))) {
           return {


### PR DESCRIPTION
## Summary

The claw/soul autonomy-policy **filesystem-scope** check (`evaluateAutonomyPolicy`) extracts path arguments from a fixed `PATH_ARG_KEYS` allowlist. When a `FILE_TOOLS` member runs under `filesystemScopes` but **none of its args match a recognized path key**, the containment loop had nothing to check and fell through to **allow** — a silent scope bypass for any file tool whose path argument uses an unrecognized key.

## Change
Fail closed: return `require_approval` when a file tool runs under a filesystem scope but exposes no verifiable path argument. If the gate can't see the path, it can't prove containment, so it must not silently allow.

**No-op for the current tool surface** — all built-in file tools use recognized keys (`path` / `file_path` / `source` / `destination`), verified against their schemas. This guards future/custom file tools from becoming a containment hole.

## Test plan
- New regression tests: fail-closed on an unrecognized path key; no false positive on recognized keys.
- `permission/` suites + `claw/runner.test.ts`: **122 passed**; gateway `tsc` clean.

This implements the recommendation from `docs/SECURITY_AUDIT_2026-06-02.md` (residual limitation #2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)