### PR TITLE
fix(triggers): reschedule a schedule trigger even when it throws

### DIFF
--- a/packages/gateway/src/triggers/engine.ts
+++ b/packages/gateway/src/triggers/engine.ts
@@ -791,18 +791,9 @@ export class TriggerEngine {
             }
       );
 
-      // Calculate next fire time for schedule triggers
+      // Advance a schedule trigger to its next fire time (mark non-schedule fired)
       if (trigger.type === 'schedule') {
-        const config = trigger.config as ScheduleConfig;
-        const nextFire = this.calculateNextFire(config);
-        await this.triggerService.markFired(this.config.userId, trigger.id, nextFire ?? undefined);
-        if (nextFire) {
-          log.info('Next fire scheduled', { trigger: trigger.name, nextFire });
-        } else {
-          log.warn('Trigger has no next fire time — will not auto-fire again', {
-            trigger: trigger.name,
-          });
-        }
+        await this.advanceSchedule(trigger);
       } else {
         await this.triggerService.markFired(this.config.userId, trigger.id);
       }
@@ -830,8 +821,42 @@ export class TriggerEngine {
         error: errorMessage,
       });
       log.error('Trigger failed', { trigger: trigger.name, error });
+
+      // Advance the schedule even on unexpected failure. Otherwise nextFire
+      // stays in the past, getDueTriggers keeps returning this trigger, and it
+      // re-fires on every poll — an infinite hot loop that re-hammers the
+      // failing action (e.g. a scheduled channel send to a blocked chat). Wrap
+      // in its own try so a reschedule failure can't mask the original error.
+      try {
+        await this.advanceSchedule(trigger);
+      } catch (rescheduleError) {
+        log.error('Failed to reschedule trigger after failure', {
+          trigger: trigger.name,
+          error: getErrorMessage(rescheduleError),
+        });
+      }
     } finally {
       this.executingTriggers.delete(trigger.id);
+    }
+  }
+
+  /**
+   * Advance a schedule trigger to its next cron fire time (persisted via
+   * markFired). No-op for non-schedule triggers. Extracted so it runs on BOTH
+   * the success and failure paths of executeTrigger — a throwing schedule
+   * trigger must still reschedule, or it hot-loops every poll.
+   */
+  private async advanceSchedule(trigger: Trigger): Promise<void> {
+    if (trigger.type !== 'schedule') return;
+    const config = trigger.config as ScheduleConfig;
+    const nextFire = this.calculateNextFire(config);
+    await this.triggerService.markFired(this.config.userId, trigger.id, nextFire ?? undefined);
+    if (nextFire) {
+      log.info('Next fire scheduled', { trigger: trigger.name, nextFire });
+    } else {
+      log.warn('Trigger has no next fire time — will not auto-fire again', {
+        trigger: trigger.name,
+      });
     }
   }
 

--- a/packages/gateway/src/triggers/trigger-engine.test.ts
+++ b/packages/gateway/src/triggers/trigger-engine.test.ts
@@ -1768,6 +1768,51 @@ describe('TriggerEngine', () => {
       e.stop();
     });
 
+    it('still advances nextFire when a schedule trigger throws (no hot loop)', async () => {
+      // Regression: if executeTrigger threw before rescheduling, nextFire stayed
+      // in the past, getDueTriggers kept returning the trigger, and it re-fired
+      // every poll forever. The failure path must still reschedule.
+      const nextDate = new Date('2025-12-01T10:00:00Z');
+      vi.mocked(getNextRunTime).mockReturnValue(nextDate);
+
+      const trigger = makeTrigger({
+        id: 'sched-throw',
+        type: 'schedule',
+        config: { cron: '0 10 * * *' },
+        action: { type: 'boom' as Trigger['action']['type'], payload: {} },
+      });
+      mockTriggerService.getDueTriggers.mockResolvedValueOnce([trigger]);
+
+      const e = new TriggerEngine({
+        enabled: true,
+        pollIntervalMs: 999999,
+        conditionCheckIntervalMs: 999999,
+      });
+      e.registerActionHandler('boom', async () => {
+        throw new Error('action exploded');
+      });
+      e.start();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Logged as a failure...
+      expect(mockTriggerService.logExecution).toHaveBeenCalledWith(
+        'default',
+        'sched-throw',
+        expect.any(String),
+        'failure',
+        undefined,
+        expect.any(String),
+        expect.any(Number)
+      );
+      // ...but nextFire was still advanced so it won't hot-loop.
+      expect(mockTriggerService.markFired).toHaveBeenCalledWith(
+        'default',
+        'sched-throw',
+        nextDate.toISOString()
+      );
+      e.stop();
+    });
+
     it('merges action payload with event payload, adding triggerId and triggerName', async () => {
       const handler = vi.fn(async () => ({ success: true, message: 'ok' }));
       engine.registerActionHandler('merge_test', handler);


### PR DESCRIPTION
## Problem

`executeTrigger` advanced `nextFire` (`calculateNextFire` + `markFired`) **only in the `try` block's success path**. If anything threw, the `catch` logged the failure but never advanced `nextFire`. The trigger's `nextFire` stayed in the past, so `getDueTriggers` kept returning it and it re-fired on **every poll** — an infinite hot loop that re-hammered the failing action forever (and, for agent actions, kept spending tokens).

### Reachable throws (not just defensive)

- `deliverPreRunOutput` → `executeTool('send_channel_message')` — a scheduled digest to a Telegram/Discord chat that's been **blocked or deleted** throws on send.
- `resolveChainedContext` / `logExecution` — DB blips.
- A throwing action handler (handlers aren't guaranteed to return `success:false`).

## Fix

Extract `advanceSchedule(trigger)` and call it on **both** the success path and the failure path. The `catch` wraps it in its own `try` so a reschedule failure can't mask the original error. A throwing schedule trigger now skips to its next cron time instead of hot-looping.

Non-schedule triggers are unchanged (`advanceSchedule` is a no-op for them; they only `markFired` on success as before).

## Tests

New regression test: a schedule trigger whose action throws is logged as `failure` **but** `markFired` is still called with the next fire time. Verified it **fails without the fix** and passes with it. Trigger suite **146/146**; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)