### PR TITLE
fix: 2 cancellation-status bugs + cost-pricing & startup-security gaps

### DIFF
--- a/packages/core/src/costs/calculator.ts
+++ b/packages/core/src/costs/calculator.ts
@@ -6,6 +6,7 @@
 
 import type { AIProvider, BillingType, CostEstimate, ModelPricing } from './types.js';
 import { MODEL_PRICING } from './model-pricing.js';
+import { loadProviderConfig } from '../agent/providers/configs/index.js';
 
 // Pre-built lookup maps for O(1) exact-match pricing (built once at module load)
 export const pricingByExactKey = new Map<string, ModelPricing>();
@@ -15,6 +16,40 @@ for (const p of MODEL_PRICING) {
   if (!pricingByProvider.has(p.provider)) {
     pricingByProvider.set(p.provider, p);
   }
+}
+
+/**
+ * Build a ModelPricing from the synced provider config (data/providers/*.json).
+ *
+ * The static MODEL_PRICING table only covers a hand-maintained subset of
+ * providers/models, but every provider JSON synced from models.dev already
+ * carries per-model `inputPrice`/`outputPrice` (same per-million units). This
+ * lets cost tracking cover models the static table never listed, instead of
+ * silently billing them at $0. Exact-id or alias match only — loose substring
+ * matching is intentionally avoided so a fake/unknown model still falls through
+ * to the provider-level fallback rather than mispricing against a sibling model.
+ */
+function pricingFromProviderConfig(provider: AIProvider, modelId: string): ModelPricing | null {
+  const config = loadProviderConfig(provider);
+  if (!config) return null;
+
+  const model =
+    config.models.find((m) => m.id === modelId) ??
+    config.models.find((m) => m.aliases?.includes(modelId));
+  if (!model) return null;
+
+  return {
+    provider,
+    modelId: model.id,
+    displayName: model.name,
+    inputPricePerMillion: model.inputPrice,
+    outputPricePerMillion: model.outputPrice,
+    contextWindow: model.contextWindow,
+    maxOutput: model.maxOutput,
+    supportsVision: model.capabilities?.includes('vision'),
+    supportsFunctions: model.capabilities?.includes('function_calling'),
+    updatedAt: '',
+  };
 }
 
 /**
@@ -30,6 +65,12 @@ export function getModelPricing(provider: AIProvider, modelId: string): ModelPri
     (p) => p.provider === provider && modelId.includes(p.modelId.split('-').slice(0, 3).join('-'))
   );
   if (partial) return partial;
+
+  // Synced provider data (models.dev) — exact/alias match for models the static
+  // table never listed. Preferred over the weak provider-level fallback below
+  // because it returns this model's real price, not an arbitrary sibling's.
+  const synced = pricingFromProviderConfig(provider, modelId);
+  if (synced) return synced;
 
   // Fallback: any model from the same provider
   return pricingByProvider.get(provider) ?? null;

--- a/packages/core/src/costs/index.test.ts
+++ b/packages/core/src/costs/index.test.ts
@@ -212,6 +212,18 @@ describe('getModelPricing', () => {
     expect(result).not.toBeNull();
     expect(result!.provider).toBe('google');
   });
+
+  it('resolves pricing from synced provider config for a model absent from the static table', () => {
+    // cohere has a synced data/providers/cohere.json but no static MODEL_PRICING
+    // entry, so this exercises the synced-config fallback exclusively. Before the
+    // fallback existed this returned null and the model billed at $0.
+    const result = getModelPricing('cohere' as AIProvider, 'command-a-translate-08-2025');
+    expect(result).not.toBeNull();
+    expect(result!.provider).toBe('cohere');
+    expect(result!.modelId).toBe('command-a-translate-08-2025');
+    expect(result!.inputPricePerMillion).toBe(2.5);
+    expect(result!.outputPricePerMillion).toBe(10);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -244,6 +256,18 @@ describe('calculateCost', () => {
   it('returns 0 cost for local model', () => {
     const cost = calculateCost('local', 'local-model', 100_000, 50_000);
     expect(cost).toBe(0);
+  });
+
+  it('calculates cost from synced provider config for a model absent from the static table', () => {
+    // cohere command-a-translate: input $2.5/M, output $10/M (from synced JSON).
+    // Previously billed at $0 because the static table has no cohere entry.
+    const cost = calculateCost(
+      'cohere' as AIProvider,
+      'command-a-translate-08-2025',
+      1_000_000,
+      1_000_000
+    );
+    expect(cost).toBeCloseTo(2.5 + 10, 6);
   });
 
   it('handles large token counts', () => {

--- a/packages/core/src/security/index.test.ts
+++ b/packages/core/src/security/index.test.ts
@@ -270,12 +270,26 @@ describe('Security Module', () => {
         expect(status.errors.some((e) => e.includes('DOCKER_SANDBOX_RELAXED_SECURITY'))).toBe(true);
       });
 
-      it('errors when Docker is not available', async () => {
+      it('errors when Docker unavailable in docker execution mode', async () => {
+        mockMode.mockReturnValue('docker');
         mockDocker.mockResolvedValue(false);
 
         const status = await validateSecurityConfig();
         expect(status.isSecure).toBe(false);
-        expect(status.errors.some((e) => e.includes('Docker is required'))).toBe(true);
+        expect(status.errors.some((e) => e.includes('Docker is not available'))).toBe(true);
+      });
+
+      it('warns (not errors) when Docker unavailable in auto/local mode', async () => {
+        // Production gateways commonly run without a Docker socket (e.g. the
+        // docker-compose gateway container) and gate execution per-call. That
+        // must not hard-fail startup — only EXECUTION_MODE=docker requires it.
+        mockMode.mockReturnValue('auto');
+        mockDocker.mockResolvedValue(false);
+
+        const status = await validateSecurityConfig();
+        expect(status.isSecure).toBe(true);
+        expect(status.errors).toHaveLength(0);
+        expect(status.warnings.some((w) => w.includes('per-call gating'))).toBe(true);
       });
 
       it('is secure when Docker is available and no dangerous vars', async () => {
@@ -352,9 +366,22 @@ describe('Security Module', () => {
   describe('enforceSecurityConfig', () => {
     it('throws in production when there are errors', async () => {
       process.env.NODE_ENV = 'production';
+      mockMode.mockReturnValue('docker'); // docker mode + no Docker => hard error
       mockDocker.mockResolvedValue(false);
 
       await expect(enforceSecurityConfig()).rejects.toThrow('SECURITY');
+    });
+
+    it('does not throw in production without Docker when mode is auto/local', async () => {
+      // Mirrors the docker-compose gateway: production, no Docker socket, but
+      // EXECUTION_MODE=auto — must start (per-call gating), not crash.
+      process.env.NODE_ENV = 'production';
+      mockMode.mockReturnValue('auto');
+      mockDocker.mockResolvedValue(false);
+      delete process.env.ALLOW_HOME_DIR_ACCESS;
+      delete process.env.DOCKER_SANDBOX_RELAXED_SECURITY;
+
+      await expect(enforceSecurityConfig()).resolves.toBeUndefined();
     });
 
     it('does not throw in development with errors', async () => {

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -95,13 +95,27 @@ export async function validateSecurityConfig(): Promise<SecurityStatus> {
       }
     }
 
-    // Require Docker in production
+    // Require Docker in production ONLY when execution mode is 'docker'.
+    // In 'auto'/'local' the gateway is expected to run without a Docker
+    // socket (e.g. the docker-compose gateway container has none) and gates
+    // code execution per-call instead — so a hard startup failure there would
+    // break valid deployments. Consult the mode-aware `dockerRequired` flag
+    // rather than failing unconditionally.
     if (!status.dockerAvailable) {
-      status.errors.push(
-        'SECURITY ERROR: Docker is required for production but not available. ' +
-          'Code execution tools will be disabled.'
-      );
-      status.isSecure = false;
+      if (status.dockerRequired) {
+        status.errors.push(
+          'SECURITY ERROR: EXECUTION_MODE=docker but Docker is not available. ' +
+            'Code execution requires a Docker sandbox in this mode.'
+        );
+        status.isSecure = false;
+      } else {
+        status.warnings.push(
+          'Docker not available in production. Code execution falls back to ' +
+            'per-call gating (mode: ' +
+            executionMode +
+            ').'
+        );
+      }
     }
   }
 

--- a/packages/gateway/src/autonomy/engine.test.ts
+++ b/packages/gateway/src/autonomy/engine.test.ts
@@ -278,6 +278,63 @@ describe('AutonomyEngine', () => {
       expect(firstResult.error).toBeUndefined();
     });
 
+    it('keeps the scheduled loop alive when a tick fires during a manual pulse', async () => {
+      // Regression: a scheduled tick that fires while a user-triggered manual
+      // pulse is in flight must re-arm the timer. Manual pulses never
+      // reschedule themselves, so without re-arming the autonomous loop would
+      // silently die until restart.
+      const { gatherPulseContext } = await import('./context.js');
+      const mockGather = gatherPulseContext as ReturnType<typeof vi.fn>;
+
+      const idleCtx = {
+        userId: 'test-user',
+        gatheredAt: new Date(),
+        timeContext: { hour: 10, dayOfWeek: 1, isWeekend: false },
+        goals: { active: [], stale: [], upcoming: [] },
+        memories: { total: 0, recentCount: 0, avgImportance: 0.5 },
+        activity: { daysSinceLastActivity: 0, hasRecentActivity: true },
+        systemHealth: { pendingApprovals: 0, triggerErrors: 0 },
+      };
+
+      // quietHoursStart === quietHoursEnd disables quiet hours regardless of the
+      // (fake-timer) wall clock, so tick() always reaches runPulse.
+      const loopEngine = new AutonomyEngine({
+        userId: 'test-user',
+        minIntervalMs: 1000,
+        maxIntervalMs: 5000,
+        quietHoursStart: 0,
+        quietHoursEnd: 0,
+      });
+
+      try {
+        loopEngine.start(); // schedules the first tick at maxIntervalMs (5000)
+
+        // Begin a manual pulse that blocks in gatherPulseContext, holding the
+        // execution lock (activePulse) open.
+        let releaseManual!: () => void;
+        mockGather.mockImplementationOnce(
+          () => new Promise<unknown>((resolve) => (releaseManual = () => resolve(idleCtx)))
+        );
+        const manual = loopEngine.runPulse('test-user', true);
+
+        // Fire the scheduled tick while the manual pulse is still in flight.
+        await vi.advanceTimersByTimeAsync(5000);
+
+        // Release the manual pulse and let it settle.
+        releaseManual();
+        await manual;
+
+        // The loop must still be armed: advancing past minIntervalMs should run
+        // a fresh scheduled pulse. Before the fix the tick was consumed without
+        // rescheduling and this stays at 0.
+        mockGather.mockClear();
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(mockGather).toHaveBeenCalled();
+      } finally {
+        loopEngine.stop();
+      }
+    });
+
     it('getStatus exposes activePulse as null when idle', () => {
       const status = engine.getStatus();
       expect(status.activePulse).toBeNull();

--- a/packages/gateway/src/autonomy/engine.ts
+++ b/packages/gateway/src/autonomy/engine.ts
@@ -587,7 +587,20 @@ export class AutonomyEngine implements IPulseService {
   }
 
   private async tick(): Promise<void> {
-    if (!this.running || this.activePulse) return;
+    if (!this.running) return;
+
+    // A pulse is already in flight — almost always a user-triggered manual
+    // pulse (two scheduled pulses can't overlap, since each schedules its
+    // successor only on completion). Don't start a second pulse, but DO
+    // re-arm the timer: this tick consumed the pending timeout, and manual
+    // pulses never reschedule themselves (gated on !manual in runPulse), so
+    // without this the autonomous loop silently dies until the engine is
+    // restarted. Retry at minInterval so a normal cadence resumes promptly
+    // once the in-flight pulse clears.
+    if (this.activePulse) {
+      this.scheduleNext(this.config.minIntervalMs);
+      return;
+    }
 
     // Quiet hours check
     const hour = new Date().getHours();

--- a/packages/gateway/src/plans/executor.test.ts
+++ b/packages/gateway/src/plans/executor.test.ts
@@ -889,6 +889,51 @@ describe('PlanExecutor', () => {
       // but executeSteps completed (step=null → completed path)
       expect(result.planId).toBe('plan-1');
     });
+
+    it('persists status=cancelled (not failed) when aborted mid-loop', async () => {
+      // Regression: abort() sets status='cancelled' and aborts the signal; the
+      // loop then throws 'Plan execution aborted'. The catch must NOT overwrite
+      // the cancelled status with 'failed' (nor fire plan:failed).
+      const plan = makePlan();
+      const step = makeStep({ config: { toolName: 'slow_tool', toolArgs: {} } });
+
+      mockPlanService.getPlan.mockResolvedValue(plan);
+      mockPlanService.getSteps.mockResolvedValue([step]);
+      mockPlanService.getStepsByStatus.mockResolvedValue([]);
+      (hasTool as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+      (executeTool as ReturnType<typeof vi.fn>).mockResolvedValue({ success: true, result: {} });
+
+      // Block the loop in getNextStep so we can abort while it is in flight,
+      // then hand it a step so the loop executes it and iterates back to the
+      // top — where the aborted signal triggers the throw.
+      let releaseStep!: () => void;
+      mockPlanService.getNextStep
+        .mockImplementationOnce(
+          () => new Promise<PlanStep>((resolve) => (releaseStep = () => resolve(step)))
+        )
+        .mockResolvedValue(null);
+
+      const failedListener = vi.fn();
+      executor.on('plan:failed', failedListener);
+
+      const promise = executor.execute('plan-1');
+      await vi.advanceTimersByTimeAsync(0); // reach getNextStep
+
+      expect(await executor.abort('plan-1')).toBe(true);
+
+      releaseStep();
+      await vi.advanceTimersByTimeAsync(100); // run step, loop back, throw on aborted signal
+      const result = await promise;
+
+      expect(result.status).toBe('cancelled');
+      expect(result.error).toBeUndefined();
+      expect(failedListener).not.toHaveBeenCalled();
+      expect(mockPlanService.updatePlan).not.toHaveBeenCalledWith(
+        'user-1',
+        'plan-1',
+        expect.objectContaining({ status: 'failed' })
+      );
+    });
   });
 
   // ========================================================================

--- a/packages/gateway/src/plans/executor.ts
+++ b/packages/gateway/src/plans/executor.ts
@@ -184,8 +184,30 @@ export class PlanExecutor extends EventEmitter {
 
       return result;
     } catch (error) {
+      // If the signal was already aborted when we reached here, this is a
+      // user-initiated abort(): it has already persisted status='cancelled'
+      // and the execution loop threw 'Plan execution aborted'. Capture that
+      // BEFORE our own abort() call below so we can tell a cancellation apart
+      // from a genuine failure — otherwise the catch would overwrite the
+      // 'cancelled' status with 'failed' (and fire plan:failed) for every
+      // user cancel of a running plan.
+      const wasCancelled = abortController.signal.aborted;
+
       // Signal cancellation to any pending step execution
       abortController.abort();
+
+      if (wasCancelled) {
+        return {
+          planId,
+          status: 'cancelled',
+          completedSteps: (
+            await this.planService.getStepsByStatus(this.config.userId, planId, 'completed')
+          ).length,
+          totalSteps: (await this.planService.getSteps(this.config.userId, planId)).length,
+          duration: Date.now() - startTime,
+          results,
+        };
+      }
 
       const errorMessage = getErrorMessage(error);
       await this.planService.updatePlan(this.config.userId, planId, {

--- a/packages/gateway/src/server.ts
+++ b/packages/gateway/src/server.ts
@@ -64,6 +64,7 @@ import {
   Services,
   getEventSystem,
   setModuleResolver,
+  enforceSecurityConfig,
   type ServiceToken,
 } from '@ownpilot/core';
 import type { NormalizedMessage } from '@ownpilot/core';
@@ -157,6 +158,13 @@ async function main() {
   // ── Config Validation (fail-fast before any heavy initialization) ─────────
   const { assertBootConfig } = await import('./config/validation.js');
   assertBootConfig();
+
+  // ── Security enforcement (fail-fast) ──────────────────────────────────────
+  // Throws in production on insecure config: dangerous env vars
+  // (DOCKER_SANDBOX_RELAXED_SECURITY / ALLOW_HOME_DIR_ACCESS) always block;
+  // Docker is only required when EXECUTION_MODE=docker. Logs the security
+  // posture in all environments.
+  await enforceSecurityConfig();
 
   // ── Module resolver (allows core tools to import gateway's npm packages) ──
   setModuleResolver((name) => import(name));


### PR DESCRIPTION
Batch of fixes from a deep audit of the autonomy / plans / costs / security subsystems. Each commit is self-contained with its own regression tests; the two real bugs were verified failing (RED) before the fix.

## Commits

### 🐛 `fix(autonomy)`: re-arm pulse timer when a tick overlaps a manual pulse
`tick()` returned early on `this.activePulse` without rescheduling. Manual pulses never reschedule themselves (gated on `!manual`), so a scheduled tick firing while a user-triggered manual pulse was in flight consumed the timer with no successor — **silently killing the autonomous pulse loop until restart**. Fix: re-arm at `minInterval` on the in-flight-pulse skip path.

### 🐛 `fix(plans)`: preserve cancelled status when a running plan is aborted
`abort()` persists `status='cancelled'` then aborts the signal; the loop throws `'Plan execution aborted'`; `execute()`'s catch then overwrote with `status='failed'` + fired `plan:failed`. **Every user abort of a running plan was persisted as `'failed'`** with a spurious error. Fix: detect the already-aborted signal at the top of the catch and return a `'cancelled'` result without overwriting (genuine failures like dependency deadlock still become `'failed'`).

### `fix(costs)`: fall back to synced provider pricing for models absent from the static table
`getModelPricing()` only read the ~41-entry hand-maintained `MODEL_PRICING` table, so the ~100 providers / hundreds of models in the synced `data/providers/*.json` (which already carry per-model prices) billed at **\$0**. Fix: add a cached `loadProviderConfig()` fallback (exact-id + alias match only) after the static lookup. Static table stays primary — zero behaviour change for existing models.

### `fix(security)`: enforce security config at startup with mode-aware Docker requirement
`enforceSecurityConfig()` was defined but never called, leaving its production hard-fail on dangerous env vars dormant. Wired into `server.ts main()` (fail-fast). Made the production "Docker required" error mode-aware (only hard-fails when `EXECUTION_MODE=docker`) so socket-less deployments (e.g. the docker-compose gateway container) still boot; dangerous env vars still always hard-fail.

## Tests
- core: 209/209 (costs + security) · gateway: 84/84 (autonomy + plans)
- Both real bugs have regression tests verified RED without their fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)