### PR TITLE
fix(ws): unsubscribe EventBus listeners when reaping idle sessions

### DIFF
--- a/packages/gateway/src/ws/session.test.ts
+++ b/packages/gateway/src/ws/session.test.ts
@@ -982,5 +982,26 @@ describe('SessionManager', () => {
       expect(removed).toBe(3);
       expect(manager.count).toBe(0);
     });
+
+    it('unsubscribes EventBus subscriptions when reaping an idle session', () => {
+      // Regression: cleanup() used a bare sessions.delete() that skipped the
+      // remove() unsubscribe loop, leaking every onPattern() listener for
+      // ungracefully-dropped clients (unbounded EventBus growth).
+      const socket = createMockSocket(1);
+      const session = manager.create(socket);
+
+      const unsubA = vi.fn();
+      const unsubB = vi.fn();
+      manager.addEventSubscription(session.id, 'chat.*', unsubA);
+      manager.addEventSubscription(session.id, 'claw.*', unsubB);
+
+      vi.advanceTimersByTime(60_000);
+      const removed = manager.cleanup(30_000);
+
+      expect(removed).toBe(1);
+      expect(unsubA).toHaveBeenCalledTimes(1);
+      expect(unsubB).toHaveBeenCalledTimes(1);
+      expect(manager.getEventSubscriptions(session.id)).toEqual([]);
+    });
   });
 });

--- a/packages/gateway/src/ws/session.ts
+++ b/packages/gateway/src/ws/session.ts
@@ -435,7 +435,6 @@ export class SessionManager {
   cleanup(maxIdleMs: number): number {
     const now = Date.now();
     let removed = 0;
-    const svc = tryGetSessionService();
 
     for (const [id, session] of this.sessions) {
       if (now - session.lastActivityAt.getTime() > maxIdleMs) {
@@ -444,12 +443,15 @@ export class SessionManager {
         } catch {
           // Socket may already be closed — continue cleanup
         }
-        this.sessions.delete(id);
-        try {
-          svc?.close(id);
-        } catch (error) {
-          log.debug('Session service close failed', { sessionId: id, error });
-        }
+        // Route through remove() rather than a bare sessions.delete(): remove()
+        // unsubscribes the session's EventBus listeners (onPattern handlers) and
+        // clears socketToSession + ISessionService. A direct delete here leaked
+        // every event subscription — the listeners kept firing send() to an
+        // already-removed session on every matching event, forever, so the
+        // EventBus accumulated dead listeners (unbounded memory + per-event CPU)
+        // as ungracefully-dropped clients were reaped. remove() also calls
+        // svc.close(id), so no separate ISessionService close is needed.
+        this.remove(id);
         removed++;
       }
     }


### PR DESCRIPTION
## Problem

`SessionManager.cleanup()` (the idle-session reaper) removed sessions with a bare `this.sessions.delete(id)`, bypassing `remove()`'s unsubscribe loop.

Each WS session can hold up to 50 EventBus subscriptions — `eventSystem.onPattern(pattern, …)` handlers registered via the WS event-bridge, each forwarding matching events to the client via `send()`. The bare delete left **every one of them registered**: the handler closures kept firing `send()` to an already-removed session on every matching event, forever.

`cleanup()` is precisely the path that reaps **ungracefully-dropped** clients (frozen tabs, suspended laptops, dropped mobile — connections whose TCP still looks open but never pong). So the global EventBus steadily accumulated dead listeners — **unbounded memory growth plus per-event CPU cost that scales with the number of clients that ever timed out**.

Graceful closes were unaffected (`socket 'close'` → `removeBySocket` → `remove`, which already unsubscribes). Only the idle-timeout reaper leaked.

## Fix

Route `cleanup()` through `remove()`, which unsubscribes the EventBus listeners and clears `socketToSession` + `ISessionService`. `remove()` already calls `svc.close(id)`, so the separate `ISessionService` close (and its now-unused local) are dropped. Map deletion during the `for…of` is safe.

## Tests

New regression test: register two subscriptions on a session, let it go idle, `cleanup()` — both unsubscribe fns are invoked and `getEventSubscriptions()` is empty. `ws` suite **328/328**; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)