### PR TITLE
fix(triggers): mark non-schedule triggers fired on failure too

### DIFF
--- a/packages/gateway/src/triggers/engine.ts
+++ b/packages/gateway/src/triggers/engine.ts
@@ -822,13 +822,19 @@ export class TriggerEngine {
       });
       log.error('Trigger failed', { trigger: trigger.name, error });
 
-      // Advance the schedule even on unexpected failure. Otherwise nextFire
-      // stays in the past, getDueTriggers keeps returning this trigger, and it
-      // re-fires on every poll — an infinite hot loop that re-hammers the
-      // failing action (e.g. a scheduled channel send to a blocked chat). Wrap
-      // in its own try so a reschedule failure can't mask the original error.
+      // Advance the trigger's schedule/lastFired even on unexpected failure,
+      // mirroring the success path. Otherwise a persistently-failing trigger
+      // re-fires forever: a schedule trigger stays "due" and fires every poll;
+      // a condition trigger never sets lastFired, so its checkInterval throttle
+      // never engages and it re-fires every condition tick — both re-hammer the
+      // failing action (e.g. a channel send to a blocked chat). Wrap in its own
+      // try so a reschedule failure can't mask the original error.
       try {
-        await this.advanceSchedule(trigger);
+        if (trigger.type === 'schedule') {
+          await this.advanceSchedule(trigger);
+        } else {
+          await this.triggerService.markFired(this.config.userId, trigger.id);
+        }
       } catch (rescheduleError) {
         log.error('Failed to reschedule trigger after failure', {
           trigger: trigger.name,

--- a/packages/gateway/src/triggers/trigger-engine.test.ts
+++ b/packages/gateway/src/triggers/trigger-engine.test.ts
@@ -1083,6 +1083,47 @@ describe('TriggerEngine', () => {
       e.stop();
     });
 
+    it('marks a failed condition trigger as fired so its throttle engages (no hot loop)', async () => {
+      // Regression: the failure path did not set lastFired for non-schedule
+      // triggers, so a condition trigger whose action threw never engaged its
+      // checkInterval throttle and re-fired every condition tick forever.
+      const trigger = makeTrigger({
+        id: 'cond-throw',
+        type: 'condition',
+        config: { condition: 'upcoming_deadline', threshold: 7 },
+        lastFired: null,
+        action: { type: 'cond_boom' as Trigger['action']['type'], payload: {} },
+      });
+      mockTriggerService.getConditionTriggers.mockResolvedValueOnce([trigger]);
+      mockGoalService.getUpcoming.mockResolvedValueOnce([{ id: 'g1', title: 'Due Soon' }]);
+
+      const e = new TriggerEngine({
+        enabled: true,
+        pollIntervalMs: 999999,
+        conditionCheckIntervalMs: 999999,
+      });
+      e.registerActionHandler('cond_boom', async () => {
+        throw new Error('condition action exploded');
+      });
+      e.start();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Logged as a failure...
+      expect(mockTriggerService.logExecution).toHaveBeenCalledWith(
+        'default',
+        'cond-throw',
+        expect.any(String),
+        'failure',
+        undefined,
+        expect.any(String),
+        expect.any(Number)
+      );
+      // ...but lastFired was still set (markFired without nextFire) so the
+      // checkInterval throttle now applies on the next tick.
+      expect(mockTriggerService.markFired).toHaveBeenCalledWith('default', 'cond-throw');
+      e.stop();
+    });
+
     it('fires when trigger has never been fired (lastFired is null)', async () => {
       const trigger = makeTrigger({
         type: 'condition',


### PR DESCRIPTION
## Problem

Follow-up to #44. `executeTrigger`'s `catch` path only advanced **schedule** triggers; non-schedule (condition) triggers were left un-marked on failure.

`processConditionTriggers` throttles re-evaluation via `checkInterval`, but that throttle is gated on `lastFired`. A condition trigger sets `lastFired` only on the success path — so a condition trigger whose action **throws** (e.g. a channel send to a blocked/deleted chat) never set `lastFired`, the throttle never engaged, and it re-fired on **every condition tick (every 5 min)** forever instead of respecting its `checkInterval` (default 60 min).

## Fix

The `catch` path now mirrors the success path for all trigger types: schedule advances `nextFire`, others `markFired` (set `lastFired`). The `checkInterval` throttle now engages, so a persistently-failing condition trigger retries at its `checkInterval` cadence instead of every tick. Event triggers are unaffected in practice (they don't gate on `lastFired`).

## Tests

New regression test: a condition trigger with a throwing action is logged as `failure` **but** `markFired` is still called (setting `lastFired`). Trigger suite **147/147**; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)