### PR TITLE
fix(coding-agent): dispose PTY on session error/timeout (leak)

### DIFF
--- a/packages/gateway/src/services/coding-agent/sessions.test.ts
+++ b/packages/gateway/src/services/coding-agent/sessions.test.ts
@@ -358,6 +358,20 @@ describe('CodingAgentSessionManager', () => {
         error: 'spawn error',
       });
     });
+
+    it('onError disposes the PTY (no leak on timeout/error)', async () => {
+      // Regression: onError is the timeout path — after SIGTERM the streaming
+      // exit handler skips onExit (killed=true), so onError must dispose the PTY
+      // itself or its node-pty listeners leak on every coding-agent timeout.
+      const ptyHandle = createMockPtyHandle();
+      mockSpawnStreamingProcess.mockReturnValue(ptyHandle);
+
+      await manager.createSession(defaultInput(), USER_A, {}, 'codex', []);
+      const callbacks = mockSpawnStreamingProcess.mock.calls[0][3];
+      callbacks.onError('Process timed out after 1800000ms');
+
+      expect(ptyHandle.dispose).toHaveBeenCalled();
+    });
   });
 
   // ===========================================================================

--- a/packages/gateway/src/services/coding-agent/sessions.ts
+++ b/packages/gateway/src/services/coding-agent/sessions.ts
@@ -190,6 +190,13 @@ export class CodingAgentSessionManager {
             error,
           });
 
+          // Dispose the PTY just like onExit does. onError is the timeout path:
+          // after SIGTERM the streaming exit handler sees killed=true and skips
+          // the onExit callback, so without this the PTY handle and its node-pty
+          // onData/onExit listeners would leak on every coding-agent timeout.
+          managed.pty?.dispose();
+          managed.pty = null;
+
           // Fire completion callbacks on error too
           this.fireCompletionCallbacks(managed);
 


### PR DESCRIPTION
## Problem

The session `onExit` callback disposes the PTY (`managed.pty?.dispose(); managed.pty = null`), but the `onError` callback did **not**.

`onError` is the **timeout** path: `pty.ts` SIGTERMs the process and calls `onError`, and when the process then exits, the streaming exit handler sees `killed === true` and **skips the `onExit` callback**. So on every coding-agent timeout (and any spawn error routed through `onError`), the PTY handle and its node-pty `onData`/`onExit` listeners were never disposed — a resource leak that accumulates with each timed-out session.

## Fix

`onError` now disposes and nulls the PTY exactly like `onExit`. `terminateSession` already null-guards `managed.pty`, so the extra null is safe, and the timeout path no longer double-handles (`onExit` is suppressed when `killed`).

## Tests

New regression test: triggering `onError` disposes the PTY handle. coding-agent sessions suite **25/25**; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)