### PR TITLE
harden(channels): bridge-level loop guard (bot-origin + self-target)

### DIFF
--- a/packages/core/src/channels/ucp/bridge.test.ts
+++ b/packages/core/src/channels/ucp/bridge.test.ts
@@ -156,6 +156,41 @@ describe('UCPBridgeManager', () => {
       expect(count).toBe(0);
     });
 
+    it('does not bridge bot-originated messages (loop guard)', async () => {
+      // A bridge re-emits AS the bot; if that output ever re-enters the inbound
+      // path it is bot-flagged. Skipping bot senders breaks cross-channel echo
+      // loops independently of per-plugin self-message filtering.
+      manager.addBridge(makeBridge());
+
+      const msg = makeMessage({
+        channelInstanceId: 'channel.telegram',
+        direction: 'inbound',
+        sender: { id: 'bot-1', platform: 'telegram', isBot: true },
+      });
+      const count = await manager.bridgeMessage(msg);
+      expect(count).toBe(0);
+      expect(sendFn).not.toHaveBeenCalled();
+    });
+
+    it('does not forward to the same channel (source === target)', async () => {
+      // Misconfigured self-bridge must not echo the message back to its origin.
+      manager.addBridge(
+        makeBridge({
+          sourceChannelId: 'channel.telegram',
+          targetChannelId: 'channel.telegram',
+          direction: 'both',
+        })
+      );
+
+      const msg = makeMessage({
+        channelInstanceId: 'channel.telegram',
+        direction: 'inbound',
+      });
+      const count = await manager.bridgeMessage(msg);
+      expect(count).toBe(0);
+      expect(sendFn).not.toHaveBeenCalled();
+    });
+
     it('does not bridge disabled bridges', async () => {
       manager.addBridge(makeBridge({ enabled: false }));
 

--- a/packages/core/src/channels/ucp/bridge.ts
+++ b/packages/core/src/channels/ucp/bridge.ts
@@ -89,6 +89,15 @@ export class UCPBridgeManager {
   async bridgeMessage(msg: UCPMessage): Promise<number> {
     if (!this.sendFn || msg.direction !== 'inbound') return 0;
 
+    // Loop guard (defense in depth): a bridge always re-emits a message AS the
+    // bot, so anything bridged that later re-enters the inbound path is
+    // bot-flagged. Skipping bot-originated messages stops cross-channel echo
+    // loops even if a channel plugin fails to filter the bot's own messages —
+    // today every plugin does, but the bridge must not depend on that invariant
+    // holding for every current and future platform. The single-owner mirror
+    // use case only ever bridges the human owner's messages.
+    if (msg.sender?.isBot) return 0;
+
     const sourceId = msg.channelInstanceId;
     let forwardCount = 0;
 
@@ -109,6 +118,10 @@ export class UCPBridgeManager {
       }
 
       if (!targetId) continue;
+
+      // Never forward a message back onto its own channel (a misconfigured
+      // source === target bridge) — that would just echo to the owner.
+      if (targetId === sourceId) continue;
 
       // Apply filter pattern if configured
       if (bridge.filterPattern) {


### PR DESCRIPTION
## Context (hardening, not an active-bug fix)

The cross-channel bridge re-emits every forwarded message **as the bot**. Today the only thing preventing an A→B→A echo loop is that **every** channel plugin filters the bot's own inbound messages (Discord, Slack, Telegram, WhatsApp, Matrix all do). I verified this — **no loop is currently reachable.**

But that makes loop prevention a fragile cross-cutting invariant the bridge itself doesn't enforce. A new channel plugin (or a platform behavior change) that forgets to filter self-messages would create an infinite, token- and rate-limit-burning cross-channel loop. The bridge should be self-protecting.

## Change

Two bridge-level guards in `UCPBridgeManager.bridgeMessage`:

- **Bot-origin skip** (`msg.sender?.isBot`): a bridged message that re-enters the inbound path is always bot-flagged, so this breaks any echo loop independent of per-plugin filtering. The single-owner "mirror my messages" use case only bridges the human owner's messages, so this changes nothing for legitimate traffic.
- **Self-target skip** (`targetId === sourceId`): a misconfigured bridge whose source and target are the same channel would just echo the message back to the owner.

## Tests

- A bot-originated inbound message is not forwarded (`count === 0`, `sendFn` not called).
- A `source === target` bridge does not forward.

Core bridge suite **16/16**; build + lint clean. Existing forwarding tests are unaffected (their fixtures have no `isBot` and distinct source/target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)