### PR TITLE
fix(extensions): recover() must clear the error state after reload

### DIFF
--- a/packages/gateway/src/services/extension/service.test.ts
+++ b/packages/gateway/src/services/extension/service.test.ts
@@ -604,6 +604,63 @@ describe('ExtensionService', () => {
     });
   });
 
+  describe('recover()', () => {
+    it('returns null when extension not found', async () => {
+      mockRepo.getById.mockReturnValue(null);
+      expect(await svc.recover('no-such-id')).toBeNull();
+    });
+
+    it('returns the record unchanged when not in error state', async () => {
+      const record = makeRecord({ status: 'enabled' });
+      mockRepo.getById.mockReturnValue(record);
+      const result = await svc.recover('test-ext');
+      expect(result).toEqual(record);
+      expect(mockRepo.updateStatus).not.toHaveBeenCalled();
+    });
+
+    it('clears the error to disabled after a successful reload (not left stuck in error)', async () => {
+      // Regression: install() upserts but ON CONFLICT preserves status, so a
+      // successful reload returns a record still in 'error'. recover() must fall
+      // through and clear the error rather than return that record.
+      mockRepo.getById.mockReturnValue(makeRecord({ status: 'error' }));
+      mockExists.mockReturnValue(true);
+      const installSpy = vi
+        .spyOn(svc, 'install')
+        .mockResolvedValue(makeRecord({ status: 'error' }));
+      mockRepo.updateStatus.mockResolvedValue(makeRecord({ status: 'disabled' }));
+
+      const result = await svc.recover('test-ext');
+
+      expect(installSpy).toHaveBeenCalledWith('/path/to/extension.json', 'default');
+      expect(mockRepo.updateStatus).toHaveBeenCalledWith('test-ext', 'disabled');
+      expect(result).toEqual(makeRecord({ status: 'disabled' }));
+      expect(mockESEmit).toHaveBeenCalledWith(
+        'extension.disabled',
+        'extension-service',
+        expect.any(Object)
+      );
+    });
+
+    it('resets to disabled when the reload throws', async () => {
+      mockRepo.getById.mockReturnValue(makeRecord({ status: 'error' }));
+      mockExists.mockReturnValue(true);
+      vi.spyOn(svc, 'install').mockRejectedValue(new Error('reload boom'));
+      mockRepo.updateStatus.mockResolvedValue(makeRecord({ status: 'disabled' }));
+
+      await svc.recover('test-ext');
+      expect(mockRepo.updateStatus).toHaveBeenCalledWith('test-ext', 'disabled');
+    });
+
+    it('resets to disabled when there is no source path on disk', async () => {
+      mockRepo.getById.mockReturnValue(makeRecord({ status: 'error' }));
+      mockExists.mockReturnValue(false);
+      mockRepo.updateStatus.mockResolvedValue(makeRecord({ status: 'disabled' }));
+
+      await svc.recover('test-ext');
+      expect(mockRepo.updateStatus).toHaveBeenCalledWith('test-ext', 'disabled');
+    });
+  });
+
   // ==========================================================================
   // Read methods
   // ==========================================================================

--- a/packages/gateway/src/services/extension/service.ts
+++ b/packages/gateway/src/services/extension/service.ts
@@ -411,16 +411,22 @@ export class ExtensionService implements IExtensionService {
 
     if (record.status !== 'error') return record;
 
-    // Try to reload from disk if source path exists
+    // Try to reload from disk if source path exists (refreshes the manifest and
+    // re-registers config requirements). Do NOT return install()'s record here:
+    // install() upserts, but the ON CONFLICT clause preserves the existing
+    // status, so a successful reload leaves the row still 'error'. We must fall
+    // through and explicitly clear the error below — otherwise "recover" is a
+    // no-op that returns an extension still stuck in the error state.
     if (record.sourcePath && existsSync(record.sourcePath)) {
       try {
-        return await this.install(record.sourcePath, userId);
+        await this.install(record.sourcePath, userId);
       } catch (e) {
         log.warn(`Recovery reload failed for ${id}, resetting to disabled`, { error: String(e) });
       }
     }
 
-    // Fall back to disabling (clear error state)
+    // Clear the error state. 'disabled' is the safe post-recovery state; the
+    // user re-enables when ready (which re-activates triggers).
     const updated = await extensionsRepo.updateStatus(id, 'disabled');
     if (updated) {
       getEventSystem().emit('extension.disabled', 'extension-service', {


### PR DESCRIPTION
## Problem

`ExtensionService.recover()` reloads an errored extension from disk via `install()` and `return`ed that record directly. But `install()` → `upsert()`, and the `ON CONFLICT (id) DO UPDATE` clause deliberately **does not touch the `status` column** (so a user's `disabled` choice survives restarts — see the upsert note in CLAUDE memory).

So when an extension is in `'error'` state and its `sourcePath` exists, a successful reload **left the row still `'error'`**, and the early `return await this.install(...)` skipped the `updateStatus(..., 'disabled')` fallback that was meant to clear it. Net effect: clicking **recover** appeared to succeed (no throw) but the extension stayed stuck in the error state. The fallback only ran when the reload threw or there was no source path.

## Fix

Drop the early `return` — always fall through to `updateStatus(id, 'disabled')` after the optional reload, which clears both `status` and `error_message`. `'disabled'` is the safe post-recovery state (the user re-enables when ready, which re-activates triggers). The reload still refreshes the manifest and re-registers config requirements.

## Tests

Adds the first `recover()` tests (5): not-found; not-in-error no-op; **clears error after a successful reload** (the regression — `install` resolves but status stays `'error'`, recover must still `updateStatus → 'disabled'`); resets on reload failure; resets when no source path on disk.

Extension service suite **92/92**; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)