### PR TITLE
fix(ui): don't auto-reconnect WebSocket after an intentional close

### DIFF
--- a/packages/ui/src/hooks/useWebSocket.test.tsx
+++ b/packages/ui/src/hooks/useWebSocket.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+/**
+ * useWebSocket tests — reconnection lifecycle.
+ *
+ * Focus: an INTENTIONAL close (disconnect / unmount / logout) must NOT trigger
+ * the auto-reconnect, while a genuine dropped connection MUST. Uses a minimal
+ * renderHook built on react-dom/client (no @testing-library/react dependency)
+ * and a controllable fake WebSocket.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createElement, act, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useWebSocket } from './useWebSocket';
+
+// ---- Controllable fake WebSocket ----
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  url: string;
+  readyState = FakeWebSocket.CONNECTING;
+  onopen: (() => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+
+  send() {}
+  // close() does NOT auto-fire onclose — tests drive that explicitly to model
+  // both intentional and dropped closes deterministically.
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+
+  simulateOpen() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+  simulateClose() {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
+// ---- Minimal renderHook ----
+
+function renderHook<T>(useHook: () => T) {
+  const result = { current: null as unknown as T };
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root: Root;
+
+  function TestComponent() {
+    result.current = useHook();
+    return null as unknown as ReactNode;
+  }
+
+  act(() => {
+    root = createRoot(container);
+    root.render(createElement(TestComponent));
+  });
+
+  return {
+    result,
+    unmount: () =>
+      act(() => {
+        root.unmount();
+        if (container.parentNode) container.parentNode.removeChild(container);
+      }),
+  };
+}
+
+beforeEach(() => {
+  FakeWebSocket.instances = [];
+  vi.stubGlobal('WebSocket', FakeWebSocket);
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('useWebSocket reconnect lifecycle', () => {
+  test('a genuine dropped connection reconnects', () => {
+    const { result, unmount } = renderHook(() => useWebSocket({ reconnectDelay: 1000 }));
+    // Mount auto-connects → one socket.
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    act(() => FakeWebSocket.instances[0]!.simulateOpen());
+    expect(result.current.status).toBe('connected');
+
+    // Server drops the connection (not via disconnect()).
+    act(() => FakeWebSocket.instances[0]!.simulateClose());
+    expect(result.current.status).toBe('disconnected');
+
+    // Backoff fires → a second socket is created.
+    act(() => vi.advanceTimersByTime(1000));
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    unmount();
+  });
+
+  test('an intentional disconnect() does NOT reconnect', () => {
+    const { result, unmount } = renderHook(() => useWebSocket({ reconnectDelay: 1000 }));
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    act(() => FakeWebSocket.instances[0]!.simulateOpen());
+
+    // Intentional close.
+    act(() => result.current.disconnect());
+
+    // The socket's close event still fires afterwards — it must be ignored.
+    act(() => FakeWebSocket.instances[0]!.simulateClose());
+    act(() => vi.advanceTimersByTime(60_000));
+
+    // No new socket was created.
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(result.current.status).toBe('disconnected');
+
+    unmount();
+  });
+
+  test('unmount does not spawn a zombie reconnecting socket', () => {
+    const { unmount } = renderHook(() => useWebSocket({ reconnectDelay: 1000 }));
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    act(() => FakeWebSocket.instances[0]!.simulateOpen());
+
+    // Unmount triggers disconnect() in the effect cleanup.
+    unmount();
+
+    // A late close event from the torn-down socket must not reconnect.
+    act(() => FakeWebSocket.instances[0]!.simulateClose());
+    act(() => vi.advanceTimersByTime(60_000));
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+});

--- a/packages/ui/src/hooks/useWebSocket.tsx
+++ b/packages/ui/src/hooks/useWebSocket.tsx
@@ -111,22 +111,40 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRes
    * Connect to WebSocket
    */
   const connect = useCallback(() => {
-    if (wsRef.current?.readyState === WebSocket.OPEN) {
+    // Skip if a socket is already open or still opening — avoids orphaning a
+    // CONNECTING socket (which would never be closed) on a double connect().
+    // Intentional reconnects (login) null wsRef first, so they still proceed.
+    const existing = wsRef.current?.readyState;
+    if (existing === WebSocket.OPEN || existing === WebSocket.CONNECTING) {
       return;
     }
 
     setStatus('connecting');
 
     try {
-      wsRef.current = new WebSocket(url);
+      const socket = new WebSocket(url);
+      wsRef.current = socket;
 
-      wsRef.current.onopen = () => {
+      // Per-socket identity guard: once wsRef.current is replaced (reconnect)
+      // or nulled (disconnect / logout / unmount), this socket's late events
+      // must NOT mutate state or schedule a reconnect. Without it, an
+      // intentional close still reconnected (tokenless after logout; a zombie
+      // socket that reconnected forever after unmount).
+      const isActive = () => wsRef.current === socket;
+
+      socket.onopen = () => {
+        if (!isActive()) return;
         setStatus('connected');
       };
 
-      wsRef.current.onmessage = handleMessage;
+      socket.onmessage = (event) => {
+        if (!isActive()) return;
+        handleMessage(event);
+      };
 
-      wsRef.current.onclose = () => {
+      socket.onclose = () => {
+        if (!isActive()) return;
+        wsRef.current = null;
         setStatus('disconnected');
         setSessionId(null);
 
@@ -144,7 +162,8 @@ export function useWebSocket(options: UseWebSocketOptions = {}): UseWebSocketRes
         }
       };
 
-      wsRef.current.onerror = (error) => {
+      socket.onerror = (error) => {
+        if (!isActive()) return;
         setStatus('error');
         console.error('WebSocket error:', error);
       };


### PR DESCRIPTION
## Problem

`useWebSocket`'s `onclose` handler scheduled a reconnect on **every** close, with no way to distinguish an intentional close from a dropped connection. Two real consequences:

- **Logout** — `onSessionChanged` (`authenticated:false`) closes the socket and deliberately does **not** reconnect (its own comment: *"server will reject tokenless WS if password is configured"*). But `onclose` fired with `reconnect===true` and reopened a tokenless connection → reject → reconnect storm.
- **Unmount / `disconnect()`** — `wsRef` was nulled, but the closing socket's `onclose` still scheduled `connect()`, spawning a **zombie socket that reconnects forever** after the component is gone (state updates on an unmounted tree + a leaked connection).

## Fix

Per-socket **identity guard**. `connect()` captures the `socket` it creates; its `onopen`/`onmessage`/`onclose`/`onerror` no-op once `wsRef.current` is no longer that socket — and every intentional path (`disconnect`, logout, login-reconnect, unmount) nulls or swaps `wsRef`. `onclose` also nulls `wsRef` before scheduling a reconnect. `connect()` additionally skips when a socket is `OPEN` **or** `CONNECTING`, so a double `connect()` can't orphan a never-closed `CONNECTING` socket.

Genuine drops still reconnect with the same exponential backoff.

## Tests

New `useWebSocket.test.tsx` (happy-dom + controllable fake `WebSocket`, minimal `renderHook`):
- genuine dropped connection → reconnects (2nd socket created);
- intentional `disconnect()` → no reconnect (still 1 socket) — fails under the old code;
- unmount → no zombie reconnecting socket.

UI hooks suite **54/54**; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)