### PR TITLE
fix(compaction): skip DB mirror when nothing older to summarize

### DIFF
--- a/packages/gateway/src/services/agent/service.test.ts
+++ b/packages/gateway/src/services/agent/service.test.ts
@@ -1986,6 +1986,48 @@ describe('compactContext', () => {
     expect(mockChatRepoAddMessage).not.toHaveBeenCalled();
   });
 
+  it('skips DB mirror when the DB has fewer messages than keepRecent (no orphan summary)', async () => {
+    // Transient in-memory/DB desync: in-memory accumulated past the compaction
+    // threshold (12 msgs) while the DB only has 4 persisted rows. With
+    // keepRecent=6 there is nothing older to fold into a summary, so the mirror
+    // must NOT delete anything AND must NOT insert a summary pair — otherwise it
+    // would orphan the pair at Date.now() (end of an uncompacted conversation),
+    // diverging from the in-memory layout. The next chat write reconciles drift.
+    const messages = Array.from({ length: 12 }, (_, i) => ({
+      role: i % 2 === 0 ? 'user' : 'assistant',
+      content: `msg-${i}`,
+    }));
+    const { agent, memory } = makeMockAgent();
+    memory.getContextMessages.mockReturnValue(messages);
+    memory.getStats.mockReturnValue({
+      messageCount: 8,
+      estimatedTokens: 500,
+      lastActivity: new Date(),
+    });
+    chatAgentCache.set('chat|openai|gpt-4o', agent);
+
+    // Only 4 DB messages — fewer than keepRecent=6 → olderDbMessages is empty.
+    mockChatRepoGetMessages.mockResolvedValueOnce(
+      Array.from({ length: 4 }, (_, i) => ({
+        id: `db-msg-${i}`,
+        role: i % 2 === 0 ? 'user' : 'assistant',
+        content: `db msg ${i}`,
+        createdAt: new Date(2026, 0, 1, 12, i).toISOString(),
+      }))
+    );
+
+    const mockProvider = {
+      complete: vi.fn().mockResolvedValue({ ok: true, value: { content: 'Summary' } }),
+    };
+    mockCreateProvider.mockReturnValue(mockProvider);
+
+    const result = await mod.compactContext('openai', 'gpt-4o', 6, undefined, 'user-123');
+    // In-memory compaction still succeeds; only the DB mirror is skipped.
+    expect(result.compacted).toBe(true);
+    expect(mockChatRepoDeleteMessage).not.toHaveBeenCalled();
+    expect(mockChatRepoAddMessage).not.toHaveBeenCalled();
+  });
+
   it('does NOT attempt DB mirror when userId is omitted', async () => {
     const messages = Array.from({ length: 12 }, (_, i) => ({
       role: i % 2 === 0 ? 'user' : 'assistant',

--- a/packages/gateway/src/services/agent/service.ts
+++ b/packages/gateway/src/services/agent/service.ts
@@ -945,6 +945,19 @@ async function mirrorCompactionToDatabase(opts: {
   const olderDbMessages = existing.slice(0, Math.max(0, existing.length - opts.keepRecent));
   const firstRemaining = existing[existing.length - opts.keepRecent];
 
+  // Nothing older to fold into a summary. This happens when the DB has
+  // <= keepRecent messages while the in-memory store accumulated past the
+  // compaction threshold (transient desync — e.g. in-memory messages not yet
+  // flushed). Inserting a summary pair here would orphan it: no messages get
+  // deleted, and with no `firstRemaining` the pair lands at Date.now() — i.e.
+  // appended to the END of an uncompacted conversation, at the wrong
+  // chronological position and diverging from the in-memory layout. Mirror the
+  // in-memory `too_few_messages` guard and skip — the next chat write reconciles
+  // any drift once persistence catches up.
+  if (olderDbMessages.length === 0) {
+    return;
+  }
+
   // Delete the older DB messages.
   for (const msg of olderDbMessages) {
     await chatRepo.deleteMessage(msg.id);


### PR DESCRIPTION
## Problem

`mirrorCompactionToDatabase` (in `services/agent/service.ts`) mirrors an auto-compaction to the persisted chat history so the change survives gateway restarts / agent-cache evictions. It computes `olderDbMessages = existing.slice(0, max(0, existing.length - keepRecent))` and inserts a summary pair stamped just before `firstRemaining`.

When the DB has **≤ keepRecent** messages, `olderDbMessages` is empty (nothing to delete) **but the summary pair was still inserted** — and with no `firstRemaining`, `baseTime` falls back to `Date.now()`, so the orphan `[Conversation summary from compaction]` pair lands at the **end** of an uncompacted conversation, at the wrong chronological position and diverging from the in-memory layout.

### Reachability

A transient in-memory/DB desync: the in-memory store accumulates past the compaction threshold (`messages.length > keepRecent + 2`) before all rows are flushed to the DB. The in-memory side compacts correctly; only the DB mirror misbehaves.

## Fix

Mirror the in-memory `too_few_messages` guard: early-return from the mirror when `olderDbMessages.length === 0`. Nothing is deleted, no orphan summary is inserted, and the next chat write reconciles any drift once persistence catches up. The in-memory compaction is unaffected.

## Tests

- New regression test: DB has 4 rows, `keepRecent=6` → no `deleteMessage`, no `addMessage`, in-memory `compacted === true`.
- Full `service.test.ts`: **167/167** passing. Lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)