### PR TITLE
fix(channels): dedup redelivered inbound webhooks before AI routing

### DIFF
--- a/packages/gateway/src/channels/service-impl.test.ts
+++ b/packages/gateway/src/channels/service-impl.test.ts
@@ -42,6 +42,7 @@ const mockSessionsRepo = vi.hoisted(() => ({
 
 const mockMessagesRepo = vi.hoisted(() => ({
   create: vi.fn().mockResolvedValue(undefined),
+  createIfNew: vi.fn().mockResolvedValue(true),
   linkConversation: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -185,6 +186,7 @@ vi.mock('../db/repositories/channels/sessions.js', () => ({
 vi.mock('../db/repositories/channels/messages.js', () => ({
   ChannelMessagesRepository: class {
     create = mockMessagesRepo.create;
+    createIfNew = mockMessagesRepo.createIfNew;
     linkConversation = mockMessagesRepo.linkConversation;
   },
 }));
@@ -1204,12 +1206,12 @@ describe('ChannelServiceImpl', () => {
         expect(mockUsersRepo.findOrCreate).toHaveBeenCalledTimes(limit);
 
         // One more from the same sender within the window — should be dropped
-        // BEFORE findOrCreate / messagesRepo.create are called.
+        // BEFORE findOrCreate / the inbound createIfNew save are called.
         mockUsersRepo.findOrCreate.mockClear();
-        mockMessagesRepo.create.mockClear();
+        mockMessagesRepo.createIfNew.mockClear();
         await service.processIncomingMessage(createIncomingMessage({ id: 'msg-overflow' }));
         expect(mockUsersRepo.findOrCreate).not.toHaveBeenCalled();
-        expect(mockMessagesRepo.create).not.toHaveBeenCalled();
+        expect(mockMessagesRepo.createIfNew).not.toHaveBeenCalled();
       });
 
       it('does not penalize a different sender on the same channel', async () => {
@@ -1491,7 +1493,8 @@ describe('ChannelServiceImpl', () => {
       it('should save incoming message', async () => {
         await service.processIncomingMessage(message);
 
-        expect(mockMessagesRepo.create).toHaveBeenCalledWith(
+        // Inbound save goes through createIfNew (the idempotency gate).
+        expect(mockMessagesRepo.createIfNew).toHaveBeenCalledWith(
           expect.objectContaining({
             id: 'msg-1',
             channelId: 'test-plugin',
@@ -1503,8 +1506,18 @@ describe('ChannelServiceImpl', () => {
         );
       });
 
+      it('ignores a duplicate (redelivered) inbound message before AI routing', async () => {
+        // createIfNew returns false → the row already existed → must short-circuit
+        // before the session lookup / LLM call so the user isn't replied to twice.
+        mockMessagesRepo.createIfNew.mockResolvedValueOnce(false);
+
+        await service.processIncomingMessage(message);
+
+        expect(mockSessionsRepo.findActive).not.toHaveBeenCalled();
+      });
+
       it('should tolerate save failure for incoming message', async () => {
-        mockMessagesRepo.create.mockRejectedValueOnce(new Error('DB error'));
+        mockMessagesRepo.createIfNew.mockRejectedValueOnce(new Error('DB error'));
 
         // Should not throw; continues processing
         await service.processIncomingMessage(message);
@@ -1771,8 +1784,9 @@ describe('ChannelServiceImpl', () => {
       it('should save outgoing message to channel_messages table', async () => {
         await service.processIncomingMessage(message);
 
-        // Second call to create (first is incoming, second is outgoing)
-        const outgoingCall = mockMessagesRepo.create.mock.calls[1];
+        // Inbound now goes through createIfNew (idempotency gate); the outbound
+        // save is the first (and only) plain create() call.
+        const outgoingCall = mockMessagesRepo.create.mock.calls[0];
         expect(outgoingCall[0]).toMatchObject({
           channelId: 'test-plugin',
           direction: 'outbound',

--- a/packages/gateway/src/channels/service-impl.ts
+++ b/packages/gateway/src/channels/service-impl.ts
@@ -860,10 +860,17 @@ export class ChannelServiceImpl implements IChannelService {
         } // end else (non-whatsapp verification)
       }
 
-      // 5. Save incoming message (conversationId wired after session creation below)
+      // 5. Save incoming message (conversationId wired after session creation
+      //    below). This is also the idempotency gate: message.id is derived
+      //    deterministically from the provider's message id (e.g. `slack:<ts>`,
+      //    `channel.sms:<sid>`), so a redelivered webhook produces the same id.
+      //    createIfNew inserts ON CONFLICT (id) DO NOTHING and reports whether
+      //    the row was new; a duplicate delivery returns early BEFORE the LLM
+      //    routing below, preventing a second (paid) AI reply to the same
+      //    message. Race-safe against concurrent redeliveries.
       let savedInboundId: string | undefined;
       try {
-        await this.messagesRepo.create({
+        const isNew = await this.messagesRepo.createIfNew({
           id: message.id,
           channelId: message.channelPluginId,
           externalId: message.metadata?.platformMessageId?.toString(),
@@ -886,8 +893,19 @@ export class ChannelServiceImpl implements IChannelService {
           replyToId: message.replyToId,
           metadata: message.metadata,
         });
+        if (!isNew) {
+          log.info('Duplicate inbound message ignored (idempotency)', {
+            id: message.id,
+            platform: message.platform,
+          });
+          return;
+        }
         savedInboundId = message.id;
       } catch (error) {
+        // A save failure here must NOT silently fall through to a second AI
+        // reply on the next retry. But unlike a clean duplicate, we can't tell
+        // whether this delivery was already answered, so we continue (best
+        // effort) — the dedup above handles the common redelivery case.
         log.warn('Failed to save incoming message', { error });
       }
 

--- a/packages/gateway/src/db/repositories/channels/messages.test.ts
+++ b/packages/gateway/src/db/repositories/channels/messages.test.ts
@@ -184,6 +184,42 @@ describe('ChannelMessagesRepository', () => {
     });
   });
 
+  // ---- createIfNew (idempotency gate) ----
+
+  describe('createIfNew', () => {
+    it('uses ON CONFLICT DO NOTHING and returns true when a row is inserted', async () => {
+      mockAdapter.execute.mockResolvedValueOnce({ changes: 1 });
+
+      const inserted = await repo.createIfNew({
+        id: 'msg-1',
+        channelId: 'ch-1',
+        direction: 'inbound',
+        content: 'Hello',
+      });
+
+      expect(inserted).toBe(true);
+      expect(mockAdapter.execute).toHaveBeenCalledWith(
+        expect.stringContaining('ON CONFLICT (id) DO NOTHING'),
+        expect.arrayContaining(['msg-1', 'ch-1', 'inbound'])
+      );
+      // Pure insert — must not do a follow-up getById read.
+      expect(mockAdapter.queryOne).not.toHaveBeenCalled();
+    });
+
+    it('returns false when the id already exists (no row inserted)', async () => {
+      mockAdapter.execute.mockResolvedValueOnce({ changes: 0 });
+
+      const inserted = await repo.createIfNew({
+        id: 'dup-1',
+        channelId: 'ch-1',
+        direction: 'inbound',
+        content: 'Duplicate',
+      });
+
+      expect(inserted).toBe(false);
+    });
+  });
+
   // ---- getById ----
 
   describe('getById', () => {

--- a/packages/gateway/src/db/repositories/channels/messages.ts
+++ b/packages/gateway/src/db/repositories/channels/messages.ts
@@ -109,6 +109,51 @@ export class ChannelMessagesRepository extends BaseRepository {
     return result;
   }
 
+  /**
+   * Insert an inbound message only if its id is not already present.
+   * Returns true when a new row was inserted, false when the id already
+   * existed — i.e. a redelivered/duplicate webhook. Atomic dedup via
+   * `ON CONFLICT (id) DO NOTHING`, so it is race-safe against concurrent
+   * redeliveries (only one INSERT reports changes > 0).
+   */
+  async createIfNew(data: {
+    id: string;
+    channelId: string;
+    externalId?: string;
+    direction: ChannelMessage['direction'];
+    senderId?: string;
+    senderName?: string;
+    content: string;
+    contentType?: string;
+    attachments?: ChannelMessage['attachments'];
+    replyToId?: string;
+    conversationId?: string;
+    metadata?: Record<string, unknown>;
+  }): Promise<boolean> {
+    const result = await this.execute(
+      `INSERT INTO channel_messages (
+        id, channel_id, external_id, direction, sender_id, sender_name,
+        content, content_type, attachments, reply_to_id, conversation_id, metadata
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+      ON CONFLICT (id) DO NOTHING`,
+      [
+        data.id,
+        data.channelId,
+        data.externalId ?? null,
+        data.direction,
+        data.senderId ?? null,
+        data.senderName ?? null,
+        data.content,
+        data.contentType ?? 'text',
+        data.attachments ? JSON.stringify(data.attachments) : null,
+        data.replyToId ?? null,
+        data.conversationId ?? null,
+        JSON.stringify(data.metadata ?? {}),
+      ]
+    );
+    return result.changes > 0;
+  }
+
   async getById(id: string): Promise<ChannelMessage | null> {
     const row = await this.queryOne<ChannelMessageRow>(
       `SELECT * FROM channel_messages WHERE id = $1`,


### PR DESCRIPTION
## Problem

`processIncomingMessage` saved the inbound message with a plain `INSERT` and, on failure, only logged a warning and **continued**.

`channel_messages.id` is derived deterministically from the provider's message id — `slack:<ts>`, `channel.sms:<sid>`, `discord:<id>`, `matrix:<event_id>`, `channel.email:<id>`. So a **redelivered webhook** (provider retry on timeout / non-2xx) produces the **same id**. The duplicate `INSERT` threw a unique violation, which was caught as a generic "save failed" — and execution fell through to the session lookup and the LLM call: **a second (paid) AI reply to the user for one message.**

## Fix

New `ChannelMessagesRepository.createIfNew()` inserts with `ON CONFLICT (id) DO NOTHING` and returns whether a row was actually inserted (`changes > 0`). `processIncomingMessage` uses it as an **idempotency gate**: a duplicate (`changes === 0`) logs and returns **before** AI routing.

It's atomic, so it's **race-safe** against concurrent redeliveries — only one `INSERT` reports `changes > 0`.

**Trade-off:** a crash between save and reply means a retry is deduped rather than re-answered (at-most-once after save). This is the standard webhook-idempotency posture and strictly better than the double-reply it replaces.

Outbound saves and the group-message path are unchanged.

## Tests

- Repo: `createIfNew` returns `true` on insert / `false` on conflict, emits `ON CONFLICT (id) DO NOTHING`, does no follow-up read.
- Service: a duplicate (`createIfNew → false`) short-circuits **before** `sessionsRepo.findActive` (no LLM call).
- Updated existing inbound-save assertions to `createIfNew`.

**181/181**; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)