### PR TITLE
fix(channels): replace dangling progress placeholder with error on failure

### DIFF
--- a/packages/gateway/src/channels/service-impl.test.ts
+++ b/packages/gateway/src/channels/service-impl.test.ts
@@ -1696,6 +1696,35 @@ describe('ChannelServiceImpl', () => {
         mockGetOrCreateChatAgent.mockResolvedValue(createMockAgent());
       });
 
+      it('replaces a pending progress placeholder with the error on failure', async () => {
+        // Channel exposes a progress manager (e.g. Telegram "Thinking..."). When
+        // the pipeline throws after the placeholder is shown, the catch must
+        // finish() it with the error text — not orphan it and append a second
+        // message.
+        const finish = vi.fn().mockResolvedValue('msg-err');
+        const progressManager = {
+          start: vi.fn().mockResolvedValue('msg-prog'),
+          update: vi.fn(),
+          finish,
+          cancel: vi.fn().mockResolvedValue(undefined),
+          getMessageId: vi.fn().mockReturnValue(1),
+        };
+        (channelPlugin.api as Record<string, unknown>).createProgressManager = vi.fn(
+          () => progressManager
+        );
+        mockBus.process.mockRejectedValueOnce(new Error('pipeline boom'));
+
+        await service.processIncomingMessage(message);
+
+        // Placeholder was started, then replaced in place with the error...
+        expect(progressManager.start).toHaveBeenCalled();
+        expect(finish).toHaveBeenCalledWith(
+          expect.stringContaining('Sorry, I encountered an internal error')
+        );
+        // ...not orphaned with a separate sendMessage error reply.
+        expect(channelPlugin.api.sendMessage).not.toHaveBeenCalled();
+      });
+
       it('should route through MessageBus when available', async () => {
         await service.processIncomingMessage(message);
 

--- a/packages/gateway/src/channels/service-impl.ts
+++ b/packages/gateway/src/channels/service-impl.ts
@@ -529,6 +529,16 @@ export class ChannelServiceImpl implements IChannelService {
    * This is the main pipeline: auth check -> session lookup -> AI routing.
    */
   async processIncomingMessage(message: ChannelIncomingMessage): Promise<void> {
+    type ChannelProgressManager = {
+      start(text?: string): Promise<string>;
+      update(text: string): void;
+      finish(text: string): Promise<string>;
+      cancel(): Promise<void>;
+      getMessageId(): number | null;
+    };
+    // Hoisted out of the try so the catch can replace a dangling "Thinking..."
+    // progress placeholder with the error message instead of orphaning it.
+    let progress: ChannelProgressManager | null = null;
     try {
       // 0. Drop floods before any DB/LLM work. A single sender cannot exhaust
       //    resources by spamming — see isFlooding() for the sliding window.
@@ -1040,7 +1050,7 @@ export class ChannelServiceImpl implements IChannelService {
         shouldReplyWithVoice?(message: ChannelIncomingMessage): Promise<boolean> | boolean;
       };
       const progressApi = api as ProgressCapableAPI;
-      const progress =
+      progress =
         typeof progressApi.createProgressManager === 'function'
           ? progressApi.createProgressManager(message.platformChatId)
           : null;
@@ -1154,15 +1164,25 @@ export class ChannelServiceImpl implements IChannelService {
         ? 'No AI provider configured. Please set up an API key (e.g. OpenAI, Anthropic) in OwnPilot Settings or Config Center.'
         : 'Sorry, I encountered an internal error. Please try again.';
 
-      // Try to send error reply
+      // Surface the error to the user. If a progress ("Thinking...") placeholder
+      // is pending, replace it in place — otherwise it is orphaned in the chat
+      // while a second error message is appended. finish() edits the placeholder
+      // when one was sent and falls back to a fresh message when it wasn't.
+      // Nothing after a successful reply throws to this catch (the post-send save
+      // is self-contained and wsGateway.broadcast never throws), so finishing
+      // here cannot overwrite a reply that was already delivered.
       try {
-        const api = this.getChannel(message.channelPluginId);
-        if (api) {
-          await api.sendMessage({
-            platformChatId: message.platformChatId,
-            text: userMessage,
-            replyToId: message.id,
-          });
+        if (progress) {
+          await progress.finish(userMessage);
+        } else {
+          const api = this.getChannel(message.channelPluginId);
+          if (api) {
+            await api.sendMessage({
+              platformChatId: message.platformChatId,
+              text: userMessage,
+              replyToId: message.id,
+            });
+          }
         }
       } catch {
         // Best-effort error reply — original error already logged above


### PR DESCRIPTION
## Problem

`processIncomingMessage` declared the progress manager (the Telegram-style "🤔 Thinking…" placeholder) with `const` **inside** the `try`, so the `catch` couldn't reach it. When the pipeline threw *after* `progress.start()` had posted the placeholder, the catch sent a **separate** error message and left the "Thinking…" message orphaned in the chat. On Telegram (progress on by default) that happened on **every** error — the user saw a stuck "Thinking…" *plus* a "Sorry, I encountered an internal error".

## Fix

Hoist `progress` to method scope and, in the catch, call `progress.finish(errorMessage)` when a manager exists. `finish()` edits the placeholder in place (or sends a fresh message if one was never posted), so the user sees a single message that becomes the error.  Falls back to `api.sendMessage` when the channel has no progress manager (unchanged for those).

This **cannot overwrite a delivered reply**: nothing after a successful send throws to this catch — the outgoing save has its own try/catch and `wsGateway.broadcast` never throws — so reaching the catch means the reply was not delivered.

## Tests

New regression test: the bus pipeline throws while a progress manager is active → `finish()` is called with the error text and no separate `sendMessage` is issued. service-impl suite **116/116**; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)