### PR TITLE
fix(workflow): approval pause must not be finalized as failed

### DIFF
--- a/packages/gateway/src/services/workflow/workflow-service.test.ts
+++ b/packages/gateway/src/services/workflow/workflow-service.test.ts
@@ -1244,6 +1244,50 @@ describe('approvalNode', () => {
     expect(doneEvent).toBeDefined();
   });
 
+  it('persists awaiting_approval and never overwrites it with failed', async () => {
+    const nodes = [
+      makeNode('ap1', 'approvalNode', { approvalMessage: 'Please approve', timeoutMinutes: 30 }),
+    ];
+    mockRepo.get.mockResolvedValue(makeWorkflow(nodes));
+    mockApprovalsRepo.create.mockResolvedValue({ id: 'approval-1' });
+    const statuses: string[] = [];
+    mockRepo.updateLog.mockImplementation(async (_id: string, patch: Record<string, unknown>) => {
+      if (typeof patch.status === 'string') statuses.push(patch.status);
+      return undefined;
+    });
+    mockRepo.getLog.mockResolvedValue(makeLog({ status: 'awaiting_approval' }));
+
+    await service.executeWorkflow('wf-1', 'user1');
+
+    // The LAST status persisted must be awaiting_approval — never overwritten
+    // to 'failed' by a finalize step treating the pause as a node error.
+    expect(statuses[statuses.length - 1]).toBe('awaiting_approval');
+    expect(statuses).not.toContain('failed');
+  });
+
+  it('resumeFromApproval re-pauses when it reaches a second approval node', async () => {
+    const nodes = [
+      makeNode('ap1', 'approvalNode', { approvalMessage: 'First', timeoutMinutes: 30 }),
+      makeNode('ap2', 'approvalNode', { approvalMessage: 'Second', timeoutMinutes: 30 }),
+    ];
+    const edges = [makeEdge('ap1', 'ap2')];
+    mockRepo.get.mockResolvedValue(makeWorkflow(nodes, edges));
+    mockApprovalsRepo.create.mockResolvedValue({ id: 'approval-2' });
+
+    const statuses: string[] = [];
+    mockRepo.updateLog.mockImplementation(async (_id: string, patch: Record<string, unknown>) => {
+      if (typeof patch.status === 'string') statuses.push(patch.status);
+      return undefined;
+    });
+    mockRepo.getLog.mockResolvedValue(makeLog({ status: 'awaiting_approval', nodeResults: {} }));
+
+    await service.resumeFromApproval('wf-1', 'user1', 'ap1', 'approved', 'log-1');
+
+    // Resuming past ap1 hits ap2, which must pause again — not fail.
+    expect(statuses).not.toContain('failed');
+    expect(statuses[statuses.length - 1]).toBe('awaiting_approval');
+  });
+
   it('executes approvalNode in dryRun mode (no approval created)', async () => {
     const nodes = [
       makeNode('ap1', 'approvalNode', { approvalMessage: 'Approve this', timeoutMinutes: 10 }),

--- a/packages/gateway/src/services/workflow/workflow-service.ts
+++ b/packages/gateway/src/services/workflow/workflow-service.ts
@@ -322,11 +322,21 @@ export class WorkflowService implements IWorkflowService {
         }
 
         // Process results from both paths
+        let approvalPause: ApprovalPauseError | undefined;
         for (let i = 0; i < syncNodeIds.length; i++) {
           const nodeId = syncNodeIds[i]!;
           const settled = syncResults[i]!;
           if (settled.status === 'fulfilled') {
             nodeOutputs[nodeId] = settled.value;
+          } else if (settled.reason instanceof ApprovalPauseError) {
+            // The approval node throws ApprovalPauseError to pause the workflow.
+            // Promise.allSettled captures it as a rejected result, so we must
+            // re-throw it (below, after the rest of the level is captured).
+            // Otherwise it is recorded as a failed node and the finalize step
+            // overwrites the 'awaiting_approval' status with 'failed' — leaving
+            // the workflow un-resumable. Keep the node's persisted 'running'
+            // state rather than marking it an error.
+            approvalPause = settled.reason;
           } else {
             nodeOutputs[nodeId] = {
               nodeId,
@@ -339,6 +349,12 @@ export class WorkflowService implements IWorkflowService {
         // Merge jobified results into nodeOutputs
         for (const [nodeId, result] of Object.entries(jobifiedResults)) {
           nodeOutputs[nodeId] = result;
+        }
+        if (approvalPause) {
+          // Persist whatever completed this level, then propagate to the outer
+          // catch which returns the awaiting_approval log without finalizing.
+          await repo.updateLog(wfLog.id, { nodeResults: nodeOutputs });
+          throw approvalPause;
         }
 
         // Post-processing for all nodes in level
@@ -720,12 +736,19 @@ export class WorkflowService implements IWorkflowService {
         );
 
         // Process results (same logic as executeWorkflow)
+        let approvalPause: ApprovalPauseError | undefined;
         for (let i = 0; i < level.length; i++) {
           const nodeId = level[i]!;
           const settled = results[i]!;
 
           if (settled.status === 'fulfilled') {
             nodeOutputs[nodeId] = settled.value;
+          } else if (settled.reason instanceof ApprovalPauseError) {
+            // A second approval node hit during resume — re-throw (after the
+            // level) so the workflow pauses again rather than being marked
+            // failed. See the matching note in executeWorkflow.
+            approvalPause = settled.reason;
+            continue;
           } else {
             nodeOutputs[nodeId] = {
               nodeId,
@@ -860,6 +883,15 @@ export class WorkflowService implements IWorkflowService {
           }
 
           await repo.updateLog(logId, { nodeResults: nodeOutputs });
+        }
+
+        if (approvalPause) {
+          // A node in this level paused for approval (its per-node persist was
+          // skipped via `continue`). Persist and propagate to the outer catch,
+          // which returns the awaiting_approval log without finalizing the
+          // workflow as completed/failed.
+          await repo.updateLog(logId, { nodeResults: nodeOutputs });
+          throw approvalPause;
         }
       }
 


### PR DESCRIPTION
## Problem (severe — approvals were non-functional)

An `approvalNode` throws `ApprovalPauseError` to pause the workflow, after persisting status `awaiting_approval`. But nodes run inside `Promise.allSettled`, which **captures the throw as a rejected result**. The result loop recorded it as a node `error`, so the finalize step saw a failed node and **overwrote `awaiting_approval` with `failed`**.

Net effect: **every** workflow with an approval node was marked `failed` the instant it paused, and could never be resumed — `resumeFromApproval` requires `awaiting_approval` and throws *"Log is not awaiting approval"* otherwise.

The existing test mocked `getLog` to return `awaiting_approval`, so it asserted the executor's progress emit + a mocked return — never the **persisted** status. A probe capturing real `updateLog` calls showed the last status was `failed`.

## Fix

In **both** execution paths (`executeWorkflow` and `resumeFromApproval`):

- Detect `ApprovalPauseError` among the settled results.
- Keep the approval node's persisted `running` state (don't record it as an error).
- Persist the level, then **re-throw** so the outer `catch` returns the `awaiting_approval` log without finalizing.

In the resume loop the re-throw is hoisted **out of the per-node loop** — the pause node's `continue` was skipping the per-node persist (and my first attempt's throw), so the throw now lives after the inner loop where it actually fires.

## Tests

- `executeWorkflow` persists `awaiting_approval` and never `failed` (**proven to fail before the fix** — last persisted status was `failed`).
- `resumeFromApproval` re-pauses when it reaches a second approval node.
- First-ever `resumeFromApproval` tests.

Workflow suite **422/422**; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)