### PR TITLE
refactor(gateway): hard single-tenant — route handlers use LOCAL_OWNER_ID

### DIFF
--- a/packages/gateway/src/config/defaults.ts
+++ b/packages/gateway/src/config/defaults.ts
@@ -8,6 +8,17 @@
  */
 
 // ============================================================================
+// Single-user owner scope
+// ============================================================================
+
+/**
+ * OwnPilot is a single-user/self-hosted gateway. Tables keep a `user_id`
+ * column for historical compatibility and possible future profile separation,
+ * but request handlers must not derive an owner from the authenticated request.
+ */
+export const LOCAL_OWNER_ID = 'default';
+
+// ============================================================================
 // Database
 // ============================================================================
 

--- a/packages/gateway/src/routes/agents/command-center.test.ts
+++ b/packages/gateway/src/routes/agents/command-center.test.ts
@@ -123,7 +123,8 @@ import { errorHandler } from '../../middleware/error-handler.js';
 function createApp() {
   const app = new Hono();
   app.use('*', async (c, next) => {
-    c.set('userId', 'user-1');
+    c.set('userId', 'default');
+    c.set('sessionAuthenticated', true);
     await next();
   });
   app.route('/acc', agentCommandCenterRoutes);
@@ -191,7 +192,7 @@ function makeCrew(id = 'crew-1', overrides: Record<string, unknown> = {}) {
     templateId: 'default',
     coordinationPattern: 'hub_spoke',
     status: 'active',
-    workspaceId: 'user-1',
+    workspaceId: 'default',
     createdAt: new Date('2024-01-01'),
     updatedAt: new Date('2024-01-02'),
     ...overrides,

--- a/packages/gateway/src/routes/agents/command-center.ts
+++ b/packages/gateway/src/routes/agents/command-center.ts
@@ -7,15 +7,9 @@
  * - Aggregate results from multiple agents
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
-import {
-  apiResponse,
-  apiError,
-  ERROR_CODES,
-  getErrorMessage,
-  getUserId,
-  getIntParam,
-} from '../helpers.js';
+import { apiResponse, apiError, ERROR_CODES, getErrorMessage, getIntParam } from '../helpers.js';
 import { getSoulsRepository } from '../../db/repositories/souls.js';
 import { getCrewsRepository } from '../../db/repositories/crew/index.js';
 import { getHeartbeatLogRepository } from '../../db/repositories/heartbeats/log.js';
@@ -38,7 +32,7 @@ export const agentCommandCenterRoutes = new Hono();
 
 agentCommandCenterRoutes.post('/command', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const body = validateBody(agentCommandSchema, await c.req.json());
 
     const results: {
@@ -147,7 +141,7 @@ agentCommandCenterRoutes.post('/command', async (c) => {
 
 agentCommandCenterRoutes.get('/overview', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const hbRepo = getHeartbeatLogRepository();
     const crewRepo = getCrewsRepository();
     const soulRepo = getSoulsRepository();
@@ -379,7 +373,7 @@ agentCommandCenterRoutes.get('/overview', async (c) => {
 
 agentCommandCenterRoutes.get('/status', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const soulRepo = getSoulsRepository();
     const crewRepo = getCrewsRepository();
 
@@ -527,7 +521,7 @@ agentCommandCenterRoutes.get('/activity', async (c) => {
     const { getAgentMessagesRepository } = await import('../../db/repositories/agents/messages.js');
     const msgRepo = getAgentMessagesRepository();
 
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
 
     // Get souls for the authenticated user only
     const souls = await soulRepo.list(userId, 100, 0);
@@ -592,7 +586,7 @@ agentCommandCenterRoutes.get('/activity', async (c) => {
 
 agentCommandCenterRoutes.post('/execute', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     if ((!userId || userId === 'default') && !c.get('sessionAuthenticated')) {
       return apiError(
         c,
@@ -660,7 +654,7 @@ agentCommandCenterRoutes.post('/execute', async (c) => {
 
 agentCommandCenterRoutes.get('/analytics', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const soulRepo = getSoulsRepository();
     const hbRepo = getHeartbeatLogRepository();
     const crewRepo = getCrewsRepository();

--- a/packages/gateway/src/routes/agents/messages.ts
+++ b/packages/gateway/src/routes/agents/messages.ts
@@ -2,6 +2,7 @@
  * Agent Messages Routes — inter-agent communication API
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import type { AgentMessageType } from '@ownpilot/core';
 import { getAgentMessagesRepository } from '../../db/repositories/agents/messages.js';
@@ -11,7 +12,6 @@ import {
   ERROR_CODES,
   getErrorMessage,
   getPaginationParams,
-  getUserId,
 } from '../helpers.js';
 import { validateBody, sendAgentMessageSchema } from '../../middleware/validation.js';
 
@@ -73,7 +73,7 @@ agentMessageRoutes.get('/crew/:id', async (c) => {
 agentMessageRoutes.post('/', async (c) => {
   try {
     const body = validateBody(sendAgentMessageSchema, await c.req.json());
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
 
     const message = {
       id: crypto.randomUUID(),

--- a/packages/gateway/src/routes/artifacts.test.ts
+++ b/packages/gateway/src/routes/artifacts.test.ts
@@ -36,7 +36,7 @@ const { artifactsRoutes } = await import('./artifacts.js');
 function createApp() {
   const app = new Hono();
   app.use('*', async (c, next) => {
-    c.set('userId', 'user-1');
+    c.set('userId', 'default');
     await next();
   });
   app.route('/artifacts', artifactsRoutes);
@@ -46,7 +46,7 @@ function createApp() {
 
 const sampleArtifact = {
   id: 'art-1',
-  userId: 'user-1',
+  userId: 'default',
   type: 'html',
   title: 'My Chart',
   content: '<html>hello</html>',
@@ -95,7 +95,7 @@ describe('Artifact Routes', () => {
     it('passes type filter to service', async () => {
       await app.request('/artifacts?type=html');
       expect(mockService.listArtifacts).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         expect.objectContaining({ type: 'html' })
       );
     });
@@ -103,7 +103,7 @@ describe('Artifact Routes', () => {
     it('passes pinned=true filter to service', async () => {
       await app.request('/artifacts?pinned=true');
       expect(mockService.listArtifacts).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         expect.objectContaining({ pinned: true })
       );
     });
@@ -111,7 +111,7 @@ describe('Artifact Routes', () => {
     it('passes pinned=false filter to service', async () => {
       await app.request('/artifacts?pinned=false');
       expect(mockService.listArtifacts).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         expect.objectContaining({ pinned: false })
       );
     });
@@ -119,7 +119,7 @@ describe('Artifact Routes', () => {
     it('passes search filter to service', async () => {
       await app.request('/artifacts?search=hello');
       expect(mockService.listArtifacts).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         expect.objectContaining({ search: 'hello' })
       );
     });
@@ -127,7 +127,7 @@ describe('Artifact Routes', () => {
     it('passes conversationId filter to service', async () => {
       await app.request('/artifacts?conversationId=conv-1');
       expect(mockService.listArtifacts).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         expect.objectContaining({ conversationId: 'conv-1' })
       );
     });

--- a/packages/gateway/src/routes/artifacts.ts
+++ b/packages/gateway/src/routes/artifacts.ts
@@ -5,11 +5,11 @@
  * with data bindings and dashboard pinning.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import type { ArtifactType, DataBinding, DashboardSize } from '@ownpilot/core';
 import { getArtifactService } from '../services/artifact/service.js';
 import {
-  getUserId,
   apiResponse,
   apiError,
   ERROR_CODES,
@@ -34,7 +34,7 @@ const VALID_TYPES = ['html', 'svg', 'markdown', 'form', 'chart', 'react'] as con
 
 artifactsRoutes.get('/', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { limit, offset } = getPaginationParams(c);
     const type = validateQueryEnum(c.req.query('type'), VALID_TYPES) as ArtifactType | undefined;
     const pinned = c.req.query('pinned');
@@ -63,7 +63,7 @@ artifactsRoutes.get('/', async (c) => {
 
 artifactsRoutes.get('/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = c.req.param('id');
     const service = getArtifactService();
 
@@ -84,7 +84,7 @@ artifactsRoutes.get('/:id', async (c) => {
 
 artifactsRoutes.post('/', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const body = validateBody(createArtifactSchema, await c.req.json());
 
     const service = getArtifactService();
@@ -113,7 +113,7 @@ artifactsRoutes.post('/', async (c) => {
 
 artifactsRoutes.patch('/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = c.req.param('id');
     const body = validateBody(updateArtifactSchema, await c.req.json());
     const service = getArtifactService();
@@ -144,7 +144,7 @@ artifactsRoutes.patch('/:id', async (c) => {
 
 artifactsRoutes.delete('/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = c.req.param('id');
     const service = getArtifactService();
 
@@ -165,7 +165,7 @@ artifactsRoutes.delete('/:id', async (c) => {
 
 artifactsRoutes.post('/:id/pin', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = c.req.param('id');
     const service = getArtifactService();
 
@@ -186,7 +186,7 @@ artifactsRoutes.post('/:id/pin', async (c) => {
 
 artifactsRoutes.post('/:id/refresh', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = c.req.param('id');
     const service = getArtifactService();
 
@@ -207,7 +207,7 @@ artifactsRoutes.post('/:id/refresh', async (c) => {
 
 artifactsRoutes.get('/:id/versions', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = c.req.param('id');
     const service = getArtifactService();
 

--- a/packages/gateway/src/routes/audit.ts
+++ b/packages/gateway/src/routes/audit.ts
@@ -5,9 +5,10 @@
  * All agent activities, tool executions, and system events are logged.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { getAuditLogger } from '../audit/index.js';
-import { apiResponse, apiError, ERROR_CODES, getUserId, validateQueryEnum } from './helpers.js';
+import { apiResponse, apiError, ERROR_CODES, validateQueryEnum } from './helpers.js';
 import { pagination } from '../middleware/pagination.js';
 
 const app = new Hono();
@@ -31,7 +32,7 @@ const app = new Hono();
  * - order: asc or desc (default desc)
  */
 app.get('/', pagination({ defaultLimit: 100, maxLimit: 1000 }), async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const { limit, offset } = c.get('pagination')!;
   const logger = getAuditLogger();
   await logger.initialize();
@@ -100,7 +101,7 @@ app.get('/stats', async (c) => {
  * GET /audit/tools - Get tool execution logs
  */
 app.get('/tools', pagination({ defaultLimit: 50, maxLimit: 1000 }), async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const { limit, offset } = c.get('pagination')!;
   const logger = getAuditLogger();
   await logger.initialize();
@@ -127,7 +128,7 @@ app.get('/tools', pagination({ defaultLimit: 50, maxLimit: 1000 }), async (c) =>
  * GET /audit/sessions - Get session/conversation logs
  */
 app.get('/sessions', pagination({ defaultLimit: 50, maxLimit: 1000 }), async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const { limit, offset } = c.get('pagination')!;
   const logger = getAuditLogger();
   await logger.initialize();
@@ -154,7 +155,7 @@ app.get('/sessions', pagination({ defaultLimit: 50, maxLimit: 1000 }), async (c)
  * GET /audit/errors - Get error logs
  */
 app.get('/errors', pagination({ defaultLimit: 50, maxLimit: 1000 }), async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const { limit, offset } = c.get('pagination')!;
   const logger = getAuditLogger();
   await logger.initialize();
@@ -181,7 +182,7 @@ app.get('/errors', pagination({ defaultLimit: 50, maxLimit: 1000 }), async (c) =
  * GET /audit/request/:requestId - Get all events for a specific request
  */
 app.get('/request/:requestId', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const requestId = c.req.param('requestId');
   const logger = getAuditLogger();
   await logger.initialize();

--- a/packages/gateway/src/routes/autonomy.ts
+++ b/packages/gateway/src/routes/autonomy.ts
@@ -4,6 +4,7 @@
  * API for managing autonomy levels, risk assessment, and approvals.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono, type Context } from 'hono';
 import type { AutonomyLevel } from '../autonomy/index.js';
 import {
@@ -20,7 +21,6 @@ import { DEFAULT_ACTION_COOLDOWNS } from '../autonomy/executor.js';
 import { DEFAULT_PULSE_DIRECTIVES, type PulseDirectives } from '../autonomy/engine.js';
 import { settingsRepo } from '../db/repositories/settings/index.js';
 import {
-  getUserId,
   apiResponse,
   apiError,
   ERROR_CODES,
@@ -41,7 +41,7 @@ export const autonomyRoutes = new Hono();
  * GET /autonomy/config - Get autonomy configuration
  */
 autonomyRoutes.get('/config', (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const manager = getApprovalManager();
   const config = manager.getUserConfig(userId);
 
@@ -59,7 +59,7 @@ autonomyRoutes.get('/config', (c) => {
  * PATCH /autonomy/config - Update autonomy configuration
  */
 autonomyRoutes.patch('/config', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const rawBody = await parseJsonBody(c);
 
   // Validate config update body
@@ -80,7 +80,7 @@ autonomyRoutes.patch('/config', async (c) => {
  * POST /autonomy/config/reset - Reset to default configuration
  */
 autonomyRoutes.post('/config/reset', (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const manager = getApprovalManager();
 
   // Reset by setting empty config (will use defaults)
@@ -114,7 +114,7 @@ autonomyRoutes.get('/levels', (c) => {
  * POST /autonomy/level - Set autonomy level
  */
 autonomyRoutes.post('/level', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const rawBody = await parseJsonBody(c);
   const { validateBody, autonomyLevelSchema } = await import('../middleware/validation.js');
   const body = validateBody(autonomyLevelSchema, rawBody);
@@ -146,7 +146,7 @@ autonomyRoutes.post('/level', async (c) => {
  * POST /autonomy/assess - Assess risk for an action
  */
 autonomyRoutes.post('/assess', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const rawBody = await parseJsonBody(c);
   const { validateBody, autonomyAssessSchema } = await import('../middleware/validation.js');
   const body = validateBody(autonomyAssessSchema, rawBody) as {
@@ -189,7 +189,7 @@ autonomyRoutes.post('/assess', async (c) => {
  * GET /autonomy/approvals - Get pending approvals
  */
 autonomyRoutes.get('/approvals', (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const manager = getApprovalManager();
   const pending = manager.getPendingActions(userId);
 
@@ -203,7 +203,7 @@ autonomyRoutes.get('/approvals', (c) => {
  * POST /autonomy/approvals/request - Request approval for an action
  */
 autonomyRoutes.post('/approvals/request', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const rawBody = await parseJsonBody(c);
   const { validateBody, autonomyApprovalRequestSchema } =
     await import('../middleware/validation.js');
@@ -262,7 +262,7 @@ autonomyRoutes.post('/approvals/request', async (c) => {
  */
 autonomyRoutes.get('/approvals/:id', (c) => {
   const id = c.req.param('id');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const manager = getApprovalManager();
   const action = manager.getPendingAction(id);
 
@@ -286,7 +286,7 @@ autonomyRoutes.get('/approvals/:id', (c) => {
  */
 autonomyRoutes.post('/approvals/:id/decide', async (c) => {
   const id = c.req.param('id');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const rawBody = await parseJsonBody(c);
   const { validateBody, autonomyDecisionSchema } = await import('../middleware/validation.js');
   const body = validateBody(autonomyDecisionSchema, rawBody) as Omit<ApprovalDecision, 'actionId'>;
@@ -335,7 +335,7 @@ autonomyRoutes.post('/approvals/:id/decide', async (c) => {
  */
 async function handleApprovalShorthand(c: Context, decision: 'approve' | 'reject') {
   const id = c.req.param('id') ?? '';
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const rawBody = (await parseJsonBody<Record<string, unknown>>(c)) ?? {};
   const { validateBody, autonomyApproveRejectSchema } = await import('../middleware/validation.js');
   const body = validateBody(autonomyApproveRejectSchema, rawBody) as {
@@ -377,7 +377,7 @@ autonomyRoutes.post('/approvals/:id/reject', (c) => handleApprovalShorthand(c, '
  */
 autonomyRoutes.delete('/approvals/:id', (c) => {
   const id = c.req.param('id');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const manager = getApprovalManager();
   const pending = manager.getPendingAction(id);
 
@@ -406,7 +406,7 @@ autonomyRoutes.delete('/approvals/:id', (c) => {
  * POST /autonomy/tools/allow - Add tool to allowed list
  */
 autonomyRoutes.post('/tools/allow', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const rawBody = await parseJsonBody(c);
   const { validateBody, autonomyToolPermissionSchema } =
     await import('../middleware/validation.js');
@@ -437,7 +437,7 @@ autonomyRoutes.post('/tools/allow', async (c) => {
  * POST /autonomy/tools/block - Add tool to blocked list
  */
 autonomyRoutes.post('/tools/block', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const rawBody = await parseJsonBody(c);
   const { validateBody, autonomyToolPermissionSchema } =
     await import('../middleware/validation.js');
@@ -468,7 +468,7 @@ autonomyRoutes.post('/tools/block', async (c) => {
  * DELETE /autonomy/tools/:tool - Remove tool from allowed/blocked lists
  */
 autonomyRoutes.delete('/tools/:tool', (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const tool = c.req.param('tool');
 
   const manager = getApprovalManager();
@@ -492,7 +492,7 @@ autonomyRoutes.delete('/tools/:tool', (c) => {
  * DELETE /autonomy/remembered - Clear remembered decisions
  */
 autonomyRoutes.delete('/remembered', (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const manager = getApprovalManager();
   const cleared = manager.clearRememberedDecisions(userId);
 
@@ -510,7 +510,7 @@ autonomyRoutes.delete('/remembered', (c) => {
  * GET /autonomy/budget - Get budget status
  */
 autonomyRoutes.get('/budget', (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const manager = getApprovalManager();
   const config = manager.getUserConfig(userId);
 
@@ -527,7 +527,7 @@ autonomyRoutes.get('/budget', (c) => {
  * PATCH /autonomy/budget - Update budget settings
  */
 autonomyRoutes.patch('/budget', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const rawBody = await parseJsonBody(c);
 
   // Validate budget update body
@@ -613,7 +613,7 @@ autonomyRoutes.post('/pulse/stop', (c) => {
  */
 autonomyRoutes.post('/pulse/run', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const engine = getAutonomyEngine();
 
     const status = engine.getStatus();
@@ -747,7 +747,7 @@ autonomyRoutes.put('/pulse/directives', async (c) => {
  */
 autonomyRoutes.get('/pulse/history', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { limit, offset } = getPaginationParams(c, 15);
     const engine = getAutonomyEngine();
     const result = await engine.getRecentLogsPaginated(userId, limit, offset);
@@ -766,7 +766,7 @@ autonomyRoutes.get('/pulse/history', async (c) => {
  */
 autonomyRoutes.get('/pulse/stats', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const engine = getAutonomyEngine();
     const stats = await engine.getStats(userId);
     return apiResponse(c, stats);

--- a/packages/gateway/src/routes/bridges.test.ts
+++ b/packages/gateway/src/routes/bridges.test.ts
@@ -47,7 +47,8 @@ function createApp() {
   const app = new Hono();
   app.use('*', async (c, next) => {
     // Simulate authenticated user for all bridge routes
-    c.set('userId', 'user-1');
+    c.set('userId', 'default');
+    c.set('sessionAuthenticated', true);
     await next();
   });
   app.route('/bridges', bridgeRoutes);

--- a/packages/gateway/src/routes/bridges.ts
+++ b/packages/gateway/src/routes/bridges.ts
@@ -4,9 +4,10 @@
  * REST API for managing cross-channel message bridges (UCP).
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { ChannelBridgesRepository } from '../db/repositories/channels/bridges.js';
-import { apiResponse, apiError, ERROR_CODES, getErrorMessage, getUserId } from './helpers.js';
+import { apiResponse, apiError, ERROR_CODES, getErrorMessage } from './helpers.js';
 import { validateBody, createBridgeSchema, updateBridgeSchema } from '../middleware/validation.js';
 import { reloadChannelBridges } from '../channels/bridge-runtime.js';
 
@@ -23,7 +24,7 @@ function getRepo(): ChannelBridgesRepository {
 bridgeRoutes.get('/', async (c) => {
   try {
     const repo = getRepo();
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const channelId = c.req.query('channelId');
 
     // Scope to the requesting user — getAll() would leak every user's bridges.
@@ -48,7 +49,7 @@ bridgeRoutes.get('/', async (c) => {
 bridgeRoutes.get('/:id', async (c) => {
   try {
     const repo = getRepo();
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = c.req.param('id');
 
     const bridge = await repo.getById(id);
@@ -72,7 +73,7 @@ bridgeRoutes.get('/:id', async (c) => {
 
 bridgeRoutes.post('/', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     // IDOR-017: Reject unauthenticated requests
     if (userId === 'default' && !c.get('sessionAuthenticated')) {
       return apiError(
@@ -118,7 +119,7 @@ bridgeRoutes.post('/', async (c) => {
 bridgeRoutes.patch('/:id', async (c) => {
   try {
     const repo = getRepo();
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = c.req.param('id');
 
     const existing = await repo.getById(id);
@@ -158,7 +159,7 @@ bridgeRoutes.patch('/:id', async (c) => {
 bridgeRoutes.delete('/:id', async (c) => {
   try {
     const repo = getRepo();
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = c.req.param('id');
 
     const existing = await repo.getById(id);

--- a/packages/gateway/src/routes/browser.ts
+++ b/packages/gateway/src/routes/browser.ts
@@ -4,12 +4,13 @@
  * REST API for headless browser automation and workflow management.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { getBrowserService } from '../services/browser-service.js';
 import { getTriggerService } from '../services/index.js';
 import { BrowserWorkflowsRepository } from '../db/repositories/browser-workflows.js';
-import { getUserId, apiResponse, apiError, ERROR_CODES, getPaginationParams } from './helpers.js';
+import { apiResponse, apiError, ERROR_CODES, getPaginationParams } from './helpers.js';
 import { getErrorMessage } from '@ownpilot/core';
 import {
   validateBody,
@@ -57,7 +58,7 @@ browserRoutes.get('/config', async (c) => {
 
 browserRoutes.post('/navigate', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const body = validateBody(browserNavigateSchema, await c.req.json());
 
     const service = getBrowserService();
@@ -72,7 +73,7 @@ browserRoutes.post('/navigate', async (c) => {
 
 browserRoutes.post('/action', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const body = validateBody(browserActionSchema, await c.req.json());
 
     const service = getBrowserService();
@@ -173,7 +174,7 @@ browserRoutes.post('/action', async (c) => {
 
 browserRoutes.post('/screenshot', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const raw = await c.req.json().catch(() => ({}));
     const body = validateBody(screenshotSchema, raw);
     const service = getBrowserService();
@@ -191,7 +192,7 @@ browserRoutes.post('/screenshot', async (c) => {
 
 browserRoutes.delete('/session', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const service = getBrowserService();
     const closed = await service.closePage(userId);
     return apiResponse(c, { closed });
@@ -206,7 +207,7 @@ browserRoutes.delete('/session', async (c) => {
 
 browserRoutes.get('/workflows', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { limit, offset } = getPaginationParams(c);
     const repo = getWorkflowRepo();
     const result = await repo.listByUser(userId, limit, offset);
@@ -218,7 +219,7 @@ browserRoutes.get('/workflows', async (c) => {
 
 browserRoutes.post('/workflows', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const body = validateBody(createBrowserWorkflowSchema, await c.req.json());
 
     const repo = getWorkflowRepo();
@@ -241,7 +242,7 @@ browserRoutes.post('/workflows', async (c) => {
 
 browserRoutes.get('/workflows/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = c.req.param('id');
     const repo = getWorkflowRepo();
     const workflow = await repo.getById(id, userId);
@@ -257,7 +258,7 @@ browserRoutes.get('/workflows/:id', async (c) => {
 
 browserRoutes.patch('/workflows/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = c.req.param('id');
     const body = validateBody(updateBrowserWorkflowSchema, await c.req.json());
     const repo = getWorkflowRepo();
@@ -280,7 +281,7 @@ browserRoutes.patch('/workflows/:id', async (c) => {
 
 browserRoutes.delete('/workflows/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = c.req.param('id');
     const repo = getWorkflowRepo();
 

--- a/packages/gateway/src/routes/canvas.test.ts
+++ b/packages/gateway/src/routes/canvas.test.ts
@@ -28,7 +28,7 @@ const { canvasRoutes } = await import('./canvas.js');
 function createApp() {
   const app = new Hono();
   app.use('*', async (c, next) => {
-    c.set('userId', 'user-1');
+    c.set('userId', 'default');
     await next();
   });
   app.route('/canvas', canvasRoutes);
@@ -38,7 +38,7 @@ function createApp() {
 
 const sampleElement = {
   id: 'canv-1',
-  userId: 'user-1',
+  userId: 'default',
   canvasId: 'main',
   type: 'note',
   content: 'hello',
@@ -94,7 +94,7 @@ describe('Canvas Routes', () => {
       });
       expect(res.status).toBe(201);
       expect(mockService.addElement).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         expect.objectContaining({ canvasId: 'main', type: 'note', content: 'hi', x: 10, y: 20 })
       );
     });
@@ -119,7 +119,7 @@ describe('Canvas Routes', () => {
       });
       expect(res.status).toBe(200);
       expect(mockService.updateElement).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         'canv-1',
         expect.objectContaining({ content: 'new', w: 300 })
       );
@@ -142,7 +142,7 @@ describe('Canvas Routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.data.removed).toBe(true);
-      expect(mockService.removeElement).toHaveBeenCalledWith('user-1', 'canv-1');
+      expect(mockService.removeElement).toHaveBeenCalledWith('default', 'canv-1');
     });
 
     it('returns 404 when missing', async () => {
@@ -159,7 +159,7 @@ describe('Canvas Routes', () => {
       const body = await res.json();
       expect(body.data.canvasId).toBe('main');
       expect(body.data.elements).toHaveLength(1);
-      expect(mockService.listElements).toHaveBeenCalledWith('user-1', 'main');
+      expect(mockService.listElements).toHaveBeenCalledWith('default', 'main');
     });
   });
 
@@ -173,7 +173,7 @@ describe('Canvas Routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.data.x).toBe(99);
-      expect(mockService.moveElement).toHaveBeenCalledWith('user-1', 'canv-1', 99, 88);
+      expect(mockService.moveElement).toHaveBeenCalledWith('default', 'canv-1', 99, 88);
     });
 
     it('rejects non-numeric coordinates with 400', async () => {
@@ -203,7 +203,7 @@ describe('Canvas Routes', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.data.removed).toBe(2);
-      expect(mockService.clearCanvas).toHaveBeenCalledWith('user-1', 'main');
+      expect(mockService.clearCanvas).toHaveBeenCalledWith('default', 'main');
     });
   });
 });

--- a/packages/gateway/src/routes/canvas.ts
+++ b/packages/gateway/src/routes/canvas.ts
@@ -6,10 +6,10 @@
  * `canvas:op` WS event so all open boards update live.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { getCanvasServiceImpl } from '../services/canvas/service.js';
 import {
-  getUserId,
   apiResponse,
   apiError,
   ERROR_CODES,
@@ -29,7 +29,7 @@ export const canvasRoutes = new Hono();
 // GET / - List canvases (distinct canvas ids + element counts)
 canvasRoutes.get('/', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const canvases = await getCanvasServiceImpl().listCanvases(userId);
     return apiResponse(c, { canvases });
   } catch (err) {
@@ -40,7 +40,7 @@ canvasRoutes.get('/', async (c) => {
 // GET /:canvasId/elements - List elements on a canvas
 canvasRoutes.get('/:canvasId/elements', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const canvasId = c.req.param('canvasId') || 'main';
     const elements = await getCanvasServiceImpl().listElements(userId, canvasId);
     return apiResponse(c, { canvasId, elements });
@@ -52,7 +52,7 @@ canvasRoutes.get('/:canvasId/elements', async (c) => {
 // POST /:canvasId/elements - Create an element (UI add)
 canvasRoutes.post('/:canvasId/elements', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const canvasId = c.req.param('canvasId') || 'main';
     const body = validateBody(createCanvasElementSchema, await c.req.json());
     const element = await getCanvasServiceImpl().addElement(userId, {
@@ -78,7 +78,7 @@ canvasRoutes.post('/:canvasId/elements', async (c) => {
 // PATCH /:canvasId/elements/:id - Update an element (content/size/position/style)
 canvasRoutes.patch('/:canvasId/elements/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = c.req.param('id');
     const body = validateBody(updateCanvasElementSchema, await c.req.json());
     const element = await getCanvasServiceImpl().updateElement(userId, id, {
@@ -110,7 +110,7 @@ canvasRoutes.patch('/:canvasId/elements/:id', async (c) => {
 // POST /:canvasId/elements/:id/move - Move an element (user drag persistence)
 canvasRoutes.post('/:canvasId/elements/:id/move', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = c.req.param('id');
     const body = validateBody(moveCanvasElementSchema, await c.req.json());
     const element = await getCanvasServiceImpl().moveElement(userId, id, body.x, body.y);
@@ -133,7 +133,7 @@ canvasRoutes.post('/:canvasId/elements/:id/move', async (c) => {
 // DELETE /:canvasId/elements/:id - Remove a single element
 canvasRoutes.delete('/:canvasId/elements/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = c.req.param('id');
     const removed = await getCanvasServiceImpl().removeElement(userId, id);
     if (!removed) {
@@ -152,7 +152,7 @@ canvasRoutes.delete('/:canvasId/elements/:id', async (c) => {
 // DELETE /:canvasId - Clear all elements on a canvas
 canvasRoutes.delete('/:canvasId', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const canvasId = c.req.param('canvasId') || 'main';
     const removed = await getCanvasServiceImpl().clearCanvas(userId, canvasId);
     return apiResponse(c, { canvasId, removed });

--- a/packages/gateway/src/routes/channels/auth.ts
+++ b/packages/gateway/src/routes/channels/auth.ts
@@ -5,10 +5,11 @@
  * Users generate tokens here, then use /connect on channel platforms.
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import { getChannelVerificationService } from '../../channels/auth/verification.js';
 import { channelUsersRepo } from '../../db/repositories/channels/users.js';
-import { getPaginationParams, apiResponse, apiError, ERROR_CODES, getUserId } from '../helpers.js';
+import { getPaginationParams, apiResponse, apiError, ERROR_CODES } from '../helpers.js';
 import { wsGateway } from '../../ws/server.js';
 
 export const channelAuthRoutes = new Hono();
@@ -32,7 +33,7 @@ async function getOwnedChannelUserById(id: string, ownerUserId: string) {
  * Uses the authenticated user's ID from context (security: prevents generating tokens for other users).
  */
 channelAuthRoutes.post('/generate-token', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = await c.req.json<{
     platform?: string;
     ttlMinutes?: number;
@@ -58,7 +59,7 @@ channelAuthRoutes.post('/generate-token', async (c) => {
  * Check verification status for a platform user.
  */
 channelAuthRoutes.get('/status/:platform/:platformUserId', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const { platform, platformUserId } = c.req.param();
   const service = getChannelVerificationService();
 
@@ -94,7 +95,7 @@ channelAuthRoutes.get('/status/:platform/:platformUserId', async (c) => {
  * Block a channel user.
  */
 channelAuthRoutes.post('/block/:platform/:platformUserId', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const { platform, platformUserId } = c.req.param();
   const target = await channelUsersRepo.findByPlatform(platform, platformUserId);
   if (!target || target.ownpilotUserId !== userId) {
@@ -111,7 +112,7 @@ channelAuthRoutes.post('/block/:platform/:platformUserId', async (c) => {
  * Unblock a channel user.
  */
 channelAuthRoutes.post('/unblock/:platform/:platformUserId', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const { platform, platformUserId } = c.req.param();
   const target = await channelUsersRepo.findByPlatform(platform, platformUserId);
   if (!target || target.ownpilotUserId !== userId) {
@@ -128,7 +129,7 @@ channelAuthRoutes.post('/unblock/:platform/:platformUserId', async (c) => {
  * List all channel users with optional filters.
  */
 channelAuthRoutes.get('/users', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const platform = c.req.query('platform');
   const verified = c.req.query('verified');
   const { limit, offset } = getPaginationParams(c, 100);
@@ -171,7 +172,7 @@ channelAuthRoutes.get('/users', async (c) => {
  * Approve a pending channel user.
  */
 channelAuthRoutes.post('/users/:id/approve', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const owned = await getOwnedChannelUserById(id, userId);
   if (!owned) {
@@ -203,7 +204,7 @@ channelAuthRoutes.post('/users/:id/approve', async (c) => {
  * Block a channel user by ID.
  */
 channelAuthRoutes.post('/users/:id/block', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const user = await getOwnedChannelUserById(id, userId);
   if (!user) {
@@ -221,7 +222,7 @@ channelAuthRoutes.post('/users/:id/block', async (c) => {
  * Unblock a channel user by ID.
  */
 channelAuthRoutes.post('/users/:id/unblock', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const user = await getOwnedChannelUserById(id, userId);
   if (!user) {
@@ -239,7 +240,7 @@ channelAuthRoutes.post('/users/:id/unblock', async (c) => {
  * Revoke verification for a channel user by ID.
  */
 channelAuthRoutes.post('/users/:id/unverify', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const owned = await getOwnedChannelUserById(id, userId);
   if (!owned) {
@@ -263,7 +264,7 @@ channelAuthRoutes.post('/users/:id/unverify', async (c) => {
  * Delete a channel user by ID.
  */
 channelAuthRoutes.delete('/users/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const owned = await getOwnedChannelUserById(id, userId);
   if (!owned) {

--- a/packages/gateway/src/routes/chat/history.ts
+++ b/packages/gateway/src/routes/chat/history.ts
@@ -5,12 +5,12 @@
  * Separated from chat.ts (AI streaming logic) for maintainability.
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import {
   apiResponse,
   apiError,
   ERROR_CODES,
-  getUserId,
   getIntParam,
   getPaginationParams,
   notFoundError,
@@ -54,7 +54,7 @@ export const chatHistoryRoutes = new Hono();
  * List all conversations (with pagination)
  */
 chatHistoryRoutes.get('/history', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const { limit, offset } = getPaginationParams(c, 50);
   const search = c.req.query('search');
   const agentId = c.req.query('agentId');
@@ -115,7 +115,7 @@ chatHistoryRoutes.get('/history', async (c) => {
  * Body: { ids: string[] } | { all: true } | { olderThanDays: number }
  */
 chatHistoryRoutes.post('/history/bulk-delete', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = await parseJsonBody<{
     ids?: string[];
     all?: boolean;
@@ -191,7 +191,7 @@ chatHistoryRoutes.post('/history/bulk-delete', async (c) => {
  * Body: { ids: string[], archived: boolean }
  */
 chatHistoryRoutes.post('/history/bulk-archive', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = await parseJsonBody<{
     ids?: string[];
     all?: boolean;
@@ -234,7 +234,7 @@ chatHistoryRoutes.post('/history/bulk-archive', async (c) => {
  */
 chatHistoryRoutes.get('/history/:id', async (c) => {
   const id = c.req.param('id');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   try {
     const chatRepo = new ChatRepository(userId);
@@ -290,7 +290,7 @@ chatHistoryRoutes.get('/history/:id', async (c) => {
  */
 chatHistoryRoutes.get('/history/:id/unified', async (c) => {
   const id = c.req.param('id');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   try {
     const chatRepo = new ChatRepository(userId);
@@ -471,7 +471,7 @@ chatHistoryRoutes.get('/history/:id/unified', async (c) => {
  */
 chatHistoryRoutes.post('/history/:conversationId/channel-reply', async (c) => {
   const conversationId = c.req.param('conversationId');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = await parseJsonBody<{ text: string }>(c);
 
   if (!body?.text?.trim()) {
@@ -593,7 +593,7 @@ chatHistoryRoutes.post('/history/:conversationId/channel-reply', async (c) => {
  * Updates flow via existing channel:message WebSocket events.
  */
 chatHistoryRoutes.post('/channel-send', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = await parseJsonBody<{ text: string; conversationId: string }>(c);
 
   if (!body?.text?.trim() || !body?.conversationId) {
@@ -693,7 +693,7 @@ chatHistoryRoutes.post('/channel-send', async (c) => {
  */
 chatHistoryRoutes.delete('/history/:id', async (c) => {
   const id = c.req.param('id');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   try {
     const chatRepo = new ChatRepository(userId);
@@ -725,7 +725,7 @@ chatHistoryRoutes.delete('/history/:id', async (c) => {
  */
 chatHistoryRoutes.patch('/history/:id/archive', async (c) => {
   const id = c.req.param('id');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = await parseJsonBody<{ archived: boolean }>(c);
   if (!body) {
     return apiError(c, { code: ERROR_CODES.INVALID_INPUT, message: 'Invalid JSON body' }, 400);
@@ -757,7 +757,7 @@ chatHistoryRoutes.patch('/history/:id/archive', async (c) => {
  */
 chatHistoryRoutes.patch('/history/:id', async (c) => {
   const id = c.req.param('id');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = await parseJsonBody<{ title?: string }>(c);
   if (!body) {
     return apiError(c, { code: ERROR_CODES.INVALID_INPUT, message: 'Invalid JSON body' }, 400);
@@ -794,7 +794,7 @@ chatHistoryRoutes.patch('/history/:id', async (c) => {
  * Get request logs
  */
 chatHistoryRoutes.get('/logs', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const { limit, offset } = getPaginationParams(c, 100);
   const type = validateQueryEnum(c.req.query('type'), [
     'chat',
@@ -841,7 +841,7 @@ chatHistoryRoutes.get('/logs', async (c) => {
  * Get log statistics
  */
 chatHistoryRoutes.get('/logs/stats', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const days = getIntParam(c, 'days', 7, 1, MAX_DAYS_LOOKBACK);
 
   const startDate = new Date();
@@ -858,7 +858,7 @@ chatHistoryRoutes.get('/logs/stats', async (c) => {
  */
 chatHistoryRoutes.get('/logs/:id', async (c) => {
   const id = c.req.param('id');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   try {
     const logsRepo = new LogsRepository(userId);
@@ -885,7 +885,7 @@ chatHistoryRoutes.get('/logs/:id', async (c) => {
  * - olderThanDays=N: Clear logs older than N days (default: 30)
  */
 chatHistoryRoutes.delete('/logs', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const clearAll = c.req.query('all') === 'true';
   const days = getIntParam(c, 'olderThanDays', 30, 1);
 
@@ -963,7 +963,7 @@ chatHistoryRoutes.get('/context-detail', async (c) => {
   // Use user-configured context window from AI Models settings if available
   let userContextWindow: number | undefined;
   try {
-    const userConfig = await modelConfigsRepo.getModel(getUserId(c), provider, model);
+    const userConfig = await modelConfigsRepo.getModel(LOCAL_OWNER_ID, provider, model);
     userContextWindow = userConfig?.contextWindow ?? undefined;
   } catch {
     // Fall back to pricing defaults
@@ -992,7 +992,7 @@ chatHistoryRoutes.post('/compact', async (c) => {
   // matches what the rest of the chat surface reports.
   let userContextWindow: number | undefined;
   try {
-    const userConfig = await modelConfigsRepo.getModel(getUserId(c), provider, model);
+    const userConfig = await modelConfigsRepo.getModel(LOCAL_OWNER_ID, provider, model);
     userContextWindow = userConfig?.contextWindow ?? undefined;
   } catch {
     /* fall back to pricing defaults */
@@ -1004,7 +1004,7 @@ chatHistoryRoutes.post('/compact', async (c) => {
       model,
       keepRecent,
       userContextWindow,
-      getUserId(c)
+      LOCAL_OWNER_ID
     );
     return apiResponse(c, result);
   } catch (err) {
@@ -1021,7 +1021,7 @@ chatHistoryRoutes.post('/compact', async (c) => {
  * Uses PostgreSQL tsvector/tsquery for natural language search.
  */
 chatHistoryRoutes.post('/search', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = await parseJsonBody<{ query: string; limit?: number; offset?: number }>(c);
 
   if (!body?.query?.trim()) {

--- a/packages/gateway/src/routes/chat/index.ts
+++ b/packages/gateway/src/routes/chat/index.ts
@@ -11,6 +11,7 @@
  * - routes/chat.ts:             Route handlers (this file) + backward compat re-exports
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import { streamSSE } from 'hono/streaming';
 import type { ChatRequest } from '../../types/index.js';
@@ -18,7 +19,6 @@ import {
   apiResponse,
   apiError,
   ERROR_CODES,
-  getUserId,
   notFoundError,
   getErrorMessage,
   parseJsonBody,
@@ -230,7 +230,7 @@ chatRoutes.post('/', async (c) => {
   // Idempotency: deduplicate retried requests via Idempotency-Key header.
   // Namespaced by userId in the repo so two users sending the same key value
   // cannot read each other's cached response.
-  const idempotencyUserId = getUserId(c);
+  const idempotencyUserId = LOCAL_OWNER_ID;
   const idempotencyKey = c.req.header('Idempotency-Key');
   if (idempotencyKey) {
     try {
@@ -327,7 +327,7 @@ chatRoutes.post('/', async (c) => {
   // Look up user-configured context window from AI Models settings
   let userContextWindow: number | undefined;
   try {
-    const userConfig = await modelConfigsRepo.getModel(getUserId(c), provider, model);
+    const userConfig = await modelConfigsRepo.getModel(LOCAL_OWNER_ID, provider, model);
     userContextWindow = userConfig?.contextWindow ?? undefined;
   } catch {
     // Fall back to pricing defaults if DB lookup fails
@@ -421,7 +421,7 @@ chatRoutes.post('/', async (c) => {
     // (agent was reset/evicted), reconstruct it from database messages.
     // Pattern reference: LibreChat BaseClient.loadHistory() + Chatwoot session_registry
     if (!loaded) {
-      const chatRepo = new ChatRepository(getUserId(c));
+      const chatRepo = new ChatRepository(LOCAL_OWNER_ID);
       const dbData = await chatRepo.getConversationWithMessages(body.conversationId);
       if (dbData) {
         // Create conversation in agent memory with the ORIGINAL DB ID.
@@ -470,7 +470,7 @@ chatRoutes.post('/', async (c) => {
   // ── System prompt initialization ──────────────────────────────────────────
   const conversationId = agent.getConversation().id;
   const isPromptInitialized = promptInitializedConversations.has(conversationId);
-  const chatUserId = getUserId(c);
+  const chatUserId = LOCAL_OWNER_ID;
 
   // Workspace — set on every request (cheap), but prompt section only on first
   const sessionId = body.workspaceId || body.conversationId || conversationId;
@@ -596,7 +596,7 @@ chatRoutes.post('/', async (c) => {
       return streamSSE(c, async (stream) => {
         const conversationId = agent.getConversation().id;
         const streamAgentId = body.agentId ?? `chat-${provider}`;
-        const streamUserId = getUserId(c);
+        const streamUserId = LOCAL_OWNER_ID;
 
         // Propagate client disconnect to the provider so a closed browser tab
         // stops the LLM stream instead of letting it run to natural completion
@@ -663,7 +663,7 @@ chatRoutes.post('/', async (c) => {
     return streamSSE(c, async (stream) => {
       const conversationId = agent.getConversation().id;
       const streamAgentId = body.agentId ?? `chat-${provider}`;
-      const streamUserId = getUserId(c);
+      const streamUserId = LOCAL_OWNER_ID;
 
       // Propagate client disconnect (AbortController) to provider to stop streaming.
       // agent.cancel() calls provider.cancel() which calls abortController.abort() —
@@ -790,7 +790,7 @@ chatRoutes.post('/', async (c) => {
   const startTime = performance.now();
   const requestId = c.get('requestId') ?? crypto.randomUUID();
   const agentId = body.agentId ?? `chat-${provider}`;
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   // ── MessageBus Pipeline Path ──────────────────────────────────────────────
   const bus = tryGetMessageBus();
@@ -986,7 +986,7 @@ chatRoutes.post('/', async (c) => {
 chatRoutes.get('/conversations/:id', async (c) => {
   const id = c.req.param('id');
   const agentId = c.req.query('agentId');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   if (await isDemoMode()) {
     return apiResponse(c, {
@@ -1038,7 +1038,7 @@ chatRoutes.get('/conversations/:id', async (c) => {
 chatRoutes.delete('/conversations/:id', async (c) => {
   const id = c.req.param('id');
   const agentId = c.req.query('agentId');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   if (await isDemoMode()) {
     return apiResponse(c, {});

--- a/packages/gateway/src/routes/claws.test.ts
+++ b/packages/gateway/src/routes/claws.test.ts
@@ -24,14 +24,6 @@ vi.mock('../services/claw/manager.js', () => ({
   getClawManager: mockGetClawManager,
 }));
 
-vi.mock('./helpers.js', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    getUserId: () => 'user-1',
-  };
-});
-
 const { clawRoutes } = await import('./claws.js');
 
 // ---------------------------------------------------------------------------
@@ -258,7 +250,7 @@ describe('Claws Routes', () => {
       expect(service.updateClaw).toHaveBeenCalledTimes(1);
       expect(service.updateClaw).toHaveBeenCalledWith(
         'claw-1',
-        'user-1',
+        'default',
         expect.objectContaining({ stopCondition: 'on_report' })
       );
 
@@ -352,7 +344,7 @@ describe('Claws Routes', () => {
 
       expect(service.updateClaw).toHaveBeenCalledWith(
         'claw-1',
-        'user-1',
+        'default',
         expect.objectContaining({
           stopCondition: 'idle:3',
           missionContract: expect.objectContaining({
@@ -640,7 +632,7 @@ describe('Claws Routes', () => {
       expect(res.status).toBe(200);
       expect(service.updateClaw).toHaveBeenCalledWith(
         'claw-1',
-        'user-1',
+        'default',
         expect.objectContaining({
           mode: 'event',
           intervalMs: 60_000,
@@ -801,7 +793,7 @@ describe('Claws Routes', () => {
       expect(res.status).toBe(200);
       expect(service.setNextIntent).toHaveBeenCalledWith(
         'claw-1',
-        'user-1',
+        'default',
         'switch to debugging the auth bug'
       );
     });
@@ -860,7 +852,7 @@ describe('Claws Routes', () => {
       service.resetFailures.mockResolvedValue(undefined);
       const res = await app.request('/claws/claw-1/reset-failures', { method: 'POST' });
       expect(res.status).toBe(200);
-      expect(service.resetFailures).toHaveBeenCalledWith('claw-1', 'user-1');
+      expect(service.resetFailures).toHaveBeenCalledWith('claw-1', 'default');
       const body = (await res.json()) as { data: { reset: boolean } };
       expect(body.data).toEqual({ reset: true });
     });
@@ -898,7 +890,7 @@ describe('Claws Routes', () => {
         body: JSON.stringify({ tasks: [{ id: 't1', title: 'Survey' }] }),
       });
       expect(res.status).toBe(200);
-      expect(service.replacePlan).toHaveBeenCalledWith('claw-1', 'user-1', [
+      expect(service.replacePlan).toHaveBeenCalledWith('claw-1', 'default', [
         { id: 't1', title: 'Survey' },
       ]);
     });
@@ -953,7 +945,7 @@ describe('Claws Routes', () => {
       });
       expect(res.status).toBe(200);
       // The route merges the URL taskId into the args under `id`.
-      expect(service.updateTask).toHaveBeenCalledWith('claw-1', 'user-1', {
+      expect(service.updateTask).toHaveBeenCalledWith('claw-1', 'default', {
         id: 't1',
         status: 'completed',
         evidence: 'tests green',
@@ -1003,7 +995,7 @@ describe('Claws Routes', () => {
       // The route folds the URL taskId into args.task_id so the service
       // gets the same shape regardless of whether the call came from REST
       // or from the tool dispatcher.
-      expect(service.splitTask).toHaveBeenCalledWith('claw-1', 'user-1', {
+      expect(service.splitTask).toHaveBeenCalledWith('claw-1', 'default', {
         task_id: 't1',
         subtasks: [{ title: 'sub1' }, { title: 'sub2' }],
       });
@@ -1198,7 +1190,7 @@ describe('Claws Routes', () => {
         body: JSON.stringify({ reason: 'Not needed' }),
       });
       expect(res.status).toBe(200);
-      expect(service.denyEscalation).toHaveBeenCalledWith('claw-1', 'user-1', 'Not needed');
+      expect(service.denyEscalation).toHaveBeenCalledWith('claw-1', 'default', 'Not needed');
     });
 
     it('should return 404 if no pending escalation', async () => {

--- a/packages/gateway/src/routes/claws.ts
+++ b/packages/gateway/src/routes/claws.ts
@@ -9,6 +9,7 @@
  * 3. Generic dynamic route (/:id) - MUST be last
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import type {
@@ -23,7 +24,6 @@ import type {
 import { getClawService } from '../services/claw/service.js';
 import { getLlmSemaphore } from '../services/llm/semaphore.js';
 import {
-  getUserId,
   apiResponse,
   apiError,
   ERROR_CODES,
@@ -425,15 +425,7 @@ clawRoutes.get('/presets', (c) => {
 // GET /recommendations - Operational recommendations for claws that need attention
 clawRoutes.get('/recommendations', async (c) => {
   try {
-    const userId = getUserId(c);
-    // IDOR-017: Reject unauthenticated requests
-    if (userId === 'default' && !c.get('sessionAuthenticated')) {
-      return apiError(
-        c,
-        { code: ERROR_CODES.UNAUTHORIZED, message: 'Authentication required' },
-        401
-      );
-    }
+    const userId = LOCAL_OWNER_ID;
     const service = getClawService();
     const configs = await service.listClaws(userId);
     const sessions = service.listSessions(userId);
@@ -462,15 +454,7 @@ clawRoutes.get('/recommendations', async (c) => {
 // POST /recommendations/apply - Apply conservative fixes to attention claws
 clawRoutes.post('/recommendations/apply', async (c) => {
   try {
-    const userId = getUserId(c);
-    // IDOR-017: Reject unauthenticated requests
-    if (userId === 'default' && !c.get('sessionAuthenticated')) {
-      return apiError(
-        c,
-        { code: ERROR_CODES.UNAUTHORIZED, message: 'Authentication required' },
-        401
-      );
-    }
+    const userId = LOCAL_OWNER_ID;
 
     let raw: unknown = {};
     try {
@@ -543,15 +527,7 @@ clawRoutes.post('/recommendations/apply', async (c) => {
 // GET / - List all claws
 clawRoutes.get('/', async (c) => {
   try {
-    const userId = getUserId(c);
-    // IDOR-017: Reject unauthenticated requests
-    if (userId === 'default' && !c.get('sessionAuthenticated')) {
-      return apiError(
-        c,
-        { code: ERROR_CODES.UNAUTHORIZED, message: 'Authentication required' },
-        401
-      );
-    }
+    const userId = LOCAL_OWNER_ID;
 
     const service = getClawService();
     const { limit = 50, offset = 0 } = getPaginationParams(c);
@@ -577,15 +553,7 @@ clawRoutes.get('/', async (c) => {
 // GET /stats - Aggregate claw statistics
 clawRoutes.get('/stats', async (c) => {
   try {
-    const userId = getUserId(c);
-    // IDOR-017: Reject unauthenticated requests
-    if (userId === 'default' && !c.get('sessionAuthenticated')) {
-      return apiError(
-        c,
-        { code: ERROR_CODES.UNAUTHORIZED, message: 'Authentication required' },
-        401
-      );
-    }
+    const userId = LOCAL_OWNER_ID;
 
     const service = getClawService();
     const configs = await service.listClaws(userId);
@@ -643,15 +611,7 @@ clawRoutes.get('/stats', async (c) => {
 // Registered before the /:id routes so "fleet" is not parsed as a claw id.
 clawRoutes.get('/fleet/eval', async (c) => {
   try {
-    const userId = getUserId(c);
-    // IDOR-017: Reject unauthenticated requests
-    if (userId === 'default' && !c.get('sessionAuthenticated')) {
-      return apiError(
-        c,
-        { code: ERROR_CODES.UNAUTHORIZED, message: 'Authentication required' },
-        401
-      );
-    }
+    const userId = LOCAL_OWNER_ID;
 
     const { limit } = getPaginationParams(c);
     const perClawLimit = Math.min(limit || 200, 500);
@@ -675,15 +635,7 @@ clawRoutes.get('/fleet/eval', async (c) => {
 // GET /health - Claw health indicators
 clawRoutes.get('/health', async (c) => {
   try {
-    const userId = getUserId(c);
-    // IDOR-017: Reject unauthenticated requests
-    if (userId === 'default' && !c.get('sessionAuthenticated')) {
-      return apiError(
-        c,
-        { code: ERROR_CODES.UNAUTHORIZED, message: 'Authentication required' },
-        401
-      );
-    }
+    const userId = LOCAL_OWNER_ID;
 
     const service = getClawService();
     const configs = await service.listClaws(userId);
@@ -738,15 +690,7 @@ clawRoutes.get('/health', async (c) => {
 // POST / - Create a new claw
 clawRoutes.post('/', async (c) => {
   try {
-    const userId = getUserId(c);
-    // IDOR-017: Reject unauthenticated requests
-    if (userId === 'default' && !c.get('sessionAuthenticated')) {
-      return apiError(
-        c,
-        { code: ERROR_CODES.UNAUTHORIZED, message: 'Authentication required' },
-        401
-      );
-    }
+    const userId = LOCAL_OWNER_ID;
 
     const body = validateBody(createClawSchema, await c.req.json());
 
@@ -790,15 +734,7 @@ clawRoutes.post('/', async (c) => {
 // GET /:id/doctor - Preview safe operational fixes for a claw
 clawRoutes.get('/:id/doctor', async (c) => {
   try {
-    const userId = getUserId(c);
-    // IDOR-017: Reject unauthenticated requests
-    if (userId === 'default' && !c.get('sessionAuthenticated')) {
-      return apiError(
-        c,
-        { code: ERROR_CODES.UNAUTHORIZED, message: 'Authentication required' },
-        401
-      );
-    }
+    const userId = LOCAL_OWNER_ID;
 
     const { id } = c.req.param();
     const service = getClawService();
@@ -826,7 +762,7 @@ clawRoutes.get('/:id/doctor', async (c) => {
 // POST /:id/apply-recommendations - Apply conservative config fixes
 clawRoutes.post('/:id/apply-recommendations', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const service = getClawService();
 
@@ -867,7 +803,7 @@ clawRoutes.post('/:id/apply-recommendations', async (c) => {
 // POST /:id/start
 clawRoutes.post('/:id/start', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const service = getClawService();
 
@@ -881,7 +817,7 @@ clawRoutes.post('/:id/start', async (c) => {
 // POST /:id/pause
 clawRoutes.post('/:id/pause', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const service = getClawService();
 
@@ -902,7 +838,7 @@ clawRoutes.post('/:id/pause', async (c) => {
 // POST /:id/resume
 clawRoutes.post('/:id/resume', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const service = getClawService();
 
@@ -923,7 +859,7 @@ clawRoutes.post('/:id/resume', async (c) => {
 // POST /:id/stop
 clawRoutes.post('/:id/stop', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const service = getClawService();
 
@@ -944,7 +880,7 @@ clawRoutes.post('/:id/stop', async (c) => {
 // POST /:id/execute
 clawRoutes.post('/:id/execute', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const service = getClawService();
 
@@ -958,7 +894,7 @@ clawRoutes.post('/:id/execute', async (c) => {
 // POST /:id/message
 clawRoutes.post('/:id/message', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const body = validateBody(clawMessageSchema, await c.req.json());
 
@@ -977,7 +913,7 @@ clawRoutes.post('/:id/message', async (c) => {
 // `[OPERATOR]` framing then auto-clears it after one cycle.
 clawRoutes.post('/:id/next-intent', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const body = validateBody(clawNextIntentSchema, await c.req.json());
     if (body.intent.trim().length === 0) {
@@ -1012,7 +948,7 @@ clawRoutes.post('/:id/next-intent', async (c) => {
 // tool problem (network, config, expired token) has been fixed.
 clawRoutes.post('/:id/reset-failures', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const service = getClawService();
     await service.resetFailures(id, userId);
@@ -1032,7 +968,7 @@ clawRoutes.post('/:id/reset-failures', async (c) => {
 // POST /:id/steer — interrupt the in-flight cycle and redirect it now
 clawRoutes.post('/:id/steer', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const body = validateBody(clawMessageSchema, await c.req.json());
 
@@ -1049,7 +985,7 @@ clawRoutes.post('/:id/steer', async (c) => {
 // PUT /:id/plan — replace the structured task plan
 clawRoutes.put('/:id/plan', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const body = validateBody(
       z.object({ tasks: z.array(z.unknown()).max(1000).optional() }),
@@ -1077,7 +1013,7 @@ clawRoutes.put('/:id/plan', async (c) => {
 // PATCH /:id/tasks/:taskId — update a single task (status/notes/evidence)
 clawRoutes.patch('/:id/tasks/:taskId', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id, taskId } = c.req.param();
     const body = validateBody(z.record(z.string(), z.unknown()), await c.req.json());
     const service = getClawService();
@@ -1106,7 +1042,7 @@ clawRoutes.patch('/:id/tasks/:taskId', async (c) => {
 // POST /:id/tasks/:taskId/split — atomically split a task into subtasks
 clawRoutes.post('/:id/tasks/:taskId/split', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id, taskId } = c.req.param();
     const body = validateBody(z.record(z.string(), z.unknown()), await c.req.json());
     const service = getClawService();
@@ -1136,7 +1072,7 @@ clawRoutes.post('/:id/tasks/:taskId/split', async (c) => {
 // GET /:id/history
 clawRoutes.get('/:id/history', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const { limit, offset } = getPaginationParams(c);
     const service = getClawService();
@@ -1152,7 +1088,7 @@ clawRoutes.get('/:id/history', async (c) => {
 // (Hermes-style trajectory data for eval / fine-tuning).
 clawRoutes.get('/:id/trajectory', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const { limit, offset } = getPaginationParams(c);
     const service = getClawService();
@@ -1177,7 +1113,7 @@ clawRoutes.get('/:id/trajectory', async (c) => {
 // retry) detection, efficiency, and a 0-100 composite reliabilityScore.
 clawRoutes.get('/:id/eval', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const { limit, offset } = getPaginationParams(c);
     const service = getClawService();
@@ -1200,7 +1136,7 @@ clawRoutes.get('/:id/eval', async (c) => {
 // GET /:id/audit — Get audit log (per-tool-call tracking)
 clawRoutes.get('/:id/audit', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const { limit, offset } = getPaginationParams(c);
     const category = c.req.query('category');
@@ -1225,7 +1161,7 @@ clawRoutes.get('/:id/audit', async (c) => {
 // POST /:id/approve-escalation
 clawRoutes.post('/:id/approve-escalation', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const service = getClawService();
 
@@ -1249,7 +1185,7 @@ clawRoutes.post('/:id/approve-escalation', async (c) => {
 // POST /:id/deny-escalation
 clawRoutes.post('/:id/deny-escalation', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     let raw: unknown = {};
     try {
@@ -1288,7 +1224,7 @@ clawRoutes.post('/:id/deny-escalation', async (c) => {
 // GET /:id
 clawRoutes.get('/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const service = getClawService();
 
@@ -1312,7 +1248,7 @@ clawRoutes.get('/:id', async (c) => {
 // PUT /:id
 clawRoutes.put('/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const body = validateBody(updateClawSchema, await c.req.json());
     const service = getClawService();
@@ -1353,7 +1289,7 @@ clawRoutes.put('/:id', async (c) => {
 // DELETE /:id
 clawRoutes.delete('/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { id } = c.req.param();
     const service = getClawService();
 

--- a/packages/gateway/src/routes/cli/providers.test.ts
+++ b/packages/gateway/src/routes/cli/providers.test.ts
@@ -40,7 +40,7 @@ const { cliProvidersRoutes } = await import('./providers.js');
 function createApp() {
   const app = new Hono();
   app.use('*', async (c, next) => {
-    c.set('userId', 'user-1');
+    c.set('userId', 'default');
     await next();
   });
   app.route('/cli-providers', cliProvidersRoutes);
@@ -50,7 +50,7 @@ function createApp() {
 
 const sampleProvider = {
   id: 'prov-1',
-  userId: 'user-1',
+  userId: 'default',
   name: 'prettier',
   displayName: 'Prettier',
   binary: 'prettier',
@@ -90,7 +90,7 @@ describe('CLI Providers Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.data).toHaveLength(1);
-      expect(mockRepo.list).toHaveBeenCalledWith('user-1');
+      expect(mockRepo.list).toHaveBeenCalledWith('default');
     });
 
     it('returns 500 when repo throws', async () => {

--- a/packages/gateway/src/routes/cli/providers.ts
+++ b/packages/gateway/src/routes/cli/providers.ts
@@ -5,17 +5,11 @@
  * These appear in the coding agents system as 'custom:{name}'.
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { execFileSync } from 'node:child_process';
 import { Hono } from 'hono';
 import { cliProvidersRepo } from '../../db/repositories/cli/providers.js';
-import {
-  getUserId,
-  apiResponse,
-  apiError,
-  ERROR_CODES,
-  getErrorMessage,
-  parseJsonBody,
-} from '../helpers.js';
+import { apiResponse, apiError, ERROR_CODES, getErrorMessage, parseJsonBody } from '../helpers.js';
 
 export const cliProvidersRoutes = new Hono();
 
@@ -38,7 +32,7 @@ async function getOwnedProvider(id: string, ownerUserId: string) {
 // =============================================================================
 
 cliProvidersRoutes.get('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   try {
     const providers = await cliProvidersRepo.list(userId);
     return apiResponse(c, providers);
@@ -52,7 +46,7 @@ cliProvidersRoutes.get('/', async (c) => {
 // =============================================================================
 
 cliProvidersRoutes.post('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   const body = await parseJsonBody(c);
   if (!body) {
@@ -128,7 +122,7 @@ cliProvidersRoutes.post('/', async (c) => {
 // =============================================================================
 
 cliProvidersRoutes.put('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const body = await parseJsonBody(c);
@@ -177,7 +171,7 @@ cliProvidersRoutes.put('/:id', async (c) => {
 // =============================================================================
 
 cliProvidersRoutes.delete('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   try {
@@ -200,7 +194,7 @@ cliProvidersRoutes.delete('/:id', async (c) => {
 // =============================================================================
 
 cliProvidersRoutes.post('/:id/test', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   try {

--- a/packages/gateway/src/routes/cli/tools.ts
+++ b/packages/gateway/src/routes/cli/tools.ts
@@ -5,16 +5,10 @@
  * Execution happens via AI tool calling (run_cli_tool), not via these routes.
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import { getCliToolService } from '../../services/cli/tool-service.js';
-import {
-  getUserId,
-  apiResponse,
-  apiError,
-  ERROR_CODES,
-  getErrorMessage,
-  parseJsonBody,
-} from '../helpers.js';
+import { apiResponse, apiError, ERROR_CODES, getErrorMessage, parseJsonBody } from '../helpers.js';
 import type { CliToolPolicy, CliInstallMethod } from '@ownpilot/core';
 import { CLI_TOOLS_BY_NAME } from '../../services/cli/tools-catalog.js';
 import { cliProvidersRepo } from '../../db/repositories/cli/providers.js';
@@ -44,7 +38,7 @@ export const cliToolsRoutes = new Hono();
 // =============================================================================
 
 cliToolsRoutes.get('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   try {
     const service = getCliToolService();
     const tools = await service.listTools(userId);
@@ -59,7 +53,7 @@ cliToolsRoutes.get('/', async (c) => {
 // =============================================================================
 
 cliToolsRoutes.get('/policies', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   try {
     const service = getCliToolService();
     const tools = await service.listTools(userId);
@@ -82,7 +76,7 @@ cliToolsRoutes.get('/policies', async (c) => {
 // =============================================================================
 
 cliToolsRoutes.put('/policies/:toolName', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const toolName = c.req.param('toolName');
 
   const body = await parseJsonBody(c);
@@ -119,7 +113,7 @@ cliToolsRoutes.put('/policies/:toolName', async (c) => {
 // =============================================================================
 
 cliToolsRoutes.post('/:name/install', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const name = c.req.param('name');
 
   const body = await parseJsonBody(c);
@@ -169,7 +163,7 @@ cliToolsRoutes.post('/refresh', async (c) => {
 // =============================================================================
 
 cliToolsRoutes.post('/policies/batch', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = await parseJsonBody(c);
   if (!body) {
     return apiError(c, { code: ERROR_CODES.VALIDATION_ERROR, message: 'Invalid JSON body' }, 400);
@@ -234,7 +228,7 @@ cliToolsRoutes.post('/policies/batch', async (c) => {
 // =============================================================================
 
 cliToolsRoutes.post('/custom', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = await parseJsonBody(c);
   if (!body) {
     return apiError(c, { code: ERROR_CODES.VALIDATION_ERROR, message: 'Invalid JSON body' }, 400);
@@ -349,7 +343,7 @@ cliToolsRoutes.post('/custom', async (c) => {
 // =============================================================================
 
 cliToolsRoutes.delete('/custom/:name', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const name = c.req.param('name');
 
   try {

--- a/packages/gateway/src/routes/coding-agents.ts
+++ b/packages/gateway/src/routes/coding-agents.ts
@@ -5,6 +5,7 @@
  * (Claude Code, OpenAI Codex, Google Gemini CLI).
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import type { CodingAgentProvider } from '@ownpilot/core';
 import { getCodingAgentService } from '../services/coding-agent/service.js';
@@ -22,7 +23,6 @@ import { codingAgentPermissionsRepo } from '../db/repositories/coding-agent/perm
 import { codingAgentSkillAttachmentsRepo } from '../db/repositories/coding-agent/skill-attachments.js';
 import { codingAgentSubscriptionsRepo } from '../db/repositories/coding-agent/subscriptions.js';
 import {
-  getUserId,
   apiResponse,
   apiError,
   ERROR_CODES,
@@ -59,7 +59,7 @@ codingAgentsRoutes.get('/status', async (c) => {
 // =============================================================================
 
 codingAgentsRoutes.post('/run', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   const body = await parseJsonBody(c);
   if (!body) {
@@ -169,7 +169,7 @@ codingAgentsRoutes.post('/test', async (c) => {
 // =============================================================================
 
 codingAgentsRoutes.get('/sessions', (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const service = getCodingAgentService();
   const sessions = service.listSessions(userId);
   return apiResponse(c, sessions);
@@ -180,7 +180,7 @@ codingAgentsRoutes.get('/sessions', (c) => {
 // =============================================================================
 
 codingAgentsRoutes.post('/sessions', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   const body = await parseJsonBody(c);
   if (!body) {
@@ -287,7 +287,7 @@ codingAgentsRoutes.post('/sessions', async (c) => {
 // =============================================================================
 
 codingAgentsRoutes.get('/sessions/:id', (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const sessionId = c.req.param('id');
   const service = getCodingAgentService();
   const session = service.getSession(sessionId, userId);
@@ -316,7 +316,7 @@ codingAgentsRoutes.get('/sessions/:id', (c) => {
 // =============================================================================
 
 codingAgentsRoutes.delete('/sessions/:id', (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const sessionId = c.req.param('id');
   const service = getCodingAgentService();
   const success = service.terminateSession(sessionId, userId);
@@ -331,7 +331,7 @@ codingAgentsRoutes.delete('/sessions/:id', (c) => {
 // =============================================================================
 
 codingAgentsRoutes.post('/sessions/:id/input', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const sessionId = c.req.param('id');
 
   const body = await parseJsonBody(c);
@@ -368,7 +368,7 @@ codingAgentsRoutes.post('/sessions/:id/input', async (c) => {
 // =============================================================================
 
 codingAgentsRoutes.get('/sessions/:id/output', (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const sessionId = c.req.param('id');
   const service = getCodingAgentService();
 
@@ -387,7 +387,7 @@ codingAgentsRoutes.get('/sessions/:id/output', (c) => {
 });
 
 codingAgentsRoutes.post('/sessions/:id/resize', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const sessionId = c.req.param('id');
 
   const body = await parseJsonBody(c);
@@ -422,7 +422,7 @@ codingAgentsRoutes.post('/sessions/:id/resize', async (c) => {
 
 // GET /results - List persisted coding agent results
 codingAgentsRoutes.get('/results', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const { limit, offset } = getPaginationParams(c);
 
   try {
@@ -440,7 +440,7 @@ codingAgentsRoutes.get('/results', async (c) => {
 
 // GET /results/:id - Get a specific result
 codingAgentsRoutes.get('/results/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const resultId = c.req.param('id');
 
   try {
@@ -460,7 +460,7 @@ codingAgentsRoutes.get('/results/:id', async (c) => {
 
 // GET /permissions - List all permission profiles
 codingAgentsRoutes.get('/permissions', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   try {
     const perms = await codingAgentPermissionsRepo.list(userId);
     return apiResponse(c, perms);
@@ -471,7 +471,7 @@ codingAgentsRoutes.get('/permissions', async (c) => {
 
 // GET /permissions/:providerRef - Get permission profile for a provider
 codingAgentsRoutes.get('/permissions/:providerRef', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerRef = c.req.param('providerRef');
 
   try {
@@ -491,7 +491,7 @@ codingAgentsRoutes.get('/permissions/:providerRef', async (c) => {
 
 // PUT /permissions/:providerRef - Upsert permission profile
 codingAgentsRoutes.put('/permissions/:providerRef', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerRef = c.req.param('providerRef');
 
   const body = await parseJsonBody(c);
@@ -524,7 +524,7 @@ codingAgentsRoutes.put('/permissions/:providerRef', async (c) => {
 
 // DELETE /permissions/:providerRef - Delete permission profile
 codingAgentsRoutes.delete('/permissions/:providerRef', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerRef = c.req.param('providerRef');
 
   try {
@@ -544,7 +544,7 @@ codingAgentsRoutes.delete('/permissions/:providerRef', async (c) => {
 
 // GET /skills/:providerRef - List skill attachments for a provider
 codingAgentsRoutes.get('/skills/:providerRef', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerRef = c.req.param('providerRef');
 
   try {
@@ -557,7 +557,7 @@ codingAgentsRoutes.get('/skills/:providerRef', async (c) => {
 
 // POST /skills/:providerRef - Attach a skill
 codingAgentsRoutes.post('/skills/:providerRef', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerRef = c.req.param('providerRef');
 
   const body = await parseJsonBody(c);
@@ -595,7 +595,7 @@ codingAgentsRoutes.post('/skills/:providerRef', async (c) => {
 
 // PUT /skills/:providerRef/:id - Update a skill attachment
 codingAgentsRoutes.put('/skills/:providerRef/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const attachmentId = c.req.param('id');
 
   const body = await parseJsonBody(c);
@@ -631,7 +631,7 @@ codingAgentsRoutes.put('/skills/:providerRef/:id', async (c) => {
 
 // DELETE /skills/:providerRef/:id - Detach a skill
 codingAgentsRoutes.delete('/skills/:providerRef/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const attachmentId = c.req.param('id');
 
   try {
@@ -651,7 +651,7 @@ codingAgentsRoutes.delete('/skills/:providerRef/:id', async (c) => {
 
 // GET /subscriptions - List all subscriptions
 codingAgentsRoutes.get('/subscriptions', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   try {
     const subs = await codingAgentSubscriptionsRepo.list(userId);
     return apiResponse(c, subs);
@@ -662,7 +662,7 @@ codingAgentsRoutes.get('/subscriptions', async (c) => {
 
 // GET /subscriptions/:providerRef - Get subscription for a provider
 codingAgentsRoutes.get('/subscriptions/:providerRef', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerRef = c.req.param('providerRef');
 
   try {
@@ -682,7 +682,7 @@ codingAgentsRoutes.get('/subscriptions/:providerRef', async (c) => {
 
 // PUT /subscriptions/:providerRef - Upsert subscription
 codingAgentsRoutes.put('/subscriptions/:providerRef', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerRef = c.req.param('providerRef');
 
   const body = await parseJsonBody(c);
@@ -712,7 +712,7 @@ codingAgentsRoutes.put('/subscriptions/:providerRef', async (c) => {
 
 // DELETE /subscriptions/:providerRef - Delete subscription
 codingAgentsRoutes.delete('/subscriptions/:providerRef', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerRef = c.req.param('providerRef');
 
   try {
@@ -734,7 +734,7 @@ codingAgentsRoutes.delete('/subscriptions/:providerRef', async (c) => {
  * POST /orchestrate - Start a new orchestration run
  */
 codingAgentsRoutes.post('/orchestrate', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = await parseJsonBody<{
     goal: string;
     provider: string;
@@ -795,7 +795,7 @@ codingAgentsRoutes.post('/orchestrate', async (c) => {
  * GET /orchestrate - List orchestration runs
  */
 codingAgentsRoutes.get('/orchestrate', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const { limit, offset } = getPaginationParams(c);
   const [runs, total] = await Promise.all([
     listOrchestrations(userId, limit, offset),
@@ -808,7 +808,7 @@ codingAgentsRoutes.get('/orchestrate', async (c) => {
  * GET /orchestrate/:id - Get a specific orchestration run
  */
 codingAgentsRoutes.get('/orchestrate/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const run = await getOrchestration(id, userId);
   if (!run) {
@@ -821,7 +821,7 @@ codingAgentsRoutes.get('/orchestrate/:id', async (c) => {
  * POST /orchestrate/:id/continue - Continue a paused run with user input
  */
 codingAgentsRoutes.post('/orchestrate/:id/continue', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const body = await parseJsonBody<{ prompt: string }>(c);
 
@@ -852,7 +852,7 @@ codingAgentsRoutes.post('/orchestrate/:id/continue', async (c) => {
  * POST /orchestrate/:id/cancel - Cancel an orchestration run
  */
 codingAgentsRoutes.post('/orchestrate/:id/cancel', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const cancelled = await cancelOrchestration(id, userId);
@@ -866,7 +866,7 @@ codingAgentsRoutes.post('/orchestrate/:id/cancel', async (c) => {
  * DELETE /orchestrate/:id - Delete an orchestration run
  */
 codingAgentsRoutes.delete('/orchestrate/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const deleted = await orchestrationRunsRepo.delete(id, userId);
@@ -884,7 +884,7 @@ codingAgentsRoutes.delete('/orchestrate/:id', async (c) => {
  * GET /sessions/:id/acp - Get ACP-specific data (tool calls, plan)
  */
 codingAgentsRoutes.get('/sessions/:id/acp', (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const sessionId = c.req.param('id');
   const service = getCodingAgentService();
 
@@ -900,7 +900,7 @@ codingAgentsRoutes.get('/sessions/:id/acp', (c) => {
  * POST /sessions/:id/acp/prompt - Send a follow-up prompt to an ACP session
  */
 codingAgentsRoutes.post('/sessions/:id/acp/prompt', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const sessionId = c.req.param('id');
 
   const body = await parseJsonBody(c);
@@ -930,7 +930,7 @@ codingAgentsRoutes.post('/sessions/:id/acp/prompt', async (c) => {
  * POST /sessions/:id/acp/cancel - Cancel an ongoing ACP prompt turn
  */
 codingAgentsRoutes.post('/sessions/:id/acp/cancel', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const sessionId = c.req.param('id');
 
   try {

--- a/packages/gateway/src/routes/composio.ts
+++ b/packages/gateway/src/routes/composio.ts
@@ -6,17 +6,11 @@
  * and handling OAuth callbacks.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { composioService } from '../services/composio-service.js';
 import { getLog } from '../services/log.js';
-import {
-  getUserId,
-  apiResponse,
-  apiError,
-  ERROR_CODES,
-  getErrorMessage,
-  getIntParam,
-} from './helpers.js';
+import { apiResponse, apiError, ERROR_CODES, getErrorMessage, getIntParam } from './helpers.js';
 
 const log = getLog('ComposioRoutes');
 
@@ -81,7 +75,7 @@ composioRoutes.get('/apps', async (c) => {
 
 composioRoutes.get('/connections', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const connections = await composioService.getConnections(userId);
     return apiResponse(c, { connections, count: connections.length });
   } catch (err) {
@@ -114,7 +108,7 @@ composioRoutes.post('/connections', async (c) => {
       );
     }
 
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const result = await composioService.initiateConnection(userId, appName, redirectUrl);
 
     return apiResponse(c, {

--- a/packages/gateway/src/routes/costs.ts
+++ b/packages/gateway/src/routes/costs.ts
@@ -4,6 +4,7 @@
  * REST API endpoints for LLM usage cost tracking and budget management
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { getLog } from '../services/log.js';
 import {
@@ -19,7 +20,6 @@ import {
   apiResponse,
   apiError,
   getIntParam,
-  getUserId,
   ERROR_CODES,
   getErrorMessage,
   validateQueryEnum,
@@ -65,7 +65,7 @@ function getPeriodStart(period: 'day' | 'week' | 'month' | 'year'): Date {
 costRoutes.get('/', async (c) => {
   const period =
     validateQueryEnum(c.req.query('period'), ['day', 'week', 'month', 'year'] as const) ?? 'month';
-  const userId = getUserId(c); // Use authenticated user, not arbitrary query param
+  const userId = LOCAL_OWNER_ID; // Use authenticated user, not arbitrary query param
 
   const startDate = getPeriodStart(period);
   const endDate = new Date();
@@ -102,7 +102,7 @@ costRoutes.get('/', async (c) => {
  */
 costRoutes.get('/subscriptions', async (c) => {
   try {
-    const userId = getUserId(c) ?? 'default';
+    const userId = LOCAL_OWNER_ID ?? 'default';
     const { ModelConfigsRepository } = await import('../db/repositories/model-configs.js');
     const repo = new ModelConfigsRepository();
 
@@ -176,7 +176,7 @@ costRoutes.get('/subscriptions', async (c) => {
  * GET /costs/usage - Get usage stats for UI dashboard
  */
 costRoutes.get('/usage', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   // Get daily stats
   const dailyStart = new Date();
@@ -215,7 +215,7 @@ costRoutes.get('/usage', async (c) => {
 costRoutes.get('/breakdown', async (c) => {
   const period =
     validateQueryEnum(c.req.query('period'), ['day', 'week', 'month', 'year'] as const) ?? 'month';
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   const startDate = getPeriodStart(period);
   const endDate = new Date();
@@ -512,7 +512,7 @@ costRoutes.post('/budget', async (c) => {
 costRoutes.get('/history', async (c) => {
   const limit = getIntParam(c, 'limit', 100, 1, 1000);
   const days = getIntParam(c, 'days', 30, 1, MAX_DAYS_LOOKBACK);
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const provider = validateQueryEnum(c.req.query('provider'), [
     'openai',
     'anthropic',
@@ -584,7 +584,7 @@ costRoutes.post('/record', async (c) => {
   try {
     const body = validateBody(costRecordSchema, await c.req.json());
 
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
 
     // Record usage
     const record = await usageTracker.record({

--- a/packages/gateway/src/routes/crews.ts
+++ b/packages/gateway/src/routes/crews.ts
@@ -2,6 +2,7 @@
  * Crew Routes — deploy, manage, and monitor agent crews
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { getLog } from '../services/log.js';
 
@@ -19,7 +20,6 @@ import {
   ERROR_CODES,
   getErrorMessage,
   getPaginationParams,
-  getUserId,
 } from './helpers.js';
 import {
   validateBody,
@@ -35,7 +35,7 @@ export const crewRoutes = new Hono();
 
 crewRoutes.get('/', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { limit, offset } = getPaginationParams(c);
     const repo = getCrewsRepository();
     const [crews, total] = await Promise.all([
@@ -52,7 +52,7 @@ crewRoutes.get('/', async (c) => {
 
 crewRoutes.get('/stats', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const crewRepo = getCrewsRepository();
     const hbRepo = getHeartbeatLogRepository();
 
@@ -92,7 +92,7 @@ crewRoutes.get('/stats', async (c) => {
 
 crewRoutes.get('/health', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const crewRepo = getCrewsRepository();
     const hbRepo = getHeartbeatLogRepository();
 
@@ -140,8 +140,6 @@ crewRoutes.get('/health', async (c) => {
 // ── GET /templates — list crew templates (MUST be before /:id) ──
 
 crewRoutes.get('/templates', (c) => {
-  // Auth check: calling getUserId enforces session/API-key auth
-  getUserId(c);
   const templates = listCrewTemplates();
   return apiResponse(c, templates);
 });
@@ -160,7 +158,7 @@ crewRoutes.get('/templates/:id', (c) => {
 
 crewRoutes.post('/deploy', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const body = validateBody(crewDeploySchema, await c.req.json());
     const { templateId } = body;
     // provider and model are pass-through fields validated by the schema
@@ -330,7 +328,7 @@ crewRoutes.post('/deploy', async (c) => {
 crewRoutes.get('/:id', async (c) => {
   try {
     const crewId = c.req.param('id');
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const crewRepo = getCrewsRepository();
     const crew = await crewRepo.getById(crewId, userId);
     if (!crew) {
@@ -372,7 +370,7 @@ crewRoutes.get('/:id', async (c) => {
 crewRoutes.post('/:id/pause', async (c) => {
   try {
     const crewId = c.req.param('id');
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const repo = getCrewsRepository();
     const crew = await repo.getById(crewId, userId);
     if (!crew) {
@@ -396,7 +394,7 @@ crewRoutes.post('/:id/pause', async (c) => {
 crewRoutes.post('/:id/resume', async (c) => {
   try {
     const crewId = c.req.param('id');
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const repo = getCrewsRepository();
     const crew = await repo.getById(crewId, userId);
     if (!crew) {
@@ -420,7 +418,7 @@ crewRoutes.post('/:id/resume', async (c) => {
 crewRoutes.delete('/:id', async (c) => {
   try {
     const crewId = c.req.param('id');
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const repo = getCrewsRepository();
     const crew = await repo.getById(crewId, userId);
     if (!crew) {
@@ -468,7 +466,7 @@ crewRoutes.delete('/:id', async (c) => {
 crewRoutes.post('/:id/message', async (c) => {
   try {
     const crewId = c.req.param('id');
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const body = validateBody(crewMessageSchema, await c.req.json());
 
     const repo = getCrewsRepository();
@@ -531,7 +529,7 @@ crewRoutes.post('/:id/message', async (c) => {
 crewRoutes.post('/:id/delegate', async (c) => {
   try {
     const crewId = c.req.param('id');
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const body = validateBody(crewDelegateSchema, await c.req.json());
 
     const repo = getCrewsRepository();
@@ -587,7 +585,7 @@ crewRoutes.post('/:id/delegate', async (c) => {
 crewRoutes.get('/:id/status', async (c) => {
   try {
     const crewId = c.req.param('id');
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const repo = getCrewsRepository();
     const crew = await repo.getById(crewId, userId);
     if (!crew) {
@@ -655,7 +653,7 @@ crewRoutes.get('/:id/status', async (c) => {
 crewRoutes.get('/:id/memory', async (c) => {
   try {
     const crewId = c.req.param('id');
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const repo = getCrewsRepository();
     const crew = await repo.getById(crewId, userId);
     if (!crew) {
@@ -687,7 +685,7 @@ crewRoutes.delete('/:id/memory/:memoryId', async (c) => {
   try {
     const crewId = c.req.param('id');
     const memoryId = c.req.param('memoryId');
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const repo = getCrewsRepository();
     const crew = await repo.getById(crewId, userId);
     if (!crew) {
@@ -718,7 +716,7 @@ crewRoutes.delete('/:id/memory/:memoryId', async (c) => {
 crewRoutes.get('/:id/tasks', async (c) => {
   try {
     const crewId = c.req.param('id');
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const repo = getCrewsRepository();
     const crew = await repo.getById(crewId, userId);
     if (!crew) {
@@ -748,7 +746,7 @@ crewRoutes.get('/:id/tasks', async (c) => {
 crewRoutes.post('/:id/sync', async (c) => {
   try {
     const crewId = c.req.param('id');
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const body = validateBody(crewSyncSchema, await c.req.json());
 
     const repo = getCrewsRepository();

--- a/packages/gateway/src/routes/crud-factory.ts
+++ b/packages/gateway/src/routes/crud-factory.ts
@@ -9,18 +9,15 @@
  * Usage:
  *   import { createCrudRoutes } from './crud-factory.js';
  *   export const widgetsRoutes = createCrudRoutes({
- *     entity: 'widget',
- *     serviceToken: Services.Widget,
- *     schemas: { create: createWidgetSchema, update: updateWidgetSchema },
- *   });
+ *     entity: 'widget', *     serviceToken: Services.Widget, *     schemas: { create: createWidgetSchema, update: updateWidgetSchema }, *   });
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import type { Context } from 'hono';
 import type { ZodType } from 'zod';
 import { getServiceRegistry, type ServiceToken } from '@ownpilot/core';
 import {
-  getUserId,
   apiResponse,
   apiError,
   getErrorMessage,
@@ -205,7 +202,7 @@ export function createCrudRoutes<TService = unknown>(config: CrudRouteConfig<TSe
   if (methods.includes('list')) {
     app.get('/', async (c) => {
       try {
-        const userId = getUserId(c);
+        const userId = LOCAL_OWNER_ID;
         const { limit, offset } = getPaginationParams(c, defaultLimit, maxLimit);
         const service = getService();
 
@@ -244,7 +241,7 @@ export function createCrudRoutes<TService = unknown>(config: CrudRouteConfig<TSe
   if (methods.includes('get')) {
     app.get('/:id', async (c) => {
       try {
-        const userId = getUserId(c);
+        const userId = LOCAL_OWNER_ID;
         const id = c.req.param('id');
         const service = getService();
 
@@ -304,7 +301,7 @@ export function createCrudRoutes<TService = unknown>(config: CrudRouteConfig<TSe
       }
 
       try {
-        const userId = getUserId(c);
+        const userId = LOCAL_OWNER_ID;
         const service = getService();
         const created = await callServiceMethod(service, createMethod, userId, validatedBody);
 
@@ -366,7 +363,7 @@ export function createCrudRoutes<TService = unknown>(config: CrudRouteConfig<TSe
       }
 
       try {
-        const userId = getUserId(c);
+        const userId = LOCAL_OWNER_ID;
         const id = c.req.param('id');
         const service = getService();
         const updated = await callServiceMethod(service, updateMethod, userId, id, validatedBody);
@@ -402,7 +399,7 @@ export function createCrudRoutes<TService = unknown>(config: CrudRouteConfig<TSe
   if (methods.includes('delete')) {
     app.delete('/:id', async (c) => {
       try {
-        const userId = getUserId(c);
+        const userId = LOCAL_OWNER_ID;
         const id = c.req.param('id');
         const service = getService();
         const deleted = await callServiceMethod(service, deleteMethod, userId, id);

--- a/packages/gateway/src/routes/custom-data.test.ts
+++ b/packages/gateway/src/routes/custom-data.test.ts
@@ -67,7 +67,8 @@ function createApp() {
   app.use('*', requestId);
   // Simulate authenticated session — required by IDOR-007 fix
   app.use('*', async (c, next) => {
-    c.set('userId', 'test-user');
+    c.set('userId', 'default');
+    c.set('sessionAuthenticated', true);
     return next();
   });
   app.route('/custom-data', customDataRoutes);

--- a/packages/gateway/src/routes/custom-data.ts
+++ b/packages/gateway/src/routes/custom-data.ts
@@ -7,12 +7,12 @@
  * All business logic is delegated to CustomDataService.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import {
   apiResponse,
   apiError,
   getIntParam,
-  getUserId,
   ERROR_CODES,
   notFoundError,
   getErrorMessage,
@@ -295,7 +295,7 @@ customDataRoutes.get('/tables/:table/search', async (c) => {
  */
 customDataRoutes.get('/records/:id', async (c) => {
   const recordId = c.req.param('id');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   if ((!userId || userId === 'default') && !c.get('sessionAuthenticated')) {
     return apiError(c, { code: ERROR_CODES.UNAUTHORIZED, message: 'Authentication required' }, 401);
   }
@@ -324,7 +324,7 @@ customDataRoutes.get('/records/:id', async (c) => {
  */
 customDataRoutes.put('/records/:id', async (c) => {
   const recordId = c.req.param('id');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   if ((!userId || userId === 'default') && !c.get('sessionAuthenticated')) {
     return apiError(c, { code: ERROR_CODES.UNAUTHORIZED, message: 'Authentication required' }, 401);
   }
@@ -385,7 +385,7 @@ customDataRoutes.put('/records/:id', async (c) => {
  */
 customDataRoutes.delete('/records/:id', async (c) => {
   const recordId = c.req.param('id');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   if ((!userId || userId === 'default') && !c.get('sessionAuthenticated')) {
     return apiError(c, { code: ERROR_CODES.UNAUTHORIZED, message: 'Authentication required' }, 401);
   }

--- a/packages/gateway/src/routes/custom-tools/approval.ts
+++ b/packages/gateway/src/routes/custom-tools/approval.ts
@@ -5,11 +5,12 @@
  * Endpoints: POST /:id/approve, POST /:id/reject
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import { createCustomToolsRepo } from '../../db/repositories/custom/tools.js';
 import { invalidateAgentCache } from '../agents/index.js';
 import { syncToolToRegistry } from '../../services/custom/tool-registry.js';
-import { getUserId, apiResponse, apiError, ERROR_CODES, notFoundError } from '../helpers.js';
+import { apiResponse, apiError, ERROR_CODES, notFoundError } from '../helpers.js';
 import { wsGateway } from '../../ws/server.js';
 
 export const approvalRoutes = new Hono();
@@ -19,7 +20,7 @@ export const approvalRoutes = new Hono();
  */
 approvalRoutes.post('/:id/approve', async (c) => {
   const id = c.req.param('id');
-  const repo = createCustomToolsRepo(getUserId(c));
+  const repo = createCustomToolsRepo(LOCAL_OWNER_ID);
 
   const tool = await repo.get(id);
   if (!tool) {
@@ -53,7 +54,7 @@ approvalRoutes.post('/:id/approve', async (c) => {
  */
 approvalRoutes.post('/:id/reject', async (c) => {
   const id = c.req.param('id');
-  const repo = createCustomToolsRepo(getUserId(c));
+  const repo = createCustomToolsRepo(LOCAL_OWNER_ID);
 
   const tool = await repo.get(id);
   if (!tool) {

--- a/packages/gateway/src/routes/custom-tools/crud.test.ts
+++ b/packages/gateway/src/routes/custom-tools/crud.test.ts
@@ -117,7 +117,7 @@ const { crudRoutes } = await import('./crud.js');
 // Sample data factories
 // ---------------------------------------------------------------------------
 
-const USER_ID = 'user-1';
+const USER_ID = 'default';
 
 function makeTool(overrides: Record<string, unknown> = {}) {
   return {

--- a/packages/gateway/src/routes/custom-tools/crud.ts
+++ b/packages/gateway/src/routes/custom-tools/crud.ts
@@ -8,6 +8,7 @@
  *   GET /active/definitions
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import {
   createCustomToolsRepo,
@@ -25,7 +26,6 @@ import {
   unregisterToolFromRegistries,
 } from '../../services/custom/tool-registry.js';
 import {
-  getUserId,
   apiResponse,
   apiError,
   ERROR_CODES,
@@ -48,7 +48,7 @@ export const crudRoutes = new Hono();
  * Get custom tools statistics
  */
 crudRoutes.get('/stats', async (c) => {
-  const repo = createCustomToolsRepo(getUserId(c));
+  const repo = createCustomToolsRepo(LOCAL_OWNER_ID);
   const stats = await repo.getStats();
 
   return apiResponse(c, stats);
@@ -58,7 +58,7 @@ crudRoutes.get('/stats', async (c) => {
  * List custom tools with filtering
  */
 crudRoutes.get('/', async (c) => {
-  const repo = createCustomToolsRepo(getUserId(c));
+  const repo = createCustomToolsRepo(LOCAL_OWNER_ID);
 
   const status = validateQueryEnum(c.req.query('status'), [
     'active',
@@ -83,7 +83,7 @@ crudRoutes.get('/', async (c) => {
  * Get pending approval tools
  */
 crudRoutes.get('/pending', async (c) => {
-  const repo = createCustomToolsRepo(getUserId(c));
+  const repo = createCustomToolsRepo(LOCAL_OWNER_ID);
   const tools = await repo.getPendingApproval();
 
   return apiResponse(c, {
@@ -126,7 +126,7 @@ crudRoutes.get('/templates', (c) => {
  */
 crudRoutes.get('/:id', async (c) => {
   const id = c.req.param('id');
-  const repo = createCustomToolsRepo(getUserId(c));
+  const repo = createCustomToolsRepo(LOCAL_OWNER_ID);
 
   const tool = await repo.get(id);
   if (!tool) {
@@ -168,7 +168,7 @@ crudRoutes.post('/', async (c) => {
     );
   }
 
-  const repo = createCustomToolsRepo(getUserId(c));
+  const repo = createCustomToolsRepo(LOCAL_OWNER_ID);
 
   // Check if tool name already exists
   const existing = await repo.getByName(body.name);
@@ -231,7 +231,7 @@ crudRoutes.patch('/:id', async (c) => {
     requiredApiKeys?: CustomToolRecord['requiredApiKeys'];
   };
 
-  const repo = createCustomToolsRepo(getUserId(c));
+  const repo = createCustomToolsRepo(LOCAL_OWNER_ID);
 
   // Validate code if provided (centralized validator)
   if (body.code) {
@@ -277,7 +277,7 @@ crudRoutes.patch('/:id', async (c) => {
  */
 crudRoutes.delete('/:id', async (c) => {
   const id = c.req.param('id');
-  const repo = createCustomToolsRepo(getUserId(c));
+  const repo = createCustomToolsRepo(LOCAL_OWNER_ID);
 
   // Get tool name for unregistering
   const tool = await repo.get(id);
@@ -319,7 +319,7 @@ crudRoutes.patch('/:id/workflow-usable', async (c) => {
     );
   }
 
-  const repo = createCustomToolsRepo(getUserId(c));
+  const repo = createCustomToolsRepo(LOCAL_OWNER_ID);
   const tool = await repo.get(id);
   if (!tool) {
     return notFoundError(c, 'Custom tool', id);
@@ -344,7 +344,7 @@ crudRoutes.patch('/:id/workflow-usable', async (c) => {
  */
 crudRoutes.post('/:id/enable', async (c) => {
   const id = c.req.param('id');
-  const repo = createCustomToolsRepo(getUserId(c));
+  const repo = createCustomToolsRepo(LOCAL_OWNER_ID);
 
   const tool = await repo.enable(id);
   if (!tool) {
@@ -366,7 +366,7 @@ crudRoutes.post('/:id/enable', async (c) => {
  */
 crudRoutes.post('/:id/disable', async (c) => {
   const id = c.req.param('id');
-  const repo = createCustomToolsRepo(getUserId(c));
+  const repo = createCustomToolsRepo(LOCAL_OWNER_ID);
 
   const tool = await repo.disable(id);
   if (!tool) {
@@ -423,7 +423,7 @@ crudRoutes.post('/templates/:templateId/create', async (c) => {
     );
   }
 
-  const repo = createCustomToolsRepo(getUserId(c));
+  const repo = createCustomToolsRepo(LOCAL_OWNER_ID);
 
   // Check duplicate
   const existing = await repo.getByName(toolName);
@@ -469,7 +469,7 @@ crudRoutes.post('/templates/:templateId/create', async (c) => {
  * Returns tools in a format suitable for LLM tool definitions
  */
 crudRoutes.get('/active/definitions', async (c) => {
-  const repo = createCustomToolsRepo(getUserId(c));
+  const repo = createCustomToolsRepo(LOCAL_OWNER_ID);
   const tools = await repo.getActiveTools();
 
   const definitions = tools.map((tool) => ({

--- a/packages/gateway/src/routes/custom-tools/generation.ts
+++ b/packages/gateway/src/routes/custom-tools/generation.ts
@@ -6,6 +6,7 @@
  * Exports: executeCustomToolTool, executeActiveCustomTool, getActiveCustomToolDefinitions
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import {
   createCustomToolsRepo,
@@ -23,7 +24,6 @@ import {
   executeCustomToolUnified,
 } from '../../services/custom/tool-registry.js';
 import {
-  getUserId,
   apiResponse,
   apiError,
   ERROR_CODES,
@@ -52,7 +52,7 @@ generationRoutes.post('/:id/execute', async (c) => {
     return apiError(c, { code: ERROR_CODES.INVALID_INPUT, message: 'Invalid JSON body' }, 400);
   }
 
-  const repo = createCustomToolsRepo(getUserId(c));
+  const repo = createCustomToolsRepo(LOCAL_OWNER_ID);
   const tool = await repo.get(id);
 
   if (!tool) {
@@ -87,7 +87,7 @@ generationRoutes.post('/:id/execute', async (c) => {
   try {
     const result = await executeCustomToolUnified(tool.name, body.arguments ?? {}, {
       conversationId: 'direct-execution',
-      userId: getUserId(c),
+      userId: LOCAL_OWNER_ID,
     });
     const duration = Date.now() - startTime;
 
@@ -129,7 +129,7 @@ generationRoutes.post('/:id/execute', async (c) => {
  */
 generationRoutes.get('/:id/executions', async (c) => {
   const id = c.req.param('id');
-  const repo = createCustomToolsRepo(getUserId(c));
+  const repo = createCustomToolsRepo(LOCAL_OWNER_ID);
 
   const tool = await repo.get(id);
   if (!tool) {
@@ -207,7 +207,7 @@ generationRoutes.post('/test', async (c) => {
     const result = await testRegistry.execute(body.name, body.testArguments ?? {}, {
       callId: `test_${Date.now()}`,
       conversationId: 'test-execution',
-      userId: getUserId(c),
+      userId: LOCAL_OWNER_ID,
     });
     const duration = Date.now() - startTime;
 

--- a/packages/gateway/src/routes/dashboard.ts
+++ b/packages/gateway/src/routes/dashboard.ts
@@ -4,17 +4,11 @@
  * API endpoints for the AI-powered daily briefing dashboard
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { DashboardService, briefingCache, type AIBriefing } from '../services/dashboard/index.js';
 import { getLog } from '../services/log.js';
-import {
-  getUserId,
-  apiResponse,
-  apiError,
-  ERROR_CODES,
-  getErrorMessage,
-  parseJsonBody,
-} from './helpers.js';
+import { apiResponse, apiError, ERROR_CODES, getErrorMessage, parseJsonBody } from './helpers.js';
 import { getDefaultProvider, getDefaultModel } from './settings.js';
 
 const log = getLog('Dashboard');
@@ -31,7 +25,7 @@ export const dashboardRoutes = new Hono();
  * - model: string - Override AI model (uses configured default)
  */
 dashboardRoutes.get('/briefing', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const forceRefresh = c.req.query('refresh') === 'true';
   const aiOnly = c.req.query('aiOnly') === 'true';
   const queryProvider = c.req.query('provider');
@@ -85,7 +79,7 @@ dashboardRoutes.get('/briefing', async (c) => {
  * GET /data - Get raw briefing data without AI summary
  */
 dashboardRoutes.get('/data', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const service = new DashboardService(userId);
 
   try {
@@ -110,7 +104,7 @@ dashboardRoutes.get('/data', async (c) => {
  * POST /briefing/refresh - Force refresh the AI briefing
  */
 dashboardRoutes.post('/briefing/refresh', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = await c.req
     .json<{ provider?: string; model?: string }>()
     .catch(() => ({ provider: undefined, model: undefined }));
@@ -150,7 +144,7 @@ dashboardRoutes.post('/briefing/refresh', async (c) => {
  * GET /timeline - Get today's timeline view
  */
 dashboardRoutes.get('/timeline', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const service = new DashboardService(userId);
 
   try {
@@ -234,7 +228,7 @@ dashboardRoutes.get('/timeline', async (c) => {
  * - model: string - AI model (uses configured default)
  */
 dashboardRoutes.post('/briefing/stream', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = (await parseJsonBody<{ provider?: string; model?: string }>(c)) ?? {};
   const provider = body.provider ?? (await getDefaultProvider());
   if (!provider) {
@@ -310,7 +304,7 @@ dashboardRoutes.post('/briefing/stream', async (c) => {
  * DELETE /briefing/cache - Clear the briefing cache
  */
 dashboardRoutes.delete('/briefing/cache', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   briefingCache.invalidate(userId);
 
   return apiResponse(c, { cleared: true });

--- a/packages/gateway/src/routes/edge.test.ts
+++ b/packages/gateway/src/routes/edge.test.ts
@@ -56,7 +56,7 @@ import { errorHandler } from '../middleware/error-handler.js';
 
 const sampleDevice = {
   id: 'dev-1',
-  userId: 'user-1',
+  userId: 'default',
   name: 'My Pi',
   type: 'raspberry-pi',
   status: 'online',
@@ -83,7 +83,7 @@ const sampleTelemetry = [
 function buildApp() {
   const app = new Hono();
   app.use('*', async (c, next) => {
-    c.set('userId', 'user-1');
+    c.set('userId', 'default');
     await next();
   });
   app.route('/edge', edgeRoutes);
@@ -161,7 +161,7 @@ describe('Edge Routes', () => {
       await app.request('/edge?type=esp32');
 
       expect(mockEdgeService.listDevices).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         expect.objectContaining({ type: 'esp32' })
       );
     });
@@ -172,7 +172,7 @@ describe('Edge Routes', () => {
       await app.request('/edge?status=offline');
 
       expect(mockEdgeService.listDevices).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         expect.objectContaining({ status: 'offline' })
       );
     });
@@ -183,7 +183,7 @@ describe('Edge Routes', () => {
       await app.request('/edge?search=Pi');
 
       expect(mockEdgeService.listDevices).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         expect.objectContaining({ search: 'Pi' })
       );
     });
@@ -194,7 +194,7 @@ describe('Edge Routes', () => {
       await app.request('/edge?type=invalid-type');
 
       expect(mockEdgeService.listDevices).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         expect.objectContaining({ type: undefined })
       );
     });
@@ -205,7 +205,7 @@ describe('Edge Routes', () => {
       await app.request('/edge?status=broken');
 
       expect(mockEdgeService.listDevices).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         expect.objectContaining({ status: undefined })
       );
     });
@@ -257,7 +257,7 @@ describe('Edge Routes', () => {
       });
 
       expect(mockEdgeService.registerDevice).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         expect.objectContaining({
           name: 'Arduino',
           type: 'arduino',
@@ -330,7 +330,7 @@ describe('Edge Routes', () => {
 
       // Zod strips unknown fields; only name, type, and metadata are passed through
       expect(mockEdgeService.registerDevice).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         expect.objectContaining({ name: 'My Pi', type: 'raspberry-pi' })
       );
     });
@@ -415,7 +415,7 @@ describe('Edge Routes', () => {
       });
 
       expect(mockEdgeService.updateDevice).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         'dev-1',
         expect.objectContaining({
           name: 'Updated',
@@ -584,7 +584,7 @@ describe('Edge Routes', () => {
       });
 
       expect(mockEdgeService.sendCommand).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         'dev-1',
         expect.objectContaining({ payload })
       );
@@ -614,7 +614,7 @@ describe('Edge Routes', () => {
 
       await app.request('/edge/dev-1/commands?limit=10');
 
-      expect(mockEdgeService.getCommandHistory).toHaveBeenCalledWith('user-1', 'dev-1', 10);
+      expect(mockEdgeService.getCommandHistory).toHaveBeenCalledWith('default', 'dev-1', 10);
     });
 
     it('uses default limit of 50 when not specified', async () => {
@@ -622,7 +622,7 @@ describe('Edge Routes', () => {
 
       await app.request('/edge/dev-1/commands');
 
-      expect(mockEdgeService.getCommandHistory).toHaveBeenCalledWith('user-1', 'dev-1', 50);
+      expect(mockEdgeService.getCommandHistory).toHaveBeenCalledWith('default', 'dev-1', 50);
     });
 
     it('returns 500 when service throws', async () => {
@@ -658,7 +658,7 @@ describe('Edge Routes', () => {
 
       await app.request('/edge/dev-1/telemetry');
 
-      expect(mockEdgeService.getLatestTelemetry).toHaveBeenCalledWith('user-1', 'dev-1');
+      expect(mockEdgeService.getLatestTelemetry).toHaveBeenCalledWith('default', 'dev-1');
     });
 
     it('returns empty telemetry array when no data', async () => {
@@ -706,7 +706,7 @@ describe('Edge Routes', () => {
       await app.request('/edge/dev-1/telemetry/humidity');
 
       expect(mockEdgeService.getTelemetryHistory).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         'dev-1',
         'humidity',
         100
@@ -719,7 +719,7 @@ describe('Edge Routes', () => {
       await app.request('/edge/dev-1/telemetry/temp?limit=25');
 
       expect(mockEdgeService.getTelemetryHistory).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         'dev-1',
         'temp',
         25

--- a/packages/gateway/src/routes/edge.ts
+++ b/packages/gateway/src/routes/edge.ts
@@ -4,13 +4,13 @@
  * REST API for managing IoT/edge devices, commands, and telemetry.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import type { EdgeDeviceType, EdgeDeviceStatus, UpdateDeviceInput } from '@ownpilot/core';
 import { getEdgeService } from '../services/edge/service.js';
 import { getEdgeMqttClient } from '../services/edge/mqtt-client.js';
 import { createCircuitBreakerMiddleware } from '../middleware/circuit-breaker.js';
 import {
-  getUserId,
   apiResponse,
   apiError,
   ERROR_CODES,
@@ -63,7 +63,7 @@ edgeRoutes.get('/mqtt/status', (c) => {
 
 edgeRoutes.get('/', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { limit, offset } = getPaginationParams(c);
     const type = validateQueryEnum(c.req.query('type'), VALID_TYPES) as EdgeDeviceType | undefined;
     const status = validateQueryEnum(c.req.query('status'), VALID_STATUSES) as
@@ -92,7 +92,7 @@ edgeRoutes.get('/', async (c) => {
 
 edgeRoutes.post('/', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const body = validateBody(createEdgeDeviceSchema, await c.req.json());
 
     const service = getEdgeService();
@@ -116,7 +116,7 @@ edgeRoutes.post('/', async (c) => {
 
 edgeRoutes.get('/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = sanitizeId(c.req.param('id'));
 
     const service = getEdgeService();
@@ -135,7 +135,7 @@ edgeRoutes.get('/:id', async (c) => {
 
 edgeRoutes.patch('/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = sanitizeId(c.req.param('id'));
     const body = validateBody(updateEdgeDeviceSchema, await c.req.json());
 
@@ -165,7 +165,7 @@ edgeRoutes.patch('/:id', async (c) => {
 
 edgeRoutes.delete('/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = sanitizeId(c.req.param('id'));
 
     const service = getEdgeService();
@@ -185,7 +185,7 @@ edgeRoutes.delete('/:id', async (c) => {
 edgeRoutes.post('/:id/command', async (c) => {
   const id = sanitizeId(c.req.param('id'));
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const body = validateBody(edgeDeviceCommandSchema, await c.req.json());
     const commandType = body.commandType;
 
@@ -212,7 +212,7 @@ edgeRoutes.post('/:id/command', async (c) => {
 
 edgeRoutes.get('/:id/commands', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = sanitizeId(c.req.param('id'));
     const limit = getIntParam(c, 'limit', 50, 1, 200);
 
@@ -231,7 +231,7 @@ edgeRoutes.get('/:id/commands', async (c) => {
 
 edgeRoutes.get('/:id/telemetry', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = sanitizeId(c.req.param('id'));
 
     const service = getEdgeService();
@@ -249,7 +249,7 @@ edgeRoutes.get('/:id/telemetry', async (c) => {
 
 edgeRoutes.get('/:id/telemetry/:sensorId', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = sanitizeId(c.req.param('id'));
     const sensorId = sanitizeId(c.req.param('sensorId'));
     const limit = getIntParam(c, 'limit', 100, 1, 500);

--- a/packages/gateway/src/routes/execution-permissions.test.ts
+++ b/packages/gateway/src/routes/execution-permissions.test.ts
@@ -30,21 +30,13 @@ const mockResolveApproval = vi.fn(
     decision: { approved: boolean; decidedBy: string; decidedAt: number };
   } => ({
     ok: true,
-    decision: { approved: true, decidedBy: 'test-user', decidedAt: Date.now() },
+    decision: { approved: true, decidedBy: 'default', decidedAt: Date.now() },
   })
 );
 
 vi.mock('../services/permission/execution-approval.js', () => ({
   resolveApproval: mockResolveApproval,
 }));
-
-vi.mock('./helpers.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('./helpers.js')>();
-  return {
-    ...actual,
-    getUserId: vi.fn(() => 'test-user'),
-  };
-});
 
 // Import after mocks
 const { executionPermissionsRoutes } = await import('./execution-permissions.js');
@@ -115,7 +107,7 @@ describe('Execution Permissions Routes', () => {
       expect(json.data.execute_javascript).toBe('allowed');
       expect(json.data.execute_python).toBe('prompt');
       expect(json.data.execute_shell).toBe('blocked');
-      expect(mockRepo.get).toHaveBeenCalledWith('test-user');
+      expect(mockRepo.get).toHaveBeenCalledWith('default');
     });
 
     it('returns default object when repo returns defaults', async () => {
@@ -155,7 +147,7 @@ describe('Execution Permissions Routes', () => {
       const json = await res.json();
       expect(json.success).toBe(true);
       expect(json.data.enabled).toBe(true);
-      expect(mockRepo.set).toHaveBeenCalledWith('test-user', { enabled: true });
+      expect(mockRepo.set).toHaveBeenCalledWith('default', { enabled: true });
     });
 
     it('updates mode to local', async () => {
@@ -171,7 +163,7 @@ describe('Execution Permissions Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.data.mode).toBe('local');
-      expect(mockRepo.set).toHaveBeenCalledWith('test-user', { mode: 'local' });
+      expect(mockRepo.set).toHaveBeenCalledWith('default', { mode: 'local' });
     });
 
     it('updates mode to docker', async () => {
@@ -187,7 +179,7 @@ describe('Execution Permissions Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.data.mode).toBe('docker');
-      expect(mockRepo.set).toHaveBeenCalledWith('test-user', { mode: 'docker' });
+      expect(mockRepo.set).toHaveBeenCalledWith('default', { mode: 'docker' });
     });
 
     it('updates mode to auto', async () => {
@@ -203,7 +195,7 @@ describe('Execution Permissions Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.data.mode).toBe('auto');
-      expect(mockRepo.set).toHaveBeenCalledWith('test-user', { mode: 'auto' });
+      expect(mockRepo.set).toHaveBeenCalledWith('default', { mode: 'auto' });
     });
 
     it('updates execute_javascript category permission', async () => {
@@ -219,7 +211,7 @@ describe('Execution Permissions Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.data.execute_javascript).toBe('allowed');
-      expect(mockRepo.set).toHaveBeenCalledWith('test-user', { execute_javascript: 'allowed' });
+      expect(mockRepo.set).toHaveBeenCalledWith('default', { execute_javascript: 'allowed' });
     });
 
     it('updates execute_python category permission', async () => {
@@ -235,7 +227,7 @@ describe('Execution Permissions Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.data.execute_python).toBe('prompt');
-      expect(mockRepo.set).toHaveBeenCalledWith('test-user', { execute_python: 'prompt' });
+      expect(mockRepo.set).toHaveBeenCalledWith('default', { execute_python: 'prompt' });
     });
 
     it('updates execute_shell category permission', async () => {
@@ -251,7 +243,7 @@ describe('Execution Permissions Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.data.execute_shell).toBe('blocked');
-      expect(mockRepo.set).toHaveBeenCalledWith('test-user', { execute_shell: 'blocked' });
+      expect(mockRepo.set).toHaveBeenCalledWith('default', { execute_shell: 'blocked' });
     });
 
     it('updates compile_code category permission', async () => {
@@ -267,7 +259,7 @@ describe('Execution Permissions Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.data.compile_code).toBe('allowed');
-      expect(mockRepo.set).toHaveBeenCalledWith('test-user', { compile_code: 'allowed' });
+      expect(mockRepo.set).toHaveBeenCalledWith('default', { compile_code: 'allowed' });
     });
 
     it('updates package_manager category permission', async () => {
@@ -283,7 +275,7 @@ describe('Execution Permissions Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.data.package_manager).toBe('prompt');
-      expect(mockRepo.set).toHaveBeenCalledWith('test-user', { package_manager: 'prompt' });
+      expect(mockRepo.set).toHaveBeenCalledWith('default', { package_manager: 'prompt' });
     });
 
     it('updates multiple fields at once', async () => {
@@ -316,7 +308,7 @@ describe('Execution Permissions Routes', () => {
       expect(json.data.execute_python).toBe('prompt');
 
       const setCall = mockRepo.set.mock.calls[0];
-      expect(setCall[0]).toBe('test-user');
+      expect(setCall[0]).toBe('default');
       expect(setCall[1]).toMatchObject({
         enabled: true,
         mode: 'docker',
@@ -428,7 +420,7 @@ describe('Execution Permissions Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.success).toBe(true);
-      expect(mockRepo.set).toHaveBeenCalledWith('test-user', { enabled: true });
+      expect(mockRepo.set).toHaveBeenCalledWith('default', { enabled: true });
     });
 
     it('ignores non-string category values', async () => {
@@ -459,7 +451,7 @@ describe('Execution Permissions Routes', () => {
       const json = await res.json();
       expect(json.success).toBe(true);
       expect(json.data.reset).toBe(true);
-      expect(mockRepo.reset).toHaveBeenCalledWith('test-user');
+      expect(mockRepo.reset).toHaveBeenCalledWith('default');
     });
   });
 
@@ -471,7 +463,7 @@ describe('Execution Permissions Routes', () => {
     it('resolves approval when found (approved)', async () => {
       mockResolveApproval.mockReturnValueOnce({
         ok: true,
-        decision: { approved: true, decidedBy: 'test-user', decidedAt: 1234 },
+        decision: { approved: true, decidedBy: 'default', decidedAt: 1234 },
       });
 
       const res = await app.request('/exec/approvals/approval-123/resolve', {
@@ -485,13 +477,13 @@ describe('Execution Permissions Routes', () => {
       expect(json.success).toBe(true);
       expect(json.data.resolved).toBe(true);
       expect(json.data.approved).toBe(true);
-      expect(mockResolveApproval).toHaveBeenCalledWith('approval-123', true, 'test-user');
+      expect(mockResolveApproval).toHaveBeenCalledWith('approval-123', true, 'default');
     });
 
     it('resolves approval when found (rejected)', async () => {
       mockResolveApproval.mockReturnValueOnce({
         ok: true,
-        decision: { approved: false, decidedBy: 'test-user', decidedAt: 1234 },
+        decision: { approved: false, decidedBy: 'default', decidedAt: 1234 },
       });
 
       const res = await app.request('/exec/approvals/approval-456/resolve', {
@@ -505,7 +497,7 @@ describe('Execution Permissions Routes', () => {
       expect(json.success).toBe(true);
       expect(json.data.resolved).toBe(true);
       expect(json.data.approved).toBe(false);
-      expect(mockResolveApproval).toHaveBeenCalledWith('approval-456', false, 'test-user');
+      expect(mockResolveApproval).toHaveBeenCalledWith('approval-456', false, 'default');
     });
 
     it('returns 404 when approval not found', async () => {
@@ -600,13 +592,13 @@ describe('Execution Permissions Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.success).toBe(true);
-      expect(json.data.userId).toBe('test-user');
+      expect(json.data.userId).toBe('default');
       expect(json.data.permissions).toBeDefined();
       expect(json.data.executionMode).toBe('local');
       expect(json.data.masterSwitch).toBe(true);
       expect(json.data.categoryResults).toBeDefined();
       expect(json.data.diagnosis).toBeDefined();
-      expect(mockRepo.get).toHaveBeenCalledWith('test-user');
+      expect(mockRepo.get).toHaveBeenCalledWith('default');
     });
 
     it('shows "Master switch is OFF" when disabled', async () => {

--- a/packages/gateway/src/routes/execution-permissions.ts
+++ b/packages/gateway/src/routes/execution-permissions.ts
@@ -5,10 +5,11 @@
  * Also handles resolving real-time approval requests.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { executionPermissionsRepo } from '../db/repositories/execution-permissions.js';
 import { resolveApproval } from '../services/permission/execution-approval.js';
-import { apiResponse, apiError, getUserId, ERROR_CODES, notFoundError } from './helpers.js';
+import { apiResponse, apiError, ERROR_CODES, notFoundError } from './helpers.js';
 import type { ExecutionPermissions, PermissionMode } from '@ownpilot/core';
 
 const VALID_PERM_MODES: ReadonlySet<string> = new Set(['blocked', 'prompt', 'allowed']);
@@ -27,7 +28,7 @@ const app = new Hono();
  * GET / — Get current execution permissions
  */
 app.get('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const permissions = await executionPermissionsRepo.get(userId);
   return apiResponse(c, permissions);
 });
@@ -36,7 +37,7 @@ app.get('/', async (c) => {
  * PUT / — Update execution permissions (partial merge)
  */
 app.put('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = await c.req.json<Record<string, unknown>>();
 
   // Validate: accept enabled (boolean), mode (string), and category permissions
@@ -72,7 +73,7 @@ app.put('/', async (c) => {
  * POST /reset — Reset permissions to all-blocked defaults
  */
 app.post('/reset', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   await executionPermissionsRepo.reset(userId);
   return apiResponse(c, { reset: true });
 });
@@ -83,7 +84,7 @@ app.post('/reset', async (c) => {
 app.post('/approvals/:id/resolve', async (c) => {
   const approvalId = c.req.param('id');
   const body = await c.req.json<{ approved: boolean }>();
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   if (typeof body.approved !== 'boolean') {
     return apiError(
@@ -124,7 +125,7 @@ app.post('/approvals/:id/resolve', async (c) => {
  * Returns what would happen for each category without actually executing any code.
  */
 app.get('/test', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const permissions = await executionPermissionsRepo.get(userId);
 
   const categories = [

--- a/packages/gateway/src/routes/expenses.ts
+++ b/packages/gateway/src/routes/expenses.ts
@@ -5,6 +5,7 @@
  * Backed by PostgreSQL via ExpensesRepository (migrated from file-based JSON).
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import {
   apiResponse,
@@ -14,7 +15,6 @@ import {
   ERROR_CODES,
   getErrorMessage,
   parseJsonBody,
-  getUserId,
 } from './helpers.js';
 import { wsGateway } from '../ws/server.js';
 import { pagination } from '../middleware/pagination.js';
@@ -112,7 +112,7 @@ export const expensesRoutes = new Hono();
  */
 expensesRoutes.get('/', pagination({ defaultLimit: 100, maxLimit: 1000 }), async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const repo = new ExpensesRepository(userId);
     const { limit, offset } = c.get('pagination')!;
 
@@ -150,7 +150,7 @@ expensesRoutes.get('/', pagination({ defaultLimit: 100, maxLimit: 1000 }), async
  */
 expensesRoutes.get('/summary', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const repo = new ExpensesRepository(userId);
 
     const period = c.req.query('period') ?? 'this_month';
@@ -209,7 +209,7 @@ expensesRoutes.get('/summary', async (c) => {
  */
 expensesRoutes.get('/monthly', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const repo = new ExpensesRepository(userId);
     const year = c.req.query('year') ?? String(new Date().getFullYear());
 
@@ -250,7 +250,7 @@ expensesRoutes.get('/monthly', async (c) => {
  */
 expensesRoutes.get('/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const repo = new ExpensesRepository(userId);
     const expense = await repo.get(c.req.param('id'));
     if (!expense) return notFoundError(c, 'Expense', c.req.param('id'));
@@ -265,7 +265,7 @@ expensesRoutes.get('/:id', async (c) => {
  */
 expensesRoutes.post('/', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const repo = new ExpensesRepository(userId);
     const body = await parseJsonBody(c);
     if (!body)
@@ -309,7 +309,7 @@ expensesRoutes.post('/', async (c) => {
  */
 expensesRoutes.put('/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const repo = new ExpensesRepository(userId);
     const body = await parseJsonBody(c);
     if (!body)
@@ -333,7 +333,7 @@ expensesRoutes.put('/:id', async (c) => {
  */
 expensesRoutes.delete('/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const repo = new ExpensesRepository(userId);
     const id = c.req.param('id');
     const deleted = await repo.delete(id);

--- a/packages/gateway/src/routes/extensions/audit.test.ts
+++ b/packages/gateway/src/routes/extensions/audit.test.ts
@@ -88,7 +88,7 @@ const { parseLlmAuditResponse } = await import('../../services/skill/security-au
 function createApp() {
   const app = new Hono();
   app.use('*', async (c, next) => {
-    c.set('userId', 'user-1');
+    c.set('userId', 'default');
     await next();
   });
   app.route('/ext', auditRoutes);
@@ -105,7 +105,7 @@ function makeRequest(app: Hono, path: string, body?: Record<string, unknown>): P
 }
 
 /** Minimal ExtensionRecord stub for a given userId */
-function makeExtRecord(userId = 'user-1') {
+function makeExtRecord(userId = 'default') {
   return {
     id: 'ext-1',
     userId,

--- a/packages/gateway/src/routes/extensions/audit.ts
+++ b/packages/gateway/src/routes/extensions/audit.ts
@@ -8,6 +8,7 @@
  * POST /audit-manifest   — Audit a manifest before installation
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import {
   createProvider,
@@ -24,7 +25,6 @@ import {
   type SkillLlmAuditResult,
 } from '../../services/skill/security-audit.js';
 import {
-  getUserId,
   apiResponse,
   apiError,
   ERROR_CODES,
@@ -61,7 +61,7 @@ const getExtService = () => getExtensionService() as unknown as ExtensionService
 // =============================================================================
 
 auditRoutes.post('/:id/audit', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getExtService();

--- a/packages/gateway/src/routes/extensions/crud.test.ts
+++ b/packages/gateway/src/routes/extensions/crud.test.ts
@@ -57,7 +57,7 @@ const { crudRoutes } = await import('./crud.js');
 // App setup
 // ---------------------------------------------------------------------------
 
-const USER_ID = 'user-1';
+const USER_ID = 'default';
 
 function createApp() {
   const app = new Hono();

--- a/packages/gateway/src/routes/extensions/crud.ts
+++ b/packages/gateway/src/routes/extensions/crud.ts
@@ -5,11 +5,11 @@
  * POST /:id/enable, POST /:id/disable, POST /:id/reload
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono, type Context } from 'hono';
 import { getExtensionService } from '@ownpilot/core';
 import { type ExtensionService, ExtensionError } from '../../services/extension/service.js';
 import {
-  getUserId,
   apiResponse,
   apiError,
   ERROR_CODES,
@@ -28,7 +28,7 @@ export const crudRoutes = new Hono();
 const getExtService = () => getExtensionService() as unknown as ExtensionService;
 
 async function uninstallExtension(c: Context) {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   if (!id) {
@@ -66,7 +66,7 @@ async function uninstallExtension(c: Context) {
  * GET / - List extensions
  */
 crudRoutes.get('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const status = c.req.query('status');
   const category = c.req.query('category');
   const format = c.req.query('format'); // 'ownpilot' | 'agentskills'
@@ -102,7 +102,7 @@ crudRoutes.get('/gate-status', async (c) => {
  * POST / - Install from inline manifest
  */
 crudRoutes.post('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = await parseJsonBody(c);
 
   if (!body || !(body as { manifest?: unknown }).manifest) {
@@ -145,7 +145,7 @@ crudRoutes.post('/', async (c) => {
  * GET /:id - Get package details
  */
 crudRoutes.get('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getExtService();
@@ -175,7 +175,7 @@ crudRoutes.post('/:id/remove', async (c) => uninstallExtension(c));
  * PATCH /:id - Update extension metadata (name, description, version)
  */
 crudRoutes.patch('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getExtService();
@@ -252,7 +252,7 @@ crudRoutes.patch('/:id', async (c) => {
  * POST /:id/enable - Enable package + triggers
  */
 crudRoutes.post('/:id/enable', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   try {
@@ -288,7 +288,7 @@ crudRoutes.post('/:id/enable', async (c) => {
  * POST /:id/disable - Disable package + triggers
  */
 crudRoutes.post('/:id/disable', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   try {
@@ -324,7 +324,7 @@ crudRoutes.post('/:id/disable', async (c) => {
  * POST /:id/recover - Recover from error status
  */
 crudRoutes.post('/:id/recover', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   try {
@@ -356,7 +356,7 @@ crudRoutes.post('/:id/recover', async (c) => {
  * POST /:id/reload - Reload manifest from disk
  */
 crudRoutes.post('/:id/reload', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   try {

--- a/packages/gateway/src/routes/extensions/eval.test.ts
+++ b/packages/gateway/src/routes/extensions/eval.test.ts
@@ -56,7 +56,7 @@ const { evalRoutes } = await import('./eval.js');
 // App setup
 // ---------------------------------------------------------------------------
 
-const USER_ID = 'user-1';
+const USER_ID = 'default';
 
 function createApp() {
   const app = new Hono();

--- a/packages/gateway/src/routes/extensions/eval.ts
+++ b/packages/gateway/src/routes/extensions/eval.ts
@@ -6,6 +6,7 @@
  * POST /:id/eval/optimize-description — Generate and score alternative descriptions
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import {
   createProvider,
@@ -15,7 +16,6 @@ import {
 } from '@ownpilot/core';
 import type { ExtensionService } from '../../services/extension/service.js';
 import {
-  getUserId,
   apiResponse,
   apiError,
   ERROR_CODES,
@@ -86,7 +86,7 @@ async function buildProvider(providerOverride?: string, modelOverride?: string) 
 // ---------------------------------------------------------------------------
 
 evalRoutes.post('/:id/eval/run', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getExtService();
@@ -148,7 +148,7 @@ evalRoutes.post('/:id/eval/run', async (c) => {
 // ---------------------------------------------------------------------------
 
 evalRoutes.post('/:id/eval/grade', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getExtService();
@@ -223,7 +223,7 @@ Return ONLY valid JSON: {"score": 0.85, "passed": true, "feedback": "Brief expla
 // ---------------------------------------------------------------------------
 
 evalRoutes.post('/:id/eval/optimize-description', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getExtService();

--- a/packages/gateway/src/routes/extensions/files.test.ts
+++ b/packages/gateway/src/routes/extensions/files.test.ts
@@ -67,7 +67,7 @@ const { fileRoutes } = await import('./files.js');
 // App setup
 // ---------------------------------------------------------------------------
 
-const USER_ID = 'user-test';
+const USER_ID = 'default';
 const SKILL_DIR = resolve('/skills/my-skill');
 const MANIFEST = 'SKILL.md';
 const SOURCE_PATH = join(SKILL_DIR, MANIFEST);

--- a/packages/gateway/src/routes/extensions/files.ts
+++ b/packages/gateway/src/routes/extensions/files.ts
@@ -7,6 +7,7 @@
  * DELETE /:id/files/*path  — Delete a file
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import {
   existsSync,
   readFileSync,
@@ -21,14 +22,7 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { getExtensionService } from '@ownpilot/core';
 import type { ExtensionService } from '../../services/extension/service.js';
-import {
-  getUserId,
-  apiResponse,
-  apiError,
-  ERROR_CODES,
-  notFoundError,
-  getErrorMessage,
-} from '../helpers.js';
+import { apiResponse, apiError, ERROR_CODES, notFoundError, getErrorMessage } from '../helpers.js';
 import { isWithinDirectory } from '../../utils/file-safety.js';
 import { validateBody } from '../../middleware/validation.js';
 
@@ -109,7 +103,7 @@ function scanDir(dir: string, basePath: string, depth = 0): FileEntry[] {
  * GET /:id/files — List all files in the skill directory as a tree
  */
 fileRoutes.get('/:id/files', (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getExtService();
@@ -144,7 +138,7 @@ fileRoutes.get('/:id/files', (c) => {
  * GET /:id/files/* — Read a single file
  */
 fileRoutes.get('/:id/files/:path{.+}', (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const filePath = c.req.param('path');
 
@@ -219,7 +213,7 @@ fileRoutes.get('/:id/files/:path{.+}', (c) => {
  * PUT /:id/files/* — Write/create a file
  */
 fileRoutes.put('/:id/files/:path{.+}', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const filePath = c.req.param('path');
 
@@ -285,7 +279,7 @@ fileRoutes.put('/:id/files/:path{.+}', async (c) => {
  * DELETE /:id/files/* — Delete a file
  */
 fileRoutes.delete('/:id/files/:path{.+}', (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const filePath = c.req.param('path');
 

--- a/packages/gateway/src/routes/extensions/install.ts
+++ b/packages/gateway/src/routes/extensions/install.ts
@@ -4,20 +4,14 @@
  * POST /install, POST /upload
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { writeFileSync, mkdirSync, existsSync, rmSync, readdirSync } from 'node:fs';
 import { dirname, extname, join } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import { Hono, type Context } from 'hono';
 import { getExtensionService } from '@ownpilot/core';
 import { type ExtensionService, ExtensionError } from '../../services/extension/service.js';
-import {
-  getUserId,
-  apiResponse,
-  apiError,
-  ERROR_CODES,
-  getErrorMessage,
-  parseJsonBody,
-} from '../helpers.js';
+import { apiResponse, apiError, ERROR_CODES, getErrorMessage, parseJsonBody } from '../helpers.js';
 import { wsGateway } from '../../ws/server.js';
 import { getDataDirectoryInfo } from '../../paths/index.js';
 import {
@@ -170,7 +164,7 @@ function findManifestInDir(dir: string): string | null {
  * POST /install - Install from file path
  */
 installRoutes.post('/install', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const throttled = checkInstallThrottle(c);
   if (throttled) return throttled;
   const body = await parseJsonBody(c);
@@ -237,7 +231,7 @@ installRoutes.post('/install', async (c) => {
  * POST /upload - Upload extension file (single .md/.json or .zip)
  */
 installRoutes.post('/upload', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const throttled = checkInstallThrottle(c);
   if (throttled) return throttled;
 

--- a/packages/gateway/src/routes/extensions/integration.test.ts
+++ b/packages/gateway/src/routes/extensions/integration.test.ts
@@ -672,20 +672,24 @@ describe('Extensions Routes', () => {
       expect(json.data.total).toBe(1);
     });
 
-    it('GET / as different user sees only their extensions', async () => {
+    it('GET / lists only local-owner extensions, filtering out other userIds', async () => {
+      // Single-tenant: every request resolves to LOCAL_OWNER_ID ('default'),
+      // and the route filters getAll() by that owner. Records carrying any
+      // other userId (e.g. legacy rows) must be excluded.
       const otherUserRecord = { ...sampleRecord, id: 'other-ext', userId: 'user-2' };
       mockService.getAll.mockReturnValue([sampleRecord, otherUserRecord]);
 
-      const user2App = createApp('user-2');
-      const res = await user2App.request('/extensions');
+      const res = await app.request('/extensions');
       const json = await res.json();
       expect(json.data.packages).toHaveLength(1);
-      expect(json.data.packages[0].id).toBe('other-ext');
+      expect(json.data.packages[0].id).toBe('test-ext');
     });
 
-    it("GET /:id returns 404 for another user's extension", async () => {
-      const user2App = createApp('user-2');
-      const res = await user2App.request('/extensions/test-ext');
+    it('GET /:id returns 404 for an extension owned by a non-local userId', async () => {
+      // The residual ownership guard (pkg.userId !== LOCAL_OWNER_ID) still 404s
+      // rows that are not owned by the local owner.
+      mockService.getById.mockReturnValue({ ...sampleRecord, userId: 'user-2' });
+      const res = await app.request('/extensions/test-ext');
       expect(res.status).toBe(404);
     });
 

--- a/packages/gateway/src/routes/extensions/packaging-sourcepath.test.ts
+++ b/packages/gateway/src/routes/extensions/packaging-sourcepath.test.ts
@@ -63,7 +63,7 @@ const { packagingRoutes } = await import('./packaging.js');
 // App setup
 // ---------------------------------------------------------------------------
 
-const USER_ID = 'user-1';
+const USER_ID = 'default';
 
 function createApp() {
   const app = new Hono();

--- a/packages/gateway/src/routes/extensions/packaging.test.ts
+++ b/packages/gateway/src/routes/extensions/packaging.test.ts
@@ -35,7 +35,7 @@ const { packagingRoutes } = await import('./packaging.js');
 // App setup
 // ---------------------------------------------------------------------------
 
-const USER_ID = 'user-1';
+const USER_ID = 'default';
 
 function createApp() {
   const app = new Hono();

--- a/packages/gateway/src/routes/extensions/packaging.ts
+++ b/packages/gateway/src/routes/extensions/packaging.ts
@@ -4,12 +4,13 @@
  * GET /:id/package — Download extension as .skill ZIP file
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { existsSync, readdirSync } from 'node:fs';
 import { join, basename, dirname } from 'node:path';
 import { Hono } from 'hono';
 import { getExtensionService } from '@ownpilot/core';
 import type { ExtensionService } from '../../services/extension/service.js';
-import { getUserId, apiError, ERROR_CODES, notFoundError, getErrorMessage } from '../helpers.js';
+import { apiError, ERROR_CODES, notFoundError, getErrorMessage } from '../helpers.js';
 import { getLog } from '../../services/log.js';
 import { attachmentDisposition, sanitizeFilenameSegment } from '../../utils/file-safety.js';
 
@@ -23,7 +24,7 @@ const getExtService = () => getExtensionService() as unknown as ExtensionService
  * GET /:id/package — Download .skill ZIP
  */
 packagingRoutes.get('/:id/package', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getExtService();

--- a/packages/gateway/src/routes/extensions/scanner.test.ts
+++ b/packages/gateway/src/routes/extensions/scanner.test.ts
@@ -34,7 +34,7 @@ const { scannerRoutes } = await import('./scanner.js');
 function createApp() {
   const app = new Hono();
   app.use('*', async (c, next) => {
-    c.set('userId', 'user-1');
+    c.set('userId', 'default');
     await next();
   });
   app.route('/extensions', scannerRoutes);
@@ -80,7 +80,7 @@ describe('Extensions Scanner Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.data).toEqual(scanResult);
-      expect(mockScanDirectory).toHaveBeenCalledWith('/tmp/packages', 'user-1');
+      expect(mockScanDirectory).toHaveBeenCalledWith('/tmp/packages', 'default');
     });
 
     it('scans without directory (uses default)', async () => {
@@ -89,7 +89,7 @@ describe('Extensions Scanner Routes', () => {
       const res = await app.request('/extensions/scan', { method: 'POST' });
 
       expect(res.status).toBe(200);
-      expect(mockScanDirectory).toHaveBeenCalledWith(undefined, 'user-1');
+      expect(mockScanDirectory).toHaveBeenCalledWith(undefined, 'default');
     });
 
     it('returns 500 when scan fails', async () => {

--- a/packages/gateway/src/routes/extensions/scanner.ts
+++ b/packages/gateway/src/routes/extensions/scanner.ts
@@ -4,17 +4,11 @@
  * POST /scan
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import { getExtensionService } from '@ownpilot/core';
 import { type ExtensionService } from '../../services/extension/service.js';
-import {
-  getUserId,
-  apiResponse,
-  apiError,
-  ERROR_CODES,
-  getErrorMessage,
-  parseJsonBody,
-} from '../helpers.js';
+import { apiResponse, apiError, ERROR_CODES, getErrorMessage, parseJsonBody } from '../helpers.js';
 
 export const scannerRoutes = new Hono();
 
@@ -25,7 +19,7 @@ const getExtService = () => getExtensionService() as unknown as ExtensionService
  * POST /scan - Scan directory for packages
  */
 scannerRoutes.post('/scan', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = ((await parseJsonBody(c)) ?? {}) as { directory?: string };
 
   try {

--- a/packages/gateway/src/routes/file-workspaces.ts
+++ b/packages/gateway/src/routes/file-workspaces.ts
@@ -6,19 +6,13 @@
  * All endpoints are scoped to the authenticated user.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { createReadStream } from 'node:fs';
 import { stat, unlink } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { getLog } from '../services/log.js';
-import {
-  apiResponse,
-  apiError,
-  ERROR_CODES,
-  getUserId,
-  getErrorMessage,
-  parseJsonBody,
-} from './helpers.js';
+import { apiResponse, apiError, ERROR_CODES, getErrorMessage, parseJsonBody } from './helpers.js';
 import { MAX_DAYS_LOOKBACK } from '../config/defaults.js';
 
 /** Sanitize a filename for use in Content-Disposition headers */
@@ -75,7 +69,7 @@ const app = new Hono();
  * GET /file-workspaces - List all session workspaces
  */
 app.get('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   try {
     const workspaces = listSessionWorkspaces(userId);
 
@@ -99,7 +93,7 @@ app.get('/', async (c) => {
  * POST /file-workspaces - Create a new session workspace
  */
 app.post('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   try {
     const body =
       (await parseJsonBody<{
@@ -138,7 +132,7 @@ app.post('/', async (c) => {
  * GET /file-workspaces/:id - Get workspace details
  */
 app.get('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
 
   try {
@@ -162,7 +156,7 @@ app.get('/:id', async (c) => {
  * DELETE /file-workspaces/:id - Delete a workspace
  */
 app.delete('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
 
   try {
@@ -188,7 +182,7 @@ app.delete('/:id', async (c) => {
  * GET /file-workspaces/:id/files - List files in workspace
  */
 app.get('/:id/files', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   const path = c.req.query('path') || '';
 
@@ -219,7 +213,7 @@ app.get('/:id/files', async (c) => {
  * GET /file-workspaces/:id/files/* - Read a file
  */
 app.get('/:id/file/*', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   // Extract the file path from the URL by locating the marker
   // `/${workspaceId}/file/` and taking everything after it. Previous code
@@ -316,7 +310,7 @@ app.get('/:id/file/*', async (c) => {
  * PUT /file-workspaces/:id/file/* - Write a file
  */
 app.put('/:id/file/*', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   // Extract the file path from the URL by locating the marker
   // `/${workspaceId}/file/` and taking everything after it. Previous code
@@ -365,7 +359,7 @@ app.put('/:id/file/*', async (c) => {
  * DELETE /file-workspaces/:id/file/* - Delete a file
  */
 app.delete('/:id/file/*', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   // Extract the file path from the URL by locating the marker
   // `/${workspaceId}/file/` and taking everything after it. Previous code
@@ -410,7 +404,7 @@ app.delete('/:id/file/*', async (c) => {
  * GET /file-workspaces/:id/download - Download workspace as ZIP
  */
 app.get('/:id/download', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
 
   try {
@@ -460,7 +454,7 @@ app.get('/:id/download', async (c) => {
  * POST /file-workspaces/cleanup - Clean up old workspaces
  */
 app.post('/cleanup', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   try {
     const body =
       (await parseJsonBody<{
@@ -503,7 +497,7 @@ app.post('/cleanup', async (c) => {
  * POST /file-workspaces/session/:sessionId - Get or create workspace for session
  */
 app.post('/session/:sessionId', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const sessionId = c.req.param('sessionId');
 
   try {

--- a/packages/gateway/src/routes/goals.test.ts
+++ b/packages/gateway/src/routes/goals.test.ts
@@ -84,7 +84,7 @@ function createApp() {
   app.use('*', requestId);
   // Simulate authenticated user
   app.use('*', async (c, next) => {
-    c.set('userId', 'u1');
+    c.set('userId', 'default');
     await next();
   });
   app.route('/goals', goalsRoutes);
@@ -128,7 +128,7 @@ describe('Goals Routes', () => {
 
       await app.request('/goals?status=active&limit=5');
 
-      expect(mockGoalService.listGoals).toHaveBeenCalledWith('u1', {
+      expect(mockGoalService.listGoals).toHaveBeenCalledWith('default', {
         status: 'active',
         limit: 5,
         parentId: undefined,
@@ -142,7 +142,7 @@ describe('Goals Routes', () => {
       await app.request('/goals?parentId=null');
 
       expect(mockGoalService.listGoals).toHaveBeenCalledWith(
-        'u1',
+        'default',
         expect.objectContaining({
           parentId: null,
         })
@@ -592,7 +592,7 @@ describe('Goals Routes', () => {
       await app.request('/goals?status=invalid_status');
 
       expect(mockGoalService.listGoals).toHaveBeenCalledWith(
-        'u1',
+        'default',
         expect.objectContaining({
           status: undefined,
         })
@@ -605,7 +605,7 @@ describe('Goals Routes', () => {
       await app.request('/goals?parentId=parent-123');
 
       expect(mockGoalService.listGoals).toHaveBeenCalledWith(
-        'u1',
+        'default',
         expect.objectContaining({
           parentId: 'parent-123',
         })
@@ -623,7 +623,7 @@ describe('Goals Routes', () => {
 
       await app.request('/goals/next-actions?limit=10');
 
-      expect(mockGoalService.getNextActions).toHaveBeenCalledWith('u1', 10);
+      expect(mockGoalService.getNextActions).toHaveBeenCalledWith('default', 10);
     });
 
     it('returns empty actions list', async () => {
@@ -648,7 +648,7 @@ describe('Goals Routes', () => {
 
       await app.request('/goals/upcoming');
 
-      expect(mockGoalService.getUpcoming).toHaveBeenCalledWith('u1', 7);
+      expect(mockGoalService.getUpcoming).toHaveBeenCalledWith('default', 7);
     });
   });
 });
@@ -692,7 +692,7 @@ describe('executeGoalTool', () => {
           priority: 8,
           dueDate: '2026-06-01',
         },
-        'u1'
+        'default'
       );
 
       expect(result.success).toBe(true);
@@ -714,11 +714,11 @@ describe('executeGoalTool', () => {
           title: 'Sub-goal',
           parentId: 'g1',
         },
-        'u1'
+        'default'
       );
 
       expect(mockGoalService.createGoal).toHaveBeenCalledWith(
-        'u1',
+        'default',
         expect.objectContaining({
           parentId: 'g1',
         })
@@ -732,7 +732,7 @@ describe('executeGoalTool', () => {
     it('returns empty list message when no goals', async () => {
       mockGoalService.listGoals.mockResolvedValue([]);
 
-      const result = await executeGoalTool('list_goals', {}, 'u1');
+      const result = await executeGoalTool('list_goals', {}, 'default');
 
       expect(result.success).toBe(true);
       expect(result.result.message).toContain('No active goals found');
@@ -752,7 +752,7 @@ describe('executeGoalTool', () => {
         { id: 'g2', title: 'Goal B', status: 'active', priority: 5, progress: 0, dueDate: null },
       ]);
 
-      const result = await executeGoalTool('list_goals', { status: 'active', limit: 5 }, 'u1');
+      const result = await executeGoalTool('list_goals', { status: 'active', limit: 5 }, 'default');
 
       expect(result.success).toBe(true);
       expect(result.result.goals).toHaveLength(2);
@@ -763,9 +763,9 @@ describe('executeGoalTool', () => {
     it('uses default status "active" and limit 10', async () => {
       mockGoalService.listGoals.mockResolvedValue([]);
 
-      await executeGoalTool('list_goals', {}, 'u1');
+      await executeGoalTool('list_goals', {}, 'default');
 
-      expect(mockGoalService.listGoals).toHaveBeenCalledWith('u1', {
+      expect(mockGoalService.listGoals).toHaveBeenCalledWith('default', {
         status: 'active',
         limit: 10,
         orderBy: 'priority',
@@ -777,7 +777,7 @@ describe('executeGoalTool', () => {
 
   describe('update_goal', () => {
     it('returns error when goalId missing', async () => {
-      const result = await executeGoalTool('update_goal', {}, 'u1');
+      const result = await executeGoalTool('update_goal', {}, 'default');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('goalId is required');
@@ -786,7 +786,7 @@ describe('executeGoalTool', () => {
     it('returns error when goal not found', async () => {
       mockGoalService.updateGoal.mockResolvedValue(null);
 
-      const result = await executeGoalTool('update_goal', { goalId: 'g999' }, 'u1');
+      const result = await executeGoalTool('update_goal', { goalId: 'g999' }, 'default');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Goal not found');
@@ -807,7 +807,7 @@ describe('executeGoalTool', () => {
           status: 'completed',
           progress: 100,
         },
-        'u1'
+        'default'
       );
 
       expect(result.success).toBe(true);
@@ -825,7 +825,7 @@ describe('executeGoalTool', () => {
         {
           steps: [{ title: 'Step 1' }],
         },
-        'u1'
+        'default'
       );
 
       expect(result.success).toBe(false);
@@ -833,7 +833,7 @@ describe('executeGoalTool', () => {
     });
 
     it('returns error when steps missing', async () => {
-      const result = await executeGoalTool('decompose_goal', { goalId: 'g1' }, 'u1');
+      const result = await executeGoalTool('decompose_goal', { goalId: 'g1' }, 'default');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('steps array is required');
@@ -846,7 +846,7 @@ describe('executeGoalTool', () => {
           goalId: 'g1',
           steps: [],
         },
-        'u1'
+        'default'
       );
 
       expect(result.success).toBe(false);
@@ -866,7 +866,7 @@ describe('executeGoalTool', () => {
           goalId: 'g1',
           steps: [{ title: 'Step 1' }, { title: 'Step 2' }],
         },
-        'u1'
+        'default'
       );
 
       expect(result.success).toBe(true);
@@ -884,7 +884,7 @@ describe('executeGoalTool', () => {
           goalId: 'g1',
           steps: [{ title: 'Step 1' }],
         },
-        'u1'
+        'default'
       );
 
       expect(result.success).toBe(true);
@@ -898,7 +898,7 @@ describe('executeGoalTool', () => {
     it('returns empty actions message', async () => {
       mockGoalService.getNextActions.mockResolvedValue([]);
 
-      const result = await executeGoalTool('get_next_actions', {}, 'u1');
+      const result = await executeGoalTool('get_next_actions', {}, 'default');
 
       expect(result.success).toBe(true);
       expect(result.result.message).toContain('All caught up');
@@ -910,7 +910,7 @@ describe('executeGoalTool', () => {
         { id: 's1', title: 'Write tests', goalTitle: 'Ship v1', status: 'pending' },
       ]);
 
-      const result = await executeGoalTool('get_next_actions', { limit: 3 }, 'u1');
+      const result = await executeGoalTool('get_next_actions', { limit: 3 }, 'default');
 
       expect(result.success).toBe(true);
       expect(result.result.actions).toHaveLength(1);
@@ -923,7 +923,7 @@ describe('executeGoalTool', () => {
 
   describe('complete_step', () => {
     it('returns error when stepId missing', async () => {
-      const result = await executeGoalTool('complete_step', {}, 'u1');
+      const result = await executeGoalTool('complete_step', {}, 'default');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('stepId is required');
@@ -932,7 +932,7 @@ describe('executeGoalTool', () => {
     it('returns error when step not found', async () => {
       mockGoalService.completeStep.mockResolvedValue(null);
 
-      const result = await executeGoalTool('complete_step', { stepId: 's999' }, 'u1');
+      const result = await executeGoalTool('complete_step', { stepId: 's999' }, 'default');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Step not found');
@@ -951,7 +951,7 @@ describe('executeGoalTool', () => {
           stepId: 's1',
           result: 'All tests passed',
         },
-        'u1'
+        'default'
       );
 
       expect(result.success).toBe(true);
@@ -964,7 +964,7 @@ describe('executeGoalTool', () => {
 
   describe('get_goal_details', () => {
     it('returns error when goalId missing', async () => {
-      const result = await executeGoalTool('get_goal_details', {}, 'u1');
+      const result = await executeGoalTool('get_goal_details', {}, 'default');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('goalId is required');
@@ -973,7 +973,7 @@ describe('executeGoalTool', () => {
     it('returns error when goal not found', async () => {
       mockGoalService.getGoalWithSteps.mockResolvedValue(null);
 
-      const result = await executeGoalTool('get_goal_details', { goalId: 'g999' }, 'u1');
+      const result = await executeGoalTool('get_goal_details', { goalId: 'g999' }, 'default');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Goal not found');
@@ -996,7 +996,7 @@ describe('executeGoalTool', () => {
         ],
       });
 
-      const result = await executeGoalTool('get_goal_details', { goalId: 'g1' }, 'u1');
+      const result = await executeGoalTool('get_goal_details', { goalId: 'g1' }, 'default');
 
       expect(result.success).toBe(true);
       expect(result.result.goal.id).toBe('g1');
@@ -1015,7 +1015,7 @@ describe('executeGoalTool', () => {
         byStatus: { active: 7, completed: 3 },
       });
 
-      const result = await executeGoalTool('get_goal_stats', {}, 'u1');
+      const result = await executeGoalTool('get_goal_stats', {}, 'default');
 
       expect(result.success).toBe(true);
       expect(result.result.message).toContain('10 goals total');
@@ -1028,7 +1028,7 @@ describe('executeGoalTool', () => {
 
   describe('unknown tool', () => {
     it('returns error for unknown tool', async () => {
-      const result = await executeGoalTool('nonexistent_tool', {}, 'u1');
+      const result = await executeGoalTool('nonexistent_tool', {}, 'default');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Unknown tool');
@@ -1056,7 +1056,7 @@ describe('executeGoalTool', () => {
         new GoalServiceError('Duplicate goal', 'VALIDATION_ERROR')
       );
 
-      const result = await executeGoalTool('create_goal', { title: 'Dup' }, 'u1');
+      const result = await executeGoalTool('create_goal', { title: 'Dup' }, 'default');
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Duplicate goal');
@@ -1065,7 +1065,7 @@ describe('executeGoalTool', () => {
     it('catches generic errors and returns error message', async () => {
       mockGoalService.createGoal.mockRejectedValue(new Error('Network timeout'));
 
-      const result = await executeGoalTool('create_goal', { title: 'Goal' }, 'u1');
+      const result = await executeGoalTool('create_goal', { title: 'Goal' }, 'default');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Network timeout');

--- a/packages/gateway/src/routes/goals.ts
+++ b/packages/gateway/src/routes/goals.ts
@@ -7,6 +7,7 @@
  * All business logic is delegated to GoalService.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import type {
   StepStatus,
@@ -17,7 +18,6 @@ import type {
 import { GoalServiceError } from '../services/goal-service.js';
 import { getGoalService, Services } from '@ownpilot/core';
 import {
-  getUserId,
   apiResponse,
   apiError,
   getIntParam,
@@ -44,7 +44,7 @@ export const goalsRoutes = new Hono();
  * GET /goals - List goals
  */
 goalsRoutes.get('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const status = validateQueryEnum(c.req.query('status'), [
     'active',
     'paused',
@@ -72,7 +72,7 @@ goalsRoutes.get('/', async (c) => {
  * POST /goals - Create a new goal
  */
 goalsRoutes.post('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const rawBody = await parseJsonBody(c);
   const { validateBody, createGoalSchema } = await import('../middleware/validation.js');
   const body = validateBody(createGoalSchema, rawBody) as unknown as CreateGoalInput;
@@ -110,7 +110,7 @@ goalsRoutes.post('/', async (c) => {
  * GET /goals/stats - Get goal statistics
  */
 goalsRoutes.get('/stats', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const service = getGoalService();
   const stats = await service.getStats(userId);
 
@@ -121,7 +121,7 @@ goalsRoutes.get('/stats', async (c) => {
  * GET /goals/next-actions - Get next actionable steps
  */
 goalsRoutes.get('/next-actions', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const limit = getIntParam(c, 'limit', 5, 1, 20);
 
   const service = getGoalService();
@@ -137,7 +137,7 @@ goalsRoutes.get('/next-actions', async (c) => {
  * GET /goals/upcoming - Get goals with upcoming due dates
  */
 goalsRoutes.get('/upcoming', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const days = getIntParam(c, 'days', 7, 1, MAX_DAYS_LOOKBACK);
 
   const service = getGoalService();
@@ -153,7 +153,7 @@ goalsRoutes.get('/upcoming', async (c) => {
  * GET /goals/:id - Get a specific goal with steps
  */
 goalsRoutes.get('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getGoalService();
@@ -170,7 +170,7 @@ goalsRoutes.get('/:id', async (c) => {
  * PATCH /goals/:id - Update a goal
  */
 goalsRoutes.patch('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const rawBody = await parseJsonBody(c);
   const { validateBody, updateGoalSchema } = await import('../middleware/validation.js');
@@ -204,7 +204,7 @@ goalsRoutes.route('/', goalCrudRoutes);
  * POST /goals/:id/steps - Add steps to a goal
  */
 goalsRoutes.post('/:id/steps', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const goalId = c.req.param('id');
   const rawBody = await parseJsonBody(c);
   const { validateBody, createGoalStepsSchema } = await import('../middleware/validation.js');
@@ -245,7 +245,7 @@ goalsRoutes.post('/:id/steps', async (c) => {
  * GET /goals/:id/steps - Get all steps for a goal
  */
 goalsRoutes.get('/:id/steps', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const goalId = c.req.param('id');
 
   const service = getGoalService();
@@ -262,7 +262,7 @@ goalsRoutes.get('/:id/steps', async (c) => {
  * Progress is recalculated automatically when status changes.
  */
 goalsRoutes.patch('/:goalId/steps/:stepId', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const stepId = c.req.param('stepId');
   const rawBody = await parseJsonBody(c);
   const { validateBody, updateGoalStepSchema } = await import('../middleware/validation.js');
@@ -293,7 +293,7 @@ goalsRoutes.patch('/:goalId/steps/:stepId', async (c) => {
  * Progress is recalculated automatically.
  */
 goalsRoutes.post('/:goalId/steps/:stepId/complete', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const stepId = c.req.param('stepId');
   const rawBody = (await parseJsonBody(c)) ?? {};
   const { validateBody, completeGoalStepSchema } = await import('../middleware/validation.js');
@@ -322,7 +322,7 @@ goalsRoutes.post('/:goalId/steps/:stepId/complete', async (c) => {
  * Progress is recalculated automatically.
  */
 goalsRoutes.delete('/:goalId/steps/:stepId', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const stepId = c.req.param('stepId');
 
   const service = getGoalService();

--- a/packages/gateway/src/routes/heartbeats/index.ts
+++ b/packages/gateway/src/routes/heartbeats/index.ts
@@ -8,12 +8,12 @@
  * validation and error handling), and the import/export/enable/disable endpoints.
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import { getHeartbeatService, Services } from '@ownpilot/core';
 import { HeartbeatServiceError } from '../../services/heartbeat/service.js';
 import type { HeartbeatService } from '../../services/heartbeat/service.js';
 import {
-  getUserId,
   apiResponse,
   apiError,
   getIntParam,
@@ -39,7 +39,7 @@ const getService = () => getHeartbeatService() as unknown as HeartbeatService;
  * (Custom: uses enabled filter and listHeartbeats-specific API)
  */
 heartbeatsRoutes.get('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const enabled = c.req.query('enabled');
   const limit = getIntParam(c, 'limit', 20, 1, 100);
 
@@ -57,7 +57,7 @@ heartbeatsRoutes.get('/', async (c) => {
  * (Custom: has manual field validation and HeartbeatServiceError handling)
  */
 heartbeatsRoutes.post('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = await parseJsonBody(c);
 
   if (!body) {
@@ -122,7 +122,7 @@ heartbeatsRoutes.post('/', async (c) => {
  * (Static route: must be defined before parametric /:id routes)
  */
 heartbeatsRoutes.post('/import', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = await parseJsonBody(c);
 
   if (!body || typeof (body as { markdown?: string }).markdown !== 'string') {
@@ -144,7 +144,7 @@ heartbeatsRoutes.post('/import', async (c) => {
  * (Static route: must be defined before parametric /:id routes)
  */
 heartbeatsRoutes.get('/export', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   const service = getService();
   const markdown = await service.exportMarkdown(userId);
@@ -177,7 +177,7 @@ heartbeatsRoutes.route('/', crudRoutes);
  * (Custom: catches HeartbeatServiceError for domain-specific error codes)
  */
 heartbeatsRoutes.patch('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const body = await parseJsonBody(c);
 
@@ -218,7 +218,7 @@ heartbeatsRoutes.patch('/:id', async (c) => {
  * POST /:id/enable - Enable heartbeat + trigger
  */
 heartbeatsRoutes.post('/:id/enable', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getService();
@@ -237,7 +237,7 @@ heartbeatsRoutes.post('/:id/enable', async (c) => {
  * POST /:id/disable - Disable heartbeat + trigger
  */
 heartbeatsRoutes.post('/:id/disable', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getService();

--- a/packages/gateway/src/routes/heartbeats/logs.test.ts
+++ b/packages/gateway/src/routes/heartbeats/logs.test.ts
@@ -36,7 +36,7 @@ const { heartbeatLogRoutes } = await import('./logs.js');
 function createApp() {
   const app = new Hono();
   app.use('*', async (c, next) => {
-    c.set('userId', 'user-1');
+    c.set('userId', 'default');
     await next();
   });
   app.route('/heartbeat-logs', heartbeatLogRoutes);
@@ -80,7 +80,7 @@ describe('Heartbeat Log Routes', () => {
       expect(json.data.items).toHaveLength(1);
       expect(json.data.total).toBe(1);
       expect(mockRepo.listByUser).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         expect.any(Number),
         expect.any(Number)
       );
@@ -88,7 +88,7 @@ describe('Heartbeat Log Routes', () => {
 
     it('passes limit and offset to repo', async () => {
       await app.request('/heartbeat-logs?limit=5&offset=10');
-      expect(mockRepo.listByUser).toHaveBeenCalledWith('user-1', 5, 10);
+      expect(mockRepo.listByUser).toHaveBeenCalledWith('default', 5, 10);
     });
 
     it('returns 500 when repo throws', async () => {
@@ -108,7 +108,7 @@ describe('Heartbeat Log Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.data).toHaveLength(1);
-      expect(mockRepo.isAgentOwnedByUser).toHaveBeenCalledWith('agent-1', 'user-1');
+      expect(mockRepo.isAgentOwnedByUser).toHaveBeenCalledWith('agent-1', 'default');
       expect(mockRepo.listByAgent).toHaveBeenCalledWith(
         'agent-1',
         expect.any(Number),
@@ -145,13 +145,13 @@ describe('Heartbeat Log Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.data.total).toBe(10);
-      expect(mockRepo.getStatsByUser).toHaveBeenCalledWith('user-1', undefined);
+      expect(mockRepo.getStatsByUser).toHaveBeenCalledWith('default', undefined);
     });
 
     it('passes agentId to getStatsByUser when provided and owned', async () => {
       await app.request('/heartbeat-logs/stats?agentId=agent-42');
-      expect(mockRepo.isAgentOwnedByUser).toHaveBeenCalledWith('agent-42', 'user-1');
-      expect(mockRepo.getStatsByUser).toHaveBeenCalledWith('user-1', 'agent-42');
+      expect(mockRepo.isAgentOwnedByUser).toHaveBeenCalledWith('agent-42', 'default');
+      expect(mockRepo.getStatsByUser).toHaveBeenCalledWith('default', 'agent-42');
     });
 
     it('returns 404 when agentId is not owned by user', async () => {

--- a/packages/gateway/src/routes/heartbeats/logs.ts
+++ b/packages/gateway/src/routes/heartbeats/logs.ts
@@ -2,6 +2,7 @@
  * Heartbeat Log Routes — audit trail API
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import { getHeartbeatLogRepository } from '../../db/repositories/heartbeats/log.js';
 import {
@@ -10,7 +11,6 @@ import {
   ERROR_CODES,
   getErrorMessage,
   getPaginationParams,
-  getUserId,
 } from '../helpers.js';
 
 export const heartbeatLogRoutes = new Hono();
@@ -19,7 +19,7 @@ export const heartbeatLogRoutes = new Hono();
 
 heartbeatLogRoutes.get('/', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const { limit, offset } = getPaginationParams(c);
     const repo = getHeartbeatLogRepository();
     const [logs, total] = await Promise.all([
@@ -36,7 +36,7 @@ heartbeatLogRoutes.get('/', async (c) => {
 
 heartbeatLogRoutes.get('/agent/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const agentId = c.req.param('id');
     const repo = getHeartbeatLogRepository();
 
@@ -58,7 +58,7 @@ heartbeatLogRoutes.get('/agent/:id', async (c) => {
 
 heartbeatLogRoutes.get('/stats', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const agentId = c.req.query('agentId');
 
     // If agentId provided, verify ownership

--- a/packages/gateway/src/routes/helpers.test.ts
+++ b/packages/gateway/src/routes/helpers.test.ts
@@ -7,7 +7,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Context } from 'hono';
 import {
-  getUserId,
   getPaginationParams,
   getIntParam,
   getOptionalIntParam,
@@ -37,49 +36,6 @@ function createMockContext(overrides: Partial<Context> = {}): Context {
 }
 
 describe('Route Helpers', () => {
-  describe('getUserId', () => {
-    it('should return userId from context.get when available', () => {
-      const c = createMockContext();
-      vi.mocked(c.get).mockReturnValue('user-from-auth');
-
-      const result = getUserId(c);
-
-      expect(result).toBe('user-from-auth');
-      expect(c.get).toHaveBeenCalledWith('userId');
-    });
-
-    it('should return default when no userId in auth context', () => {
-      const c = createMockContext();
-      vi.mocked(c.get).mockReturnValue(undefined);
-
-      const result = getUserId(c);
-
-      expect(result).toBe('default');
-    });
-
-    it('should not accept userId from query parameters (security)', () => {
-      const c = createMockContext();
-      vi.mocked(c.get).mockReturnValue(undefined);
-      vi.mocked(c.req.query).mockReturnValue('malicious-user');
-
-      const result = getUserId(c);
-
-      expect(result).toBe('default');
-    });
-
-    // Empty string is also treated as "no user" — covers the case where a
-    // misconfigured middleware sets `userId: ''` instead of leaving the key
-    // unset.
-    it('should return default when userId is empty string', () => {
-      const c = createMockContext();
-      vi.mocked(c.get).mockReturnValue('');
-
-      const result = getUserId(c);
-
-      expect(result).toBe('default');
-    });
-  });
-
   describe('getPaginationParams', () => {
     it('should return default pagination values when no query params', () => {
       const c = createMockContext();

--- a/packages/gateway/src/routes/helpers.ts
+++ b/packages/gateway/src/routes/helpers.ts
@@ -39,27 +39,6 @@ export {
 };
 
 /**
- * Extract the authenticated user ID from a Hono context.
- *
- * Returns the authenticated user ID from context (set by auth middleware),
- * or 'default' if no authentication is configured.
- *
- * Note: this codebase is single-tenant (shared UI password, one effective
- * user). The `'default'` literal is the correct fallback for every request,
- * not a security hole — IDOR-style concerns only apply if multiple distinct
- * user IDs ever share a data store, which the schema supports but no
- * deployment currently uses. See `docs/BUILTIN_DATA.md` (user_id column
- * default) for the explicit design intent.
- */
-export function getUserId(c: Context): string {
-  const userId = c.get('userId');
-  if (userId == null || userId === '') {
-    return 'default';
-  }
-  return userId;
-}
-
-/**
  * Parse pagination parameters from query string with defaults.
  *
  * Replaces repeated pattern:

--- a/packages/gateway/src/routes/local-providers.ts
+++ b/packages/gateway/src/routes/local-providers.ts
@@ -5,12 +5,12 @@
  * Supports full CRUD, model discovery, enable/disable toggle, and default selection.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { localProvidersRepo } from '../db/repositories/local-providers.js';
 import { discoverModels } from '../services/local-discovery.js';
 import { getLog } from '../services/log.js';
 import {
-  getUserId,
   apiResponse,
   apiError,
   ERROR_CODES,
@@ -107,7 +107,7 @@ localProvidersRoutes.get('/templates', (c) => {
  * GET / - List all local providers with model counts
  */
 localProvidersRoutes.get('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   try {
     const providers = await localProvidersRepo.listProviders(userId);
@@ -140,7 +140,7 @@ localProvidersRoutes.get('/', async (c) => {
  * POST / - Create a new local provider
  */
 localProvidersRoutes.post('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   try {
     const body = await parseJsonBody(c);
@@ -197,7 +197,7 @@ localProvidersRoutes.post('/', async (c) => {
  * GET /:id - Get a single local provider with its models
  */
 localProvidersRoutes.get('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   try {
@@ -230,7 +230,7 @@ localProvidersRoutes.get('/:id', async (c) => {
  * PUT /:id - Update a local provider
  */
 localProvidersRoutes.put('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   try {
@@ -288,7 +288,7 @@ localProvidersRoutes.put('/:id', async (c) => {
  * DELETE /:id - Delete a local provider (CASCADE deletes its models)
  */
 localProvidersRoutes.delete('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   try {
@@ -322,7 +322,7 @@ localProvidersRoutes.delete('/:id', async (c) => {
  * PATCH /:id/toggle - Toggle provider enabled/disabled
  */
 localProvidersRoutes.patch('/:id/toggle', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   try {
@@ -366,7 +366,7 @@ localProvidersRoutes.patch('/:id/toggle', async (c) => {
  * PATCH /:id/set-default - Set as the default local provider
  */
 localProvidersRoutes.patch('/:id/set-default', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   try {
@@ -399,7 +399,7 @@ localProvidersRoutes.patch('/:id/set-default', async (c) => {
  * and tracks new vs existing models.
  */
 localProvidersRoutes.post('/:id/discover', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   try {
@@ -469,7 +469,7 @@ localProvidersRoutes.post('/:id/discover', async (c) => {
  * GET /:id/models - List models for a local provider
  */
 localProvidersRoutes.get('/:id/models', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   try {
@@ -509,7 +509,7 @@ localProvidersRoutes.patch('/:id/models/:modelId/toggle', async (c) => {
     const { enabled } = parsed.data;
 
     // Find the model by provider ID + logical modelId to get its DB record id
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const models = await localProvidersRepo.listModels(userId, id);
     const model = models.find((m) => m.modelId === modelId);
 

--- a/packages/gateway/src/routes/mcp.test.ts
+++ b/packages/gateway/src/routes/mcp.test.ts
@@ -997,11 +997,12 @@ describe('MCP Routes', () => {
       expect(json.error.code).toBe('INTERNAL_ERROR');
     });
 
-    it('returns 404 when userId does not match server owner', async () => {
-      mockRepo.getById.mockResolvedValue(sampleServer);
+    it('returns 404 when the server is owned by a non-local userId', async () => {
+      // Single-tenant: requests resolve to LOCAL_OWNER_ID; the residual guard
+      // 404s a server row owned by any other userId.
+      mockRepo.getById.mockResolvedValue({ ...sampleServer, userId: 'user-2' });
 
-      const user2App = createApp('user-2');
-      const res = await user2App.request('/mcp/mcp-1/tools');
+      const res = await createApp().request('/mcp/mcp-1/tools');
 
       expect(res.status).toBe(404);
       const json = (await res.json()) as { error: { code: string; message: string } };
@@ -1134,11 +1135,11 @@ describe('MCP Routes', () => {
       expect(json.error.code).toBe('NOT_FOUND');
     });
 
-    it('returns 404 when userId does not match server owner', async () => {
-      mockRepo.getById.mockResolvedValue(sampleServer);
+    it('returns 404 when the server is owned by a non-local userId', async () => {
+      // Single-tenant residual guard: a server row owned by another userId 404s.
+      mockRepo.getById.mockResolvedValue({ ...sampleServer, userId: 'user-2' });
 
-      const user2App = createApp('user-2');
-      const res = await user2App.request('/mcp/mcp-1/tool-settings', {
+      const res = await createApp().request('/mcp/mcp-1/tool-settings', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ toolName: 'my_tool', workflowUsable: false }),

--- a/packages/gateway/src/routes/mcp.ts
+++ b/packages/gateway/src/routes/mcp.ts
@@ -5,6 +5,7 @@
  * plus the MCP protocol endpoint for exposing OwnPilot tools.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { getBaseName, getMcpClientService } from '@ownpilot/core';
 import { getMcpServersRepo } from '../db/repositories/mcp-servers.js';
@@ -12,14 +13,7 @@ import { handleMcpRequest } from '../services/mcp/server.js';
 import { getSharedToolRegistry } from '../services/tool/executor.js';
 import { wsGateway } from '../ws/server.js';
 import { getLog } from '../services/log.js';
-import {
-  apiResponse,
-  apiError,
-  ERROR_CODES,
-  getErrorMessage,
-  sanitizeId,
-  getUserId,
-} from './helpers.js';
+import { apiResponse, apiError, ERROR_CODES, getErrorMessage, sanitizeId } from './helpers.js';
 import {
   validateBody,
   mcpToolCallSchema,
@@ -174,7 +168,7 @@ mcpRoutes.post('/tool-call', async (c) => {
     const { tool_name: toolName, arguments: toolArgs } = body;
 
     const registry = getSharedToolRegistry();
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const context = {
       callId: `mcp-cli-${Date.now()}`,
       userId,
@@ -244,7 +238,7 @@ mcpRoutes.get('/presets', (c) => {
  */
 mcpRoutes.post('/presets/:id/install', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const presetId = c.req.param('id');
     const preset = getMcpPreset(presetId);
     if (!preset) {
@@ -333,7 +327,7 @@ mcpRoutes.post('/presets/:id/install', async (c) => {
  */
 mcpRoutes.get('/', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const repo = getMcpServersRepo();
     const servers = await repo.getAll(userId);
 
@@ -356,7 +350,7 @@ mcpRoutes.get('/', async (c) => {
  */
 mcpRoutes.post('/', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const rawBody = await c.req.json();
     const body = validateBody(createMcpServerSchema, rawBody);
     // enabled is a pass-through field not in the schema
@@ -422,7 +416,7 @@ mcpRoutes.post('/', async (c) => {
  */
 mcpRoutes.get('/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = sanitizeId(c.req.param('id'));
     const repo = getMcpServersRepo();
     const server = await repo.getById(id);
@@ -446,7 +440,7 @@ mcpRoutes.get('/:id', async (c) => {
  */
 mcpRoutes.put('/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = sanitizeId(c.req.param('id'));
     // R3: validate body shape + enums (transport is the only field with a
     // fixed enum). Schema also strips `name`/`displayName` from the partial
@@ -498,7 +492,7 @@ mcpRoutes.put('/:id', async (c) => {
  */
 mcpRoutes.delete('/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = sanitizeId(c.req.param('id'));
     const repo = getMcpServersRepo();
     const server = await repo.getById(id);
@@ -528,7 +522,7 @@ mcpRoutes.delete('/:id', async (c) => {
  */
 mcpRoutes.post('/:id/connect', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = sanitizeId(c.req.param('id'));
     const repo = getMcpServersRepo();
     const server = await repo.getById(id);
@@ -556,7 +550,7 @@ mcpRoutes.post('/:id/connect', async (c) => {
  */
 mcpRoutes.post('/:id/disconnect', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = sanitizeId(c.req.param('id'));
     const repo = getMcpServersRepo();
     const server = await repo.getById(id);
@@ -580,7 +574,7 @@ mcpRoutes.post('/:id/disconnect', async (c) => {
  */
 mcpRoutes.patch('/:id/tool-settings', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = sanitizeId(c.req.param('id'));
     const body = validateBody(mcpToolSettingsSchema, await c.req.json());
 
@@ -623,7 +617,7 @@ mcpRoutes.patch('/:id/tool-settings', async (c) => {
  */
 mcpRoutes.get('/:id/tools', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = sanitizeId(c.req.param('id'));
     const repo = getMcpServersRepo();
     const server = await repo.getById(id);

--- a/packages/gateway/src/routes/memories.test.ts
+++ b/packages/gateway/src/routes/memories.test.ts
@@ -95,7 +95,7 @@ function createApp() {
   app.use('*', requestId);
   // Simulate authenticated user
   app.use('*', async (c, next) => {
-    c.set('userId', 'u1');
+    c.set('userId', 'default');
     await next();
   });
   app.route('/memories', memoriesRoutes);
@@ -141,13 +141,13 @@ describe('Memories Routes', () => {
 
       await app.request('/memories?type=fact&limit=5&minImportance=0.5');
 
-      expect(mockMemoryService.listMemories).toHaveBeenCalledWith('u1', {
+      expect(mockMemoryService.listMemories).toHaveBeenCalledWith('default', {
         type: 'fact',
         limit: 5,
         minImportance: 0.5,
         orderBy: 'importance',
       });
-      expect(mockMemoryService.countMemories).toHaveBeenCalledWith('u1', 'fact');
+      expect(mockMemoryService.countMemories).toHaveBeenCalledWith('default', 'fact');
     });
 
     it('uses authenticated userId from context', async () => {
@@ -156,7 +156,7 @@ describe('Memories Routes', () => {
 
       await app.request('/memories');
 
-      expect(mockMemoryService.listMemories).toHaveBeenCalledWith('u1', expect.anything());
+      expect(mockMemoryService.listMemories).toHaveBeenCalledWith('default', expect.anything());
     });
   });
 
@@ -581,7 +581,7 @@ describe('Memories Routes', () => {
       });
 
       expect(res.status).toBe(200);
-      expect(mockMemoryService.boostMemory).toHaveBeenCalledWith('u1', 'm1', 0.1);
+      expect(mockMemoryService.boostMemory).toHaveBeenCalledWith('default', 'm1', 0.1);
       const json = await res.json();
       expect(json.data.message).toContain('0.1');
     });
@@ -656,7 +656,7 @@ describe('Memories Routes', () => {
       await app.request('/memories?minImportance=5.0');
 
       expect(mockMemoryService.listMemories).toHaveBeenCalledWith(
-        'u1',
+        'default',
         expect.objectContaining({
           minImportance: 1,
         })
@@ -670,7 +670,7 @@ describe('Memories Routes', () => {
       await app.request('/memories?minImportance=-0.5');
 
       expect(mockMemoryService.listMemories).toHaveBeenCalledWith(
-        'u1',
+        'default',
         expect.objectContaining({
           minImportance: 0,
         })
@@ -684,7 +684,7 @@ describe('Memories Routes', () => {
       await app.request('/memories?minImportance=abc');
 
       expect(mockMemoryService.listMemories).toHaveBeenCalledWith(
-        'u1',
+        'default',
         expect.objectContaining({
           minImportance: 0,
         })
@@ -698,7 +698,7 @@ describe('Memories Routes', () => {
       await app.request('/memories');
 
       expect(mockMemoryService.listMemories).toHaveBeenCalledWith(
-        'u1',
+        'default',
         expect.objectContaining({
           minImportance: undefined,
         })
@@ -729,7 +729,7 @@ describe('Memories Routes', () => {
 
       await app.request('/memories/search?q=test&type=preference&limit=5');
 
-      expect(mockMemoryService.hybridSearch).toHaveBeenCalledWith('u1', 'test', {
+      expect(mockMemoryService.hybridSearch).toHaveBeenCalledWith('default', 'test', {
         type: 'preference',
         limit: 5,
       });
@@ -814,14 +814,14 @@ describe('executeMemoryTool', () => {
 
   describe('create_memory', () => {
     it('returns error when content missing', async () => {
-      const result = await executeMemoryTool('create_memory', { type: 'fact' }, 'u1');
+      const result = await executeMemoryTool('create_memory', { type: 'fact' }, 'default');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('content and type are required');
     });
 
     it('returns error when type missing', async () => {
-      const result = await executeMemoryTool('create_memory', { content: 'Hello' }, 'u1');
+      const result = await executeMemoryTool('create_memory', { content: 'Hello' }, 'default');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('content and type are required');
@@ -841,7 +841,7 @@ describe('executeMemoryTool', () => {
           importance: 0.7,
           tags: ['tech'],
         },
-        'u1'
+        'default'
       );
 
       expect(result.success).toBe(true);
@@ -861,7 +861,7 @@ describe('executeMemoryTool', () => {
           content: 'Similar content',
           type: 'fact',
         },
-        'u1'
+        'default'
       );
 
       expect(result.success).toBe(true);
@@ -881,10 +881,10 @@ describe('executeMemoryTool', () => {
           content: 'Some fact',
           type: 'fact',
         },
-        'u1'
+        'default'
       );
 
-      expect(mockMemoryService.rememberMemory).toHaveBeenCalledWith('u1', {
+      expect(mockMemoryService.rememberMemory).toHaveBeenCalledWith('default', {
         content: 'Some fact',
         type: 'fact',
         importance: 0.5,
@@ -897,7 +897,7 @@ describe('executeMemoryTool', () => {
 
   describe('batch_create_memories', () => {
     it('returns error when memories is not array', async () => {
-      const result = await executeMemoryTool('batch_create_memories', {}, 'u1');
+      const result = await executeMemoryTool('batch_create_memories', {}, 'default');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('memories must be an array');
@@ -923,7 +923,7 @@ describe('executeMemoryTool', () => {
             { content: 'Fact 2', type: 'fact', importance: 0.8 },
           ],
         },
-        'u1'
+        'default'
       );
 
       expect(result.success).toBe(true);
@@ -937,7 +937,7 @@ describe('executeMemoryTool', () => {
 
   describe('search_memories', () => {
     it('returns error when query missing', async () => {
-      const result = await executeMemoryTool('search_memories', {}, 'u1');
+      const result = await executeMemoryTool('search_memories', {}, 'default');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('query is required');
@@ -951,7 +951,7 @@ describe('executeMemoryTool', () => {
         {
           query: 'nonexistent',
         },
-        'u1'
+        'default'
       );
 
       expect(result.success).toBe(true);
@@ -978,7 +978,7 @@ describe('executeMemoryTool', () => {
         {
           query: 'TypeScript',
         },
-        'u1'
+        'default'
       );
 
       expect(result.success).toBe(true);
@@ -998,7 +998,7 @@ describe('executeMemoryTool', () => {
           query: 'test',
           tags: ['tech'],
         },
-        'u1'
+        'default'
       );
 
       expect(result.success).toBe(true);
@@ -1015,10 +1015,10 @@ describe('executeMemoryTool', () => {
           query: 'test',
           limit: 999,
         },
-        'u1'
+        'default'
       );
 
-      expect(mockMemoryService.hybridSearch).toHaveBeenCalledWith('u1', 'test', {
+      expect(mockMemoryService.hybridSearch).toHaveBeenCalledWith('default', 'test', {
         type: undefined,
         limit: 100,
       });
@@ -1029,7 +1029,7 @@ describe('executeMemoryTool', () => {
 
   describe('delete_memory', () => {
     it('returns error when memoryId missing', async () => {
-      const result = await executeMemoryTool('delete_memory', {}, 'u1');
+      const result = await executeMemoryTool('delete_memory', {}, 'default');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('memoryId is required');
@@ -1038,7 +1038,7 @@ describe('executeMemoryTool', () => {
     it('returns error when memory not found', async () => {
       mockMemoryService.getMemory.mockResolvedValue(null);
 
-      const result = await executeMemoryTool('delete_memory', { memoryId: 'm999' }, 'u1');
+      const result = await executeMemoryTool('delete_memory', { memoryId: 'm999' }, 'default');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Memory not found');
@@ -1051,7 +1051,7 @@ describe('executeMemoryTool', () => {
       });
       mockMemoryService.deleteMemory.mockResolvedValue(true);
 
-      const result = await executeMemoryTool('delete_memory', { memoryId: 'm1' }, 'u1');
+      const result = await executeMemoryTool('delete_memory', { memoryId: 'm1' }, 'default');
 
       expect(result.success).toBe(true);
       expect(result.result.message).toContain('Forgot');
@@ -1074,7 +1074,7 @@ describe('executeMemoryTool', () => {
       ]);
       mockMemoryService.countMemories.mockResolvedValue(1);
 
-      const result = await executeMemoryTool('list_memories', {}, 'u1');
+      const result = await executeMemoryTool('list_memories', {}, 'default');
 
       expect(result.success).toBe(true);
       expect(result.result.memories).toHaveLength(1);
@@ -1093,10 +1093,10 @@ describe('executeMemoryTool', () => {
           limit: 5,
           minImportance: 0.3,
         },
-        'u1'
+        'default'
       );
 
-      expect(mockMemoryService.listMemories).toHaveBeenCalledWith('u1', {
+      expect(mockMemoryService.listMemories).toHaveBeenCalledWith('default', {
         type: 'preference',
         limit: 5,
         minImportance: 0.3,
@@ -1110,7 +1110,7 @@ describe('executeMemoryTool', () => {
 
   describe('update_memory_importance', () => {
     it('returns error when memoryId missing', async () => {
-      const result = await executeMemoryTool('update_memory_importance', {}, 'u1');
+      const result = await executeMemoryTool('update_memory_importance', {}, 'default');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('memoryId is required');
@@ -1125,7 +1125,7 @@ describe('executeMemoryTool', () => {
           memoryId: 'm999',
           amount: 0.2,
         },
-        'u1'
+        'default'
       );
 
       expect(result.success).toBe(false);
@@ -1145,7 +1145,7 @@ describe('executeMemoryTool', () => {
           memoryId: 'm1',
           amount: 0.15,
         },
-        'u1'
+        'default'
       );
 
       expect(result.success).toBe(true);
@@ -1165,10 +1165,10 @@ describe('executeMemoryTool', () => {
         {
           memoryId: 'm1',
         },
-        'u1'
+        'default'
       );
 
-      expect(mockMemoryService.boostMemory).toHaveBeenCalledWith('u1', 'm1', 0.1);
+      expect(mockMemoryService.boostMemory).toHaveBeenCalledWith('default', 'm1', 0.1);
     });
   });
 
@@ -1181,7 +1181,7 @@ describe('executeMemoryTool', () => {
         recentCount: 8,
       });
 
-      const result = await executeMemoryTool('get_memory_stats', {}, 'u1');
+      const result = await executeMemoryTool('get_memory_stats', {}, 'default');
 
       expect(result.success).toBe(true);
       expect(result.result.message).toContain('50 total');
@@ -1194,7 +1194,7 @@ describe('executeMemoryTool', () => {
 
   describe('unknown tool', () => {
     it('returns error for unknown tool', async () => {
-      const result = await executeMemoryTool('nonexistent_tool', {}, 'u1');
+      const result = await executeMemoryTool('nonexistent_tool', {}, 'default');
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('Unknown tool');
@@ -1229,7 +1229,7 @@ describe('executeMemoryTool', () => {
           content: 'Test',
           type: 'fact',
         },
-        'u1'
+        'default'
       );
 
       expect(result.success).toBe(false);
@@ -1245,7 +1245,7 @@ describe('executeMemoryTool', () => {
           content: 'Test',
           type: 'fact',
         },
-        'u1'
+        'default'
       );
 
       expect(result.success).toBe(false);

--- a/packages/gateway/src/routes/memories.ts
+++ b/packages/gateway/src/routes/memories.ts
@@ -7,12 +7,12 @@
  * All business logic is delegated to MemoryService.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import type { CreateMemoryInput } from '../db/repositories/memories.js';
 import { MemoryServiceError } from '../services/memory-service.js';
 import { getMemoryService } from '@ownpilot/core';
 import {
-  getUserId,
   apiResponse,
   apiError,
   getIntParam,
@@ -37,7 +37,7 @@ export const memoriesRoutes = new Hono();
  * GET /memories - List memories
  */
 memoriesRoutes.get('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const type = validateQueryEnum(c.req.query('type'), [
     'fact',
     'preference',
@@ -70,7 +70,7 @@ memoriesRoutes.get('/', async (c) => {
  * POST /memories - Create a new memory (with deduplication)
  */
 memoriesRoutes.post('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const rawBody = await parseJsonBody(c);
   const { validateBody, createMemorySchema } = await import('../middleware/validation.js');
   const body = validateBody(createMemorySchema, rawBody) as unknown as CreateMemoryInput;
@@ -118,7 +118,7 @@ memoriesRoutes.post('/', async (c) => {
  * GET /memories/search - Search memories
  */
 memoriesRoutes.get('/search', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const query = c.req.query('q') ?? '';
   const type = validateQueryEnum(c.req.query('type'), [
     'fact',
@@ -156,7 +156,7 @@ memoriesRoutes.get('/search', async (c) => {
  * GET /memories/stats - Get memory statistics
  */
 memoriesRoutes.get('/stats', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const service = getMemoryService();
   const stats = await service.getStats(userId);
 
@@ -189,7 +189,7 @@ memoriesRoutes.get('/embedding-stats', async (c) => {
  * GET /memories/:id - Get a specific memory
  */
 memoriesRoutes.get('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getMemoryService();
@@ -206,7 +206,7 @@ memoriesRoutes.get('/:id', async (c) => {
  * PATCH /memories/:id - Update a memory
  */
 memoriesRoutes.patch('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const rawBody = await parseJsonBody(c);
   const { validateBody, updateMemorySchema } = await import('../middleware/validation.js');
@@ -249,7 +249,7 @@ memoriesRoutes.patch('/:id', async (c) => {
  * POST /memories/:id/boost - Boost memory importance
  */
 memoriesRoutes.post('/:id/boost', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const rawBody = (await parseJsonBody(c)) ?? {};
   const { validateBody, boostMemorySchema } = await import('../middleware/validation.js');
@@ -283,7 +283,7 @@ memoriesRoutes.post('/:id/boost', async (c) => {
  * DELETE /memories/:id - Delete a memory
  */
 memoriesRoutes.delete('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getMemoryService();
@@ -305,7 +305,7 @@ memoriesRoutes.delete('/:id', async (c) => {
  * POST /memories/decay - Run decay on old memories
  */
 memoriesRoutes.post('/decay', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const rawBody = (await parseJsonBody(c)) ?? {};
   const { validateBody, decayMemoriesSchema } = await import('../middleware/validation.js');
   const body = validateBody(decayMemoriesSchema, rawBody) as {
@@ -328,7 +328,7 @@ memoriesRoutes.post('/decay', async (c) => {
  * POST /memories/cleanup - Clean up low-importance memories
  */
 memoriesRoutes.post('/cleanup', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const rawBody = (await parseJsonBody(c)) ?? {};
   const { validateBody, cleanupMemoriesSchema } = await import('../middleware/validation.js');
   const body = validateBody(cleanupMemoriesSchema, rawBody) as {
@@ -351,7 +351,7 @@ memoriesRoutes.post('/cleanup', async (c) => {
  * POST /memories/backfill-embeddings - Queue all memories without embeddings
  */
 memoriesRoutes.post('/backfill-embeddings', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   const { getEmbeddingQueue } = await import('../services/embedding/queue.js');
   const queued = await getEmbeddingQueue().backfill(userId);

--- a/packages/gateway/src/routes/model-configs/models.test.ts
+++ b/packages/gateway/src/routes/model-configs/models.test.ts
@@ -47,7 +47,7 @@ vi.mock('../../services/log.js', () => ({
 
 const sampleModel = {
   id: 'cfg-1',
-  userId: 'user-1',
+  userId: 'default',
   providerId: 'anthropic',
   modelId: 'claude-3-sonnet',
   displayName: 'Claude 3 Sonnet',
@@ -61,7 +61,7 @@ const sampleModel = {
 
 const sampleModelOpenAI = {
   id: 'cfg-2',
-  userId: 'user-1',
+  userId: 'default',
   providerId: 'openai',
   modelId: 'gpt-4',
   displayName: 'GPT-4',
@@ -75,7 +75,7 @@ const sampleModelOpenAI = {
 
 const sampleModelDisabled = {
   id: 'cfg-3',
-  userId: 'user-1',
+  userId: 'default',
   providerId: 'openai',
   modelId: 'gpt-3.5-turbo',
   displayName: 'GPT-3.5 Turbo',
@@ -89,7 +89,7 @@ const sampleModelDisabled = {
 
 const sampleCustomModel = {
   id: 'cfg-4',
-  userId: 'user-1',
+  userId: 'default',
   providerId: 'anthropic',
   modelId: 'claude-custom',
   displayName: 'Custom Claude',
@@ -103,7 +103,7 @@ const sampleCustomModel = {
 
 const sampleModelWithOverride = {
   id: 'cfg-5',
-  userId: 'user-1',
+  userId: 'default',
   providerId: 'openai',
   modelId: 'gpt-4-override',
   displayName: 'GPT-4 Override',
@@ -128,7 +128,7 @@ const { modelRoutes } = await import('./models.js');
 function createApp() {
   const app = new Hono();
   app.use('*', async (c, next) => {
-    c.set('userId', 'user-1');
+    c.set('userId', 'default');
     await next();
   });
   app.route('/models', modelRoutes);
@@ -163,7 +163,7 @@ describe('Model Routes', () => {
       const json = await res.json();
       expect(json.success).toBe(true);
       expect(json.data).toHaveLength(3);
-      expect(mockGetMergedModels).toHaveBeenCalledWith('user-1');
+      expect(mockGetMergedModels).toHaveBeenCalledWith('default');
     });
 
     it('returns empty array when no models exist', async () => {
@@ -353,7 +353,7 @@ describe('Model Routes', () => {
     it('calls getMergedModels with correct userId', async () => {
       await app.request('/models/anthropic');
 
-      expect(mockGetMergedModels).toHaveBeenCalledWith('user-1');
+      expect(mockGetMergedModels).toHaveBeenCalledWith('default');
     });
   });
 
@@ -429,7 +429,7 @@ describe('Model Routes', () => {
         expect.objectContaining({
           providerId: 'anthropic',
           modelId: 'claude-custom',
-          userId: 'user-1',
+          userId: 'default',
           isCustom: true,
         })
       );
@@ -690,7 +690,7 @@ describe('Model Routes', () => {
       });
 
       expect(mockModelConfigsRepo.deleteModel).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         'anthropic',
         'claude-custom'
       );
@@ -831,7 +831,7 @@ describe('Model Routes', () => {
 
       expect(mockModelConfigsRepo.upsertModel).toHaveBeenCalledWith(
         expect.objectContaining({
-          userId: 'user-1',
+          userId: 'default',
           providerId: 'anthropic',
           modelId: 'claude-3-sonnet',
           isEnabled: false,

--- a/packages/gateway/src/routes/model-configs/models.ts
+++ b/packages/gateway/src/routes/model-configs/models.ts
@@ -5,6 +5,7 @@
  * Includes capabilities listing and parameterized provider/model routes.
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import {
   modelConfigsRepo,
@@ -14,7 +15,6 @@ import {
 import { type ModelCapability } from '@ownpilot/core';
 import { getLog } from '../../services/log.js';
 import {
-  getUserId,
   apiResponse,
   apiError,
   ERROR_CODES,
@@ -36,7 +36,7 @@ export const modelRoutes = new Hono();
  * GET /api/v1/models - List all models (merged view)
  */
 modelRoutes.get('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerId = c.req.query('provider');
   const capability = validateQueryEnum(c.req.query('capability'), [
     'chat',
@@ -76,7 +76,7 @@ modelRoutes.get('/', async (c) => {
  * POST /api/v1/models - Create custom model
  */
 modelRoutes.post('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   const body = await c.req.json<CreateModelConfigInput>().catch(() => null);
   if (!body) {
@@ -142,7 +142,7 @@ modelRoutes.get('/capabilities/list', async (c) => {
  * GET /api/v1/models/:provider - List models for a provider
  */
 modelRoutes.get('/:provider', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerId = c.req.param('provider');
 
   const models = (await getMergedModels(userId)).filter((m) => m.providerId === providerId);
@@ -154,7 +154,7 @@ modelRoutes.get('/:provider', async (c) => {
  * GET /api/v1/models/:provider/:model - Get single model
  */
 modelRoutes.get('/:provider/:model', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerId = c.req.param('provider');
   const modelId = decodeURIComponent(c.req.param('model'));
 
@@ -173,7 +173,7 @@ modelRoutes.get('/:provider/:model', async (c) => {
  * PUT /api/v1/models/:provider/:model - Update model config
  */
 modelRoutes.put('/:provider/:model', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerId = c.req.param('provider');
   const modelId = decodeURIComponent(c.req.param('model'));
 
@@ -213,7 +213,7 @@ modelRoutes.put('/:provider/:model', async (c) => {
  * DELETE /api/v1/models/:provider/:model - Delete custom model or remove override
  */
 modelRoutes.delete('/:provider/:model', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerId = c.req.param('provider');
   const modelId = decodeURIComponent(c.req.param('model'));
 
@@ -249,7 +249,7 @@ modelRoutes.delete('/:provider/:model', async (c) => {
  * PATCH /api/v1/models/:provider/:model/toggle - Toggle model enabled
  */
 modelRoutes.patch('/:provider/:model/toggle', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerId = c.req.param('provider');
   const modelId = decodeURIComponent(c.req.param('model'));
 

--- a/packages/gateway/src/routes/model-configs/pricing.ts
+++ b/packages/gateway/src/routes/model-configs/pricing.ts
@@ -5,6 +5,7 @@
  * and per-provider config deletion.
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import { modelConfigsRepo } from '../../db/repositories/index.js';
 import {
@@ -14,14 +15,7 @@ import {
   clearConfigCache,
 } from '@ownpilot/core';
 import { getLog } from '../../services/log.js';
-import {
-  getUserId,
-  apiResponse,
-  apiError,
-  ERROR_CODES,
-  sanitizeId,
-  notFoundError,
-} from '../helpers.js';
+import { apiResponse, apiError, ERROR_CODES, sanitizeId, notFoundError } from '../helpers.js';
 import { wsGateway } from '../../ws/server.js';
 import { fileURLToPath } from 'url';
 import path from 'path';
@@ -187,7 +181,7 @@ pricingRoutes.post('/sync/reset', async (c) => {
     const fs = await import('fs');
 
     // 1. Clear database records first
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const dbResult = await modelConfigsRepo.fullReset(userId);
 
     // 2. Delete all JSON config files

--- a/packages/gateway/src/routes/model-configs/providers.ts
+++ b/packages/gateway/src/routes/model-configs/providers.ts
@@ -5,6 +5,7 @@
  * Includes model discovery from provider /v1/models endpoints.
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import {
   modelConfigsRepo,
@@ -22,7 +23,6 @@ import {
 import { getApiKey } from '../settings.js';
 import { getLog } from '../../services/log.js';
 import {
-  getUserId,
   apiResponse,
   apiError,
   ERROR_CODES,
@@ -46,7 +46,7 @@ export const providerRoutes = new Hono();
  * GET /api/v1/providers - List all providers (merged view)
  */
 providerRoutes.get('/providers/list', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const type = validateQueryEnum(c.req.query('type'), ['builtin', 'aggregator', 'custom'] as const);
 
   let providers = await getMergedProviders(userId);
@@ -63,7 +63,7 @@ providerRoutes.get('/providers/list', async (c) => {
  * Includes both models.dev providers and aggregators, with isConfigured flag
  */
 providerRoutes.get('/providers/available', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const customProviders = await modelConfigsRepo.listProviders(userId);
   const disabledProviders = new Set(
     customProviders.filter((p) => !p.isEnabled).map((p) => p.providerId)
@@ -137,7 +137,7 @@ providerRoutes.get('/providers/available', async (c) => {
  * GET /api/v1/providers/:id - Get single provider
  */
 providerRoutes.get('/providers/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerId = c.req.param('id');
 
   const provider = (await getMergedProviders(userId)).find((p) => p.id === providerId);
@@ -159,7 +159,7 @@ providerRoutes.get('/providers/:id', async (c) => {
  * POST /api/v1/providers - Create/enable custom provider
  */
 providerRoutes.post('/providers', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   const body = await c.req.json<CreateProviderInput>().catch(() => null);
   if (!body) {
@@ -200,7 +200,7 @@ providerRoutes.post('/providers', async (c) => {
  * PUT /api/v1/providers/:id - Update provider
  */
 providerRoutes.put('/providers/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerId = c.req.param('id');
 
   const body = await c.req.json<UpdateProviderInput>().catch(() => null);
@@ -258,7 +258,7 @@ providerRoutes.put('/providers/:id', async (c) => {
  * DELETE /api/v1/providers/:id - Delete custom provider
  */
 providerRoutes.delete('/providers/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerId = c.req.param('id');
 
   // Can't delete built-in providers
@@ -290,7 +290,7 @@ providerRoutes.delete('/providers/:id', async (c) => {
  * Works for both builtin (models.dev) and aggregator providers
  */
 providerRoutes.patch('/providers/:id/toggle', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerId = c.req.param('id');
 
   const body = await c.req.json<{ enabled: boolean }>().catch(() => null);
@@ -379,7 +379,7 @@ providerRoutes.patch('/providers/:id/toggle', async (c) => {
  * and saves them as custom models in the database.
  */
 providerRoutes.post('/providers/:id/discover-models', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerId = c.req.param('id');
 
   // Resolve provider base URL (user override > built-in config > aggregator)

--- a/packages/gateway/src/routes/models.ts
+++ b/packages/gateway/src/routes/models.ts
@@ -5,6 +5,7 @@
  * All model data is loaded from JSON config files - no hardcoded data
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { hasApiKey } from './settings.js';
 import {
@@ -19,14 +20,7 @@ import {
 import { modelConfigsRepo } from '../db/repositories/model-configs.js';
 import { localProvidersRepo } from '../db/repositories/index.js';
 import { detectCliChatProviders } from '../services/cli/chat-provider.js';
-import {
-  getUserId,
-  apiResponse,
-  apiError,
-  ERROR_CODES,
-  getErrorMessage,
-  parseJsonBody,
-} from './helpers.js';
+import { apiResponse, apiError, ERROR_CODES, getErrorMessage, parseJsonBody } from './helpers.js';
 
 const log = console;
 
@@ -123,7 +117,7 @@ function convertToModelInfo(providerId: string): ModelInfo[] {
  */
 app.get('/', async (c) => {
   const enabledOnly = c.req.query('enabledOnly') !== 'false';
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   const allModels: ModelInfo[] = [];
   const configuredProviders: string[] = [];

--- a/packages/gateway/src/routes/notifications.test.ts
+++ b/packages/gateway/src/routes/notifications.test.ts
@@ -86,14 +86,14 @@ describe('POST /notifications/send', () => {
   });
 
   it('ignores client-supplied body.userId and scopes to the authenticated user (IDOR)', async () => {
-    const app = createApp('alice');
+    const app = createApp('default');
     await app.request('/notifications/send', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       // Attacker tries to push a notification onto 'victim' channels.
       body: JSON.stringify({ userId: 'victim', title: 'Hi', body: 'There' }),
     });
-    expect(mockRouter.notify).toHaveBeenCalledWith('alice', expect.anything());
+    expect(mockRouter.notify).toHaveBeenCalledWith('default', expect.anything());
     expect(mockRouter.notify).not.toHaveBeenCalledWith('victim', expect.anything());
   });
 });
@@ -157,21 +157,21 @@ describe('POST /notifications/broadcast', () => {
 
 describe('GET /notifications/preferences/:userId', () => {
   it('reads preferences scoped to the authenticated user, ignoring the :userId param (IDOR)', async () => {
-    const app = createApp('alice');
+    const app = createApp('default');
     // Attacker requests another user's preferences via the URL param.
     const res = await app.request('/notifications/preferences/victim');
 
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.data.preferences.channelPriority).toEqual(['web']);
-    expect(mockRouter.getPreferences).toHaveBeenCalledWith('alice');
+    expect(mockRouter.getPreferences).toHaveBeenCalledWith('default');
     expect(mockRouter.getPreferences).not.toHaveBeenCalledWith('victim');
   });
 });
 
 describe('PUT /notifications/preferences/:userId', () => {
   it('writes preferences scoped to the authenticated user, ignoring the :userId param (IDOR)', async () => {
-    const app = createApp('alice');
+    const app = createApp('default');
     const res = await app.request('/notifications/preferences/victim', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
@@ -180,7 +180,7 @@ describe('PUT /notifications/preferences/:userId', () => {
 
     expect(res.status).toBe(200);
     expect(mockRouter.setPreferences).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: 'alice', minPriority: 'normal' })
+      expect.objectContaining({ userId: 'default', minPriority: 'normal' })
     );
     expect(mockRouter.setPreferences).not.toHaveBeenCalledWith(
       expect.objectContaining({ userId: 'victim' })

--- a/packages/gateway/src/routes/notifications.ts
+++ b/packages/gateway/src/routes/notifications.ts
@@ -4,8 +4,9 @@
  * REST API for sending notifications and managing notification preferences.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
-import { apiResponse, apiError, ERROR_CODES, getErrorMessage, getUserId } from './helpers.js';
+import { apiResponse, apiError, ERROR_CODES, getErrorMessage } from './helpers.js';
 import { getNotificationRouter, createNotification } from '../services/notification-router.js';
 import {
   validateBody,
@@ -37,7 +38,7 @@ app.post('/send', async (c) => {
     // Scope to the authenticated user — never trust a client-supplied
     // body.userId, which would let one user push notifications onto another
     // user's channels (spam / phishing via the victim's connected channels).
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const result = await router.notify(userId, notification);
 
     return apiResponse(c, { notification: { id: notification.id }, result });
@@ -130,7 +131,7 @@ app.get('/preferences/:userId', async (c) => {
     // any user could read another user's notification preferences (channel
     // priorities, quiet hours) by changing the id in the URL. The param is
     // retained for route shape / client compatibility but is not trusted.
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const router = getNotificationRouter();
     const prefs = await router.getPreferences(userId);
 
@@ -150,7 +151,7 @@ app.put('/preferences/:userId', async (c) => {
     // Authenticated identity only — the :userId path param is not trusted, or
     // any user could overwrite another user's notification preferences (e.g.
     // raise minPriority to silence their alerts). See GET handler above.
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const body = validateBody(notificationPreferencesSchema, await c.req.json());
 
     const router = getNotificationRouter();

--- a/packages/gateway/src/routes/personal-data.ts
+++ b/packages/gateway/src/routes/personal-data.ts
@@ -9,6 +9,7 @@
  * - Contacts
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import {
   TasksRepository,
@@ -31,7 +32,6 @@ import {
   apiError,
   ERROR_CODES,
   getErrorMessage,
-  getUserId,
   getIntParam,
   getOptionalIntParam,
   validateQueryEnum,
@@ -98,7 +98,7 @@ export const personalDataRoutes = new Hono();
 const tasksRoutes = new Hono();
 
 tasksRoutes.get('/', async (c) => {
-  const repo = new TasksRepository(getUserId(c));
+  const repo = new TasksRepository(LOCAL_OWNER_ID);
   const query: TaskQuery = {
     status: validateQueryEnum(c.req.query('status'), [
       'pending',
@@ -124,32 +124,32 @@ tasksRoutes.get('/', async (c) => {
 });
 
 tasksRoutes.get('/today', async (c) => {
-  const repo = new TasksRepository(getUserId(c));
+  const repo = new TasksRepository(LOCAL_OWNER_ID);
   const tasks = await repo.getDueToday();
   return apiResponse(c, tasks);
 });
 
 tasksRoutes.get('/overdue', async (c) => {
-  const repo = new TasksRepository(getUserId(c));
+  const repo = new TasksRepository(LOCAL_OWNER_ID);
   const tasks = await repo.getOverdue();
   return apiResponse(c, tasks);
 });
 
 tasksRoutes.get('/upcoming', async (c) => {
-  const repo = new TasksRepository(getUserId(c));
+  const repo = new TasksRepository(LOCAL_OWNER_ID);
   const days = getIntParam(c, 'days', 7, 1, MAX_DAYS_LOOKBACK);
   const tasks = await repo.getUpcoming(days);
   return apiResponse(c, tasks);
 });
 
 tasksRoutes.get('/categories', async (c) => {
-  const repo = new TasksRepository(getUserId(c));
+  const repo = new TasksRepository(LOCAL_OWNER_ID);
   const categories = await repo.getCategories();
   return apiResponse(c, categories);
 });
 
 tasksRoutes.get('/:id', async (c) => {
-  const repo = new TasksRepository(getUserId(c));
+  const repo = new TasksRepository(LOCAL_OWNER_ID);
   const task = await repo.get(c.req.param('id'));
   if (!task) {
     return notFoundError(c, 'Task', c.req.param('id'));
@@ -160,7 +160,7 @@ tasksRoutes.get('/:id', async (c) => {
 tasksRoutes.post('/', async (c) => {
   const parsed = await parseBody(c, createTaskSchema);
   if (!parsed.ok) return parsed.res;
-  const repo = new TasksRepository(getUserId(c));
+  const repo = new TasksRepository(LOCAL_OWNER_ID);
   const task = await repo.create(parsed.data);
   emitDataChanged('task', 'created', task.id);
   return apiResponse(c, task, 201);
@@ -169,7 +169,7 @@ tasksRoutes.post('/', async (c) => {
 tasksRoutes.patch('/:id', async (c) => {
   const parsed = await parseBody(c, updateTaskSchema);
   if (!parsed.ok) return parsed.res;
-  const repo = new TasksRepository(getUserId(c));
+  const repo = new TasksRepository(LOCAL_OWNER_ID);
   const task = await repo.update(c.req.param('id'), parsed.data);
   if (!task) {
     return notFoundError(c, 'Task', c.req.param('id'));
@@ -179,7 +179,7 @@ tasksRoutes.patch('/:id', async (c) => {
 });
 
 tasksRoutes.post('/:id/complete', async (c) => {
-  const repo = new TasksRepository(getUserId(c));
+  const repo = new TasksRepository(LOCAL_OWNER_ID);
   const task = await repo.complete(c.req.param('id'));
   if (!task) {
     return notFoundError(c, 'Task', c.req.param('id'));
@@ -189,7 +189,7 @@ tasksRoutes.post('/:id/complete', async (c) => {
 });
 
 tasksRoutes.delete('/:id', async (c) => {
-  const repo = new TasksRepository(getUserId(c));
+  const repo = new TasksRepository(LOCAL_OWNER_ID);
   const id = c.req.param('id');
   const deleted = await repo.delete(id);
   if (!deleted) {
@@ -206,7 +206,7 @@ tasksRoutes.delete('/:id', async (c) => {
 const bookmarksRoutes = new Hono();
 
 bookmarksRoutes.get('/', async (c) => {
-  const repo = new BookmarksRepository(getUserId(c));
+  const repo = new BookmarksRepository(LOCAL_OWNER_ID);
   const query: BookmarkQuery = {
     category: c.req.query('category'),
     isFavorite: c.req.query('favorite') === 'true' ? true : undefined,
@@ -220,26 +220,26 @@ bookmarksRoutes.get('/', async (c) => {
 });
 
 bookmarksRoutes.get('/favorites', async (c) => {
-  const repo = new BookmarksRepository(getUserId(c));
+  const repo = new BookmarksRepository(LOCAL_OWNER_ID);
   const bookmarks = await repo.getFavorites();
   return apiResponse(c, bookmarks);
 });
 
 bookmarksRoutes.get('/recent', async (c) => {
-  const repo = new BookmarksRepository(getUserId(c));
+  const repo = new BookmarksRepository(LOCAL_OWNER_ID);
   const limit = getIntParam(c, 'limit', 10, 1, 50);
   const bookmarks = await repo.getRecent(limit);
   return apiResponse(c, bookmarks);
 });
 
 bookmarksRoutes.get('/categories', async (c) => {
-  const repo = new BookmarksRepository(getUserId(c));
+  const repo = new BookmarksRepository(LOCAL_OWNER_ID);
   const categories = await repo.getCategories();
   return apiResponse(c, categories);
 });
 
 bookmarksRoutes.get('/:id', async (c) => {
-  const repo = new BookmarksRepository(getUserId(c));
+  const repo = new BookmarksRepository(LOCAL_OWNER_ID);
   const bookmark = await repo.get(c.req.param('id'));
   if (!bookmark) {
     return notFoundError(c, 'Bookmark', c.req.param('id'));
@@ -250,7 +250,7 @@ bookmarksRoutes.get('/:id', async (c) => {
 bookmarksRoutes.post('/', async (c) => {
   const parsed = await parseBody(c, createBookmarkSchema);
   if (!parsed.ok) return parsed.res;
-  const repo = new BookmarksRepository(getUserId(c));
+  const repo = new BookmarksRepository(LOCAL_OWNER_ID);
   const bookmark = await repo.create(parsed.data);
   emitDataChanged('bookmark', 'created', bookmark.id);
   return apiResponse(c, bookmark, 201);
@@ -259,7 +259,7 @@ bookmarksRoutes.post('/', async (c) => {
 bookmarksRoutes.patch('/:id', async (c) => {
   const parsed = await parseBody(c, updateBookmarkSchema);
   if (!parsed.ok) return parsed.res;
-  const repo = new BookmarksRepository(getUserId(c));
+  const repo = new BookmarksRepository(LOCAL_OWNER_ID);
   const bookmark = await repo.update(c.req.param('id'), parsed.data);
   if (!bookmark) {
     return notFoundError(c, 'Bookmark', c.req.param('id'));
@@ -269,7 +269,7 @@ bookmarksRoutes.patch('/:id', async (c) => {
 });
 
 bookmarksRoutes.post('/:id/favorite', async (c) => {
-  const repo = new BookmarksRepository(getUserId(c));
+  const repo = new BookmarksRepository(LOCAL_OWNER_ID);
   const bookmark = await repo.toggleFavorite(c.req.param('id'));
   if (!bookmark) {
     return notFoundError(c, 'Bookmark', c.req.param('id'));
@@ -279,7 +279,7 @@ bookmarksRoutes.post('/:id/favorite', async (c) => {
 });
 
 bookmarksRoutes.delete('/:id', async (c) => {
-  const repo = new BookmarksRepository(getUserId(c));
+  const repo = new BookmarksRepository(LOCAL_OWNER_ID);
   const id = c.req.param('id');
   const deleted = await repo.delete(id);
   if (!deleted) {
@@ -296,7 +296,7 @@ bookmarksRoutes.delete('/:id', async (c) => {
 const notesRoutes = new Hono();
 
 notesRoutes.get('/', async (c) => {
-  const repo = new NotesRepository(getUserId(c));
+  const repo = new NotesRepository(LOCAL_OWNER_ID);
   const query: NoteQuery = {
     category: c.req.query('category'),
     isPinned: c.req.query('pinned') === 'true' ? true : undefined,
@@ -311,25 +311,25 @@ notesRoutes.get('/', async (c) => {
 });
 
 notesRoutes.get('/pinned', async (c) => {
-  const repo = new NotesRepository(getUserId(c));
+  const repo = new NotesRepository(LOCAL_OWNER_ID);
   const notes = await repo.getPinned();
   return apiResponse(c, notes);
 });
 
 notesRoutes.get('/archived', async (c) => {
-  const repo = new NotesRepository(getUserId(c));
+  const repo = new NotesRepository(LOCAL_OWNER_ID);
   const notes = await repo.getArchived();
   return apiResponse(c, notes);
 });
 
 notesRoutes.get('/categories', async (c) => {
-  const repo = new NotesRepository(getUserId(c));
+  const repo = new NotesRepository(LOCAL_OWNER_ID);
   const categories = await repo.getCategories();
   return apiResponse(c, categories);
 });
 
 notesRoutes.get('/:id', async (c) => {
-  const repo = new NotesRepository(getUserId(c));
+  const repo = new NotesRepository(LOCAL_OWNER_ID);
   const note = await repo.get(c.req.param('id'));
   if (!note) {
     return notFoundError(c, 'Note', c.req.param('id'));
@@ -340,7 +340,7 @@ notesRoutes.get('/:id', async (c) => {
 notesRoutes.post('/', async (c) => {
   const parsed = await parseBody(c, createNoteSchema);
   if (!parsed.ok) return parsed.res;
-  const repo = new NotesRepository(getUserId(c));
+  const repo = new NotesRepository(LOCAL_OWNER_ID);
   const note = await repo.create(parsed.data);
   emitDataChanged('note', 'created', note.id);
   return apiResponse(c, note, 201);
@@ -349,7 +349,7 @@ notesRoutes.post('/', async (c) => {
 notesRoutes.patch('/:id', async (c) => {
   const parsed = await parseBody(c, updateNoteSchema);
   if (!parsed.ok) return parsed.res;
-  const repo = new NotesRepository(getUserId(c));
+  const repo = new NotesRepository(LOCAL_OWNER_ID);
   const note = await repo.update(c.req.param('id'), parsed.data);
   if (!note) {
     return notFoundError(c, 'Note', c.req.param('id'));
@@ -359,7 +359,7 @@ notesRoutes.patch('/:id', async (c) => {
 });
 
 notesRoutes.post('/:id/pin', async (c) => {
-  const repo = new NotesRepository(getUserId(c));
+  const repo = new NotesRepository(LOCAL_OWNER_ID);
   const note = await repo.togglePin(c.req.param('id'));
   if (!note) {
     return notFoundError(c, 'Note', c.req.param('id'));
@@ -369,7 +369,7 @@ notesRoutes.post('/:id/pin', async (c) => {
 });
 
 notesRoutes.post('/:id/archive', async (c) => {
-  const repo = new NotesRepository(getUserId(c));
+  const repo = new NotesRepository(LOCAL_OWNER_ID);
   const note = await repo.archive(c.req.param('id'));
   if (!note) {
     return notFoundError(c, 'Note', c.req.param('id'));
@@ -379,7 +379,7 @@ notesRoutes.post('/:id/archive', async (c) => {
 });
 
 notesRoutes.post('/:id/unarchive', async (c) => {
-  const repo = new NotesRepository(getUserId(c));
+  const repo = new NotesRepository(LOCAL_OWNER_ID);
   const note = await repo.unarchive(c.req.param('id'));
   if (!note) {
     return notFoundError(c, 'Note', c.req.param('id'));
@@ -389,7 +389,7 @@ notesRoutes.post('/:id/unarchive', async (c) => {
 });
 
 notesRoutes.delete('/:id', async (c) => {
-  const repo = new NotesRepository(getUserId(c));
+  const repo = new NotesRepository(LOCAL_OWNER_ID);
   const id = c.req.param('id');
   const deleted = await repo.delete(id);
   if (!deleted) {
@@ -406,7 +406,7 @@ notesRoutes.delete('/:id', async (c) => {
 const calendarRoutes = new Hono();
 
 calendarRoutes.get('/', async (c) => {
-  const repo = new CalendarRepository(getUserId(c));
+  const repo = new CalendarRepository(LOCAL_OWNER_ID);
   const query: EventQuery = {
     startAfter: c.req.query('startAfter'),
     startBefore: c.req.query('startBefore'),
@@ -421,26 +421,26 @@ calendarRoutes.get('/', async (c) => {
 });
 
 calendarRoutes.get('/today', async (c) => {
-  const repo = new CalendarRepository(getUserId(c));
+  const repo = new CalendarRepository(LOCAL_OWNER_ID);
   const events = await repo.getToday();
   return apiResponse(c, events);
 });
 
 calendarRoutes.get('/upcoming', async (c) => {
-  const repo = new CalendarRepository(getUserId(c));
+  const repo = new CalendarRepository(LOCAL_OWNER_ID);
   const days = getIntParam(c, 'days', 7, 1, MAX_DAYS_LOOKBACK);
   const events = await repo.getUpcoming(days);
   return apiResponse(c, events);
 });
 
 calendarRoutes.get('/categories', async (c) => {
-  const repo = new CalendarRepository(getUserId(c));
+  const repo = new CalendarRepository(LOCAL_OWNER_ID);
   const categories = await repo.getCategories();
   return apiResponse(c, categories);
 });
 
 calendarRoutes.get('/:id', async (c) => {
-  const repo = new CalendarRepository(getUserId(c));
+  const repo = new CalendarRepository(LOCAL_OWNER_ID);
   const event = await repo.get(c.req.param('id'));
   if (!event) {
     return notFoundError(c, 'Event', c.req.param('id'));
@@ -479,7 +479,7 @@ calendarRoutes.post('/', async (c) => {
     reminderMinutes: reminders && reminders.length > 0 ? Number(reminders[0]) : undefined,
   };
 
-  const repo = new CalendarRepository(getUserId(c));
+  const repo = new CalendarRepository(LOCAL_OWNER_ID);
   const event = await repo.create(createInput);
   emitDataChanged('calendar', 'created', event.id);
   return apiResponse(c, event, 201);
@@ -506,7 +506,7 @@ calendarRoutes.patch('/:id', async (c) => {
     updateInput.reminderMinutes = Number(reminders[0]);
   }
 
-  const repo = new CalendarRepository(getUserId(c));
+  const repo = new CalendarRepository(LOCAL_OWNER_ID);
   const event = await repo.update(c.req.param('id'), updateInput);
   if (!event) {
     return notFoundError(c, 'Event', c.req.param('id'));
@@ -516,7 +516,7 @@ calendarRoutes.patch('/:id', async (c) => {
 });
 
 calendarRoutes.delete('/:id', async (c) => {
-  const repo = new CalendarRepository(getUserId(c));
+  const repo = new CalendarRepository(LOCAL_OWNER_ID);
   const id = c.req.param('id');
   const deleted = await repo.delete(id);
   if (!deleted) {
@@ -533,7 +533,7 @@ calendarRoutes.delete('/:id', async (c) => {
 const contactsRoutes = new Hono();
 
 contactsRoutes.get('/', async (c) => {
-  const repo = new ContactsRepository(getUserId(c));
+  const repo = new ContactsRepository(LOCAL_OWNER_ID);
   const query: ContactQuery = {
     relationship: c.req.query('relationship'),
     company: c.req.query('company'),
@@ -548,39 +548,39 @@ contactsRoutes.get('/', async (c) => {
 });
 
 contactsRoutes.get('/favorites', async (c) => {
-  const repo = new ContactsRepository(getUserId(c));
+  const repo = new ContactsRepository(LOCAL_OWNER_ID);
   const contacts = await repo.getFavorites();
   return apiResponse(c, contacts);
 });
 
 contactsRoutes.get('/recent', async (c) => {
-  const repo = new ContactsRepository(getUserId(c));
+  const repo = new ContactsRepository(LOCAL_OWNER_ID);
   const limit = getIntParam(c, 'limit', 10, 1, 100);
   const contacts = await repo.getRecentlyContacted(limit);
   return apiResponse(c, contacts);
 });
 
 contactsRoutes.get('/birthdays', async (c) => {
-  const repo = new ContactsRepository(getUserId(c));
+  const repo = new ContactsRepository(LOCAL_OWNER_ID);
   const days = getIntParam(c, 'days', 30, 1, MAX_DAYS_LOOKBACK);
   const contacts = await repo.getUpcomingBirthdays(days);
   return apiResponse(c, contacts);
 });
 
 contactsRoutes.get('/relationships', async (c) => {
-  const repo = new ContactsRepository(getUserId(c));
+  const repo = new ContactsRepository(LOCAL_OWNER_ID);
   const relationships = await repo.getRelationships();
   return apiResponse(c, relationships);
 });
 
 contactsRoutes.get('/companies', async (c) => {
-  const repo = new ContactsRepository(getUserId(c));
+  const repo = new ContactsRepository(LOCAL_OWNER_ID);
   const companies = await repo.getCompanies();
   return apiResponse(c, companies);
 });
 
 contactsRoutes.get('/:id', async (c) => {
-  const repo = new ContactsRepository(getUserId(c));
+  const repo = new ContactsRepository(LOCAL_OWNER_ID);
   const contact = await repo.get(c.req.param('id'));
   if (!contact) {
     return notFoundError(c, 'Contact', c.req.param('id'));
@@ -591,7 +591,7 @@ contactsRoutes.get('/:id', async (c) => {
 contactsRoutes.post('/', async (c) => {
   const parsed = await parseBody(c, createContactSchema);
   if (!parsed.ok) return parsed.res;
-  const repo = new ContactsRepository(getUserId(c));
+  const repo = new ContactsRepository(LOCAL_OWNER_ID);
   const contact = await repo.create(parsed.data);
   emitDataChanged('contact', 'created', contact.id);
   return apiResponse(c, contact, 201);
@@ -600,7 +600,7 @@ contactsRoutes.post('/', async (c) => {
 contactsRoutes.patch('/:id', async (c) => {
   const parsed = await parseBody(c, updateContactSchema);
   if (!parsed.ok) return parsed.res;
-  const repo = new ContactsRepository(getUserId(c));
+  const repo = new ContactsRepository(LOCAL_OWNER_ID);
   const contact = await repo.update(c.req.param('id'), parsed.data);
   if (!contact) {
     return notFoundError(c, 'Contact', c.req.param('id'));
@@ -610,7 +610,7 @@ contactsRoutes.patch('/:id', async (c) => {
 });
 
 contactsRoutes.post('/:id/favorite', async (c) => {
-  const repo = new ContactsRepository(getUserId(c));
+  const repo = new ContactsRepository(LOCAL_OWNER_ID);
   const contact = await repo.toggleFavorite(c.req.param('id'));
   if (!contact) {
     return notFoundError(c, 'Contact', c.req.param('id'));
@@ -620,7 +620,7 @@ contactsRoutes.post('/:id/favorite', async (c) => {
 });
 
 contactsRoutes.delete('/:id', async (c) => {
-  const repo = new ContactsRepository(getUserId(c));
+  const repo = new ContactsRepository(LOCAL_OWNER_ID);
   const id = c.req.param('id');
   const deleted = await repo.delete(id);
   if (!deleted) {
@@ -642,7 +642,7 @@ personalDataRoutes.route('/contacts', contactsRoutes);
 
 // Summary endpoint - get overview of all personal data
 personalDataRoutes.get('/summary', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   const tasksRepo = new TasksRepository(userId);
   const bookmarksRepo = new BookmarksRepository(userId);

--- a/packages/gateway/src/routes/plans.test.ts
+++ b/packages/gateway/src/routes/plans.test.ts
@@ -78,7 +78,7 @@ function createApp() {
   app.use('*', requestId);
   // Simulate authenticated user
   app.use('*', async (c, next) => {
-    c.set('userId', 'u1');
+    c.set('userId', 'default');
     await next();
   });
   app.route('/plans', plansRoutes);
@@ -125,12 +125,12 @@ describe('Plans Routes', () => {
 
       await app.request('/plans?status=running&goalId=g1&limit=5&offset=10');
 
-      expect(mockPlanService.countPlans).toHaveBeenCalledWith('u1', {
+      expect(mockPlanService.countPlans).toHaveBeenCalledWith('default', {
         status: 'running',
         goalId: 'g1',
         triggerId: undefined,
       });
-      expect(mockPlanService.listPlans).toHaveBeenCalledWith('u1', {
+      expect(mockPlanService.listPlans).toHaveBeenCalledWith('default', {
         status: 'running',
         goalId: 'g1',
         triggerId: undefined,

--- a/packages/gateway/src/routes/plans.ts
+++ b/packages/gateway/src/routes/plans.ts
@@ -4,6 +4,7 @@
  * API for managing and executing autonomous plans.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import {
   type CreatePlanInput,
@@ -13,7 +14,6 @@ import {
 import { getPlanExecutor } from '../plans/index.js';
 import { getPlanService, Services } from '@ownpilot/core';
 import {
-  getUserId,
   apiResponse,
   apiError,
   getIntParam,
@@ -39,7 +39,7 @@ export const plansRoutes = new Hono();
  * GET /plans - List plans
  */
 plansRoutes.get('/', pagination(), async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const status = validateQueryEnum(c.req.query('status'), [
     'pending',
     'running',
@@ -71,7 +71,7 @@ plansRoutes.get('/', pagination(), async (c) => {
  * POST /plans - Create a new plan
  */
 plansRoutes.post('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const rawBody = await parseJsonBody(c);
   const { validateBody, createPlanSchema } = await import('../middleware/validation.js');
   const body = validateBody(createPlanSchema, rawBody) as unknown as CreatePlanInput;
@@ -95,7 +95,7 @@ plansRoutes.post('/', async (c) => {
  * GET /plans/stats - Get plan statistics
  */
 plansRoutes.get('/stats', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const service = getPlanService();
   const stats = await service.getStats(userId);
 
@@ -106,7 +106,7 @@ plansRoutes.get('/stats', async (c) => {
  * GET /plans/active - Get active plans
  */
 plansRoutes.get('/active', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const service = getPlanService();
   const plans = await service.getActive(userId);
 
@@ -120,7 +120,7 @@ plansRoutes.get('/active', async (c) => {
  * GET /plans/pending - Get pending plans
  */
 plansRoutes.get('/pending', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const service = getPlanService();
   const plans = await service.getPending(userId);
 
@@ -134,7 +134,7 @@ plansRoutes.get('/pending', async (c) => {
  * GET /plans/:id - Get a specific plan
  */
 plansRoutes.get('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getPlanService();
@@ -159,7 +159,7 @@ plansRoutes.get('/:id', async (c) => {
  * PATCH /plans/:id - Update a plan
  */
 plansRoutes.patch('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const rawBody = await parseJsonBody(c);
   const { validateBody, updatePlanSchema } = await import('../middleware/validation.js');
@@ -198,7 +198,7 @@ plansRoutes.route('/', planCrudRoutes);
  *   - maxConcurrent: Maximum concurrent steps in wave mode (default: 5)
  */
 plansRoutes.post('/:id/execute', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const waveExecution = c.req.query('waveExecution') === 'true';
   const maxConcurrent = getIntParam(c, 'maxConcurrent', 5, 1, 20);
@@ -258,7 +258,7 @@ plansRoutes.post('/:id/execute', async (c) => {
  * POST /plans/:id/pause - Pause a running plan
  */
 plansRoutes.post('/:id/pause', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getPlanService();
@@ -288,7 +288,7 @@ plansRoutes.post('/:id/pause', async (c) => {
  * POST /plans/:id/resume - Resume a paused plan
  */
 plansRoutes.post('/:id/resume', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getPlanService();
@@ -333,7 +333,7 @@ plansRoutes.post('/:id/resume', async (c) => {
  * POST /plans/:id/abort - Abort a running plan
  */
 plansRoutes.post('/:id/abort', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getPlanService();
@@ -363,7 +363,7 @@ plansRoutes.post('/:id/abort', async (c) => {
  * POST /plans/:id/checkpoint - Create a checkpoint
  */
 plansRoutes.post('/:id/checkpoint', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const body = await c.req.json<{ data?: unknown }>().catch((): { data?: unknown } => ({}));
 
@@ -405,7 +405,7 @@ plansRoutes.post('/:id/checkpoint', async (c) => {
  * POST /plans/:id/start - Start a plan (alias for /execute)
  */
 plansRoutes.post('/:id/start', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getPlanService();
@@ -462,7 +462,7 @@ plansRoutes.post('/:id/start', async (c) => {
  * POST /plans/:id/rollback - Rollback plan to last checkpoint
  */
 plansRoutes.post('/:id/rollback', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getPlanService();
@@ -531,7 +531,7 @@ plansRoutes.post('/:id/rollback', async (c) => {
  * GET /plans/:id/steps - Get all steps for a plan
  */
 plansRoutes.get('/:id/steps', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getPlanService();
@@ -554,7 +554,7 @@ plansRoutes.get('/:id/steps', async (c) => {
  * POST /plans/:id/steps - Add a step to a plan
  */
 plansRoutes.post('/:id/steps', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const rawBody = await parseJsonBody(c);
   const { validateBody, createPlanStepSchema } = await import('../middleware/validation.js');
@@ -584,7 +584,7 @@ plansRoutes.post('/:id/steps', async (c) => {
  * GET /plans/:id/steps/:stepId - Get a specific step
  */
 plansRoutes.get('/:id/steps/:stepId', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const stepId = c.req.param('stepId');
 
   const service = getPlanService();
@@ -601,7 +601,7 @@ plansRoutes.get('/:id/steps/:stepId', async (c) => {
  * PATCH /plans/:id/steps/:stepId - Update a step
  */
 plansRoutes.patch('/:id/steps/:stepId', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const stepId = c.req.param('stepId');
   const rawBody = await parseJsonBody(c);
 
@@ -629,7 +629,7 @@ plansRoutes.patch('/:id/steps/:stepId', async (c) => {
  * GET /plans/:id/history - Get history for a plan
  */
 plansRoutes.get('/:id/history', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const limit = getIntParam(c, 'limit', 50, 1, 200);
 
@@ -657,7 +657,7 @@ plansRoutes.get('/:id/history', async (c) => {
  * GET /plans/executor/status - Get executor status
  */
 plansRoutes.get('/executor/status', (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const executor = getPlanExecutor({ userId });
 
   return apiResponse(c, {

--- a/packages/gateway/src/routes/productivity.ts
+++ b/packages/gateway/src/routes/productivity.ts
@@ -4,6 +4,7 @@
  * API for Pomodoro, Habits, and Captures functionality
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { PomodoroRepository, type UpdateSettingsInput } from '../db/repositories/pomodoro.js';
 import { HabitsRepository, type UpdateHabitInput } from '../db/repositories/habits.js';
@@ -11,7 +12,6 @@ import { CapturesRepository } from '../db/repositories/captures.js';
 import {
   apiResponse,
   apiError,
-  getUserId,
   getIntParam,
   ERROR_CODES,
   validateQueryEnum,
@@ -44,7 +44,7 @@ function getPomodoroRepo(userId = 'default'): PomodoroRepository {
  * GET /pomodoro/session - Get active session
  */
 pomodoroRoutes.get('/session', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const repo = getPomodoroRepo(userId);
   const session = await repo.getActiveSession();
 
@@ -56,7 +56,7 @@ pomodoroRoutes.get('/session', async (c) => {
  */
 pomodoroRoutes.post('/session/start', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const body = validateBody(startPomodoroSchema, await c.req.json());
 
     const repo = getPomodoroRepo(userId);
@@ -87,7 +87,7 @@ pomodoroRoutes.post('/session/start', async (c) => {
  * POST /pomodoro/session/:id/complete - Complete a session
  */
 pomodoroRoutes.post('/session/:id/complete', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const repo = getPomodoroRepo(userId);
@@ -106,7 +106,7 @@ pomodoroRoutes.post('/session/:id/complete', async (c) => {
  * POST /pomodoro/session/:id/interrupt - Interrupt a session
  */
 pomodoroRoutes.post('/session/:id/interrupt', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const body = await c.req.json<{ reason?: string }>().catch((): { reason?: string } => ({}));
 
@@ -126,7 +126,7 @@ pomodoroRoutes.post('/session/:id/interrupt', async (c) => {
  * GET /pomodoro/sessions - List sessions
  */
 pomodoroRoutes.get('/sessions', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const type = validateQueryEnum(c.req.query('type'), [
     'work',
     'short_break',
@@ -144,7 +144,7 @@ pomodoroRoutes.get('/sessions', async (c) => {
  * GET /pomodoro/settings - Get settings
  */
 pomodoroRoutes.get('/settings', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const repo = getPomodoroRepo(userId);
   const settings = await repo.getSettings();
 
@@ -155,7 +155,7 @@ pomodoroRoutes.get('/settings', async (c) => {
  * PATCH /pomodoro/settings - Update settings
  */
 pomodoroRoutes.patch('/settings', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = await c.req.json<UpdateSettingsInput>();
 
   const repo = getPomodoroRepo(userId);
@@ -170,7 +170,7 @@ pomodoroRoutes.patch('/settings', async (c) => {
  * GET /pomodoro/stats - Get statistics
  */
 pomodoroRoutes.get('/stats', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const repo = getPomodoroRepo(userId);
   const stats = await repo.getTotalStats();
   const today = await repo.getDailyStats();
@@ -182,7 +182,7 @@ pomodoroRoutes.get('/stats', async (c) => {
  * GET /pomodoro/stats/daily/:date - Get daily stats
  */
 pomodoroRoutes.get('/stats/daily/:date', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const date = c.req.param('date');
 
   const repo = getPomodoroRepo(userId);
@@ -214,7 +214,7 @@ function getHabitsRepo(userId = 'default'): HabitsRepository {
  * GET /habits - List habits
  */
 habitsRoutes.get('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const category = c.req.query('category');
   const isArchived = c.req.query('archived') === 'true';
 
@@ -229,7 +229,7 @@ habitsRoutes.get('/', async (c) => {
  */
 habitsRoutes.post('/', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const body = validateBody(createHabitSchema, await c.req.json());
 
     const repo = getHabitsRepo(userId);
@@ -249,7 +249,7 @@ habitsRoutes.post('/', async (c) => {
  * GET /habits/today - Get today's habits with status
  */
 habitsRoutes.get('/today', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const repo = getHabitsRepo(userId);
   const progress = await repo.getTodayProgress();
 
@@ -260,7 +260,7 @@ habitsRoutes.get('/today', async (c) => {
  * GET /habits/categories - Get all categories
  */
 habitsRoutes.get('/categories', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const repo = getHabitsRepo(userId);
   const categories = await repo.getCategories();
 
@@ -271,7 +271,7 @@ habitsRoutes.get('/categories', async (c) => {
  * GET /habits/:id - Get a habit
  */
 habitsRoutes.get('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const repo = getHabitsRepo(userId);
@@ -288,7 +288,7 @@ habitsRoutes.get('/:id', async (c) => {
  * PATCH /habits/:id - Update a habit
  */
 habitsRoutes.patch('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const body = await c.req.json<UpdateHabitInput>();
 
@@ -308,7 +308,7 @@ habitsRoutes.patch('/:id', async (c) => {
  * DELETE /habits/:id - Delete a habit
  */
 habitsRoutes.delete('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const repo = getHabitsRepo(userId);
@@ -327,7 +327,7 @@ habitsRoutes.delete('/:id', async (c) => {
  * POST /habits/:id/archive - Archive a habit
  */
 habitsRoutes.post('/:id/archive', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const repo = getHabitsRepo(userId);
@@ -346,7 +346,7 @@ habitsRoutes.post('/:id/archive', async (c) => {
  * POST /habits/:id/log - Log habit completion
  */
 habitsRoutes.post('/:id/log', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const body = await c.req
     .json<{ date?: string; count?: number; notes?: string }>()
@@ -371,7 +371,7 @@ habitsRoutes.post('/:id/log', async (c) => {
  * GET /habits/:id/logs - Get habit logs
  */
 habitsRoutes.get('/:id/logs', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const startDate = c.req.query('startDate');
   const endDate = c.req.query('endDate');
@@ -401,7 +401,7 @@ function getCapturesRepo(userId = 'default'): CapturesRepository {
  * GET /captures - List captures
  */
 capturesRoutes.get('/', pagination(), async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const type = validateQueryEnum(c.req.query('type'), [
     'idea',
     'thought',
@@ -433,7 +433,7 @@ capturesRoutes.get('/', pagination(), async (c) => {
  */
 capturesRoutes.post('/', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const body = validateBody(createCaptureSchema, await c.req.json());
 
     const repo = getCapturesRepo(userId);
@@ -462,7 +462,7 @@ capturesRoutes.post('/', async (c) => {
  * GET /captures/inbox - Get unprocessed captures
  */
 capturesRoutes.get('/inbox', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const limit = getIntParam(c, 'limit', 10, 1, 50);
 
   const repo = getCapturesRepo(userId);
@@ -491,7 +491,7 @@ capturesRoutes.get('/inbox', async (c) => {
  * GET /captures/stats - Get capture statistics
  */
 capturesRoutes.get('/stats', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const repo = getCapturesRepo(userId);
   const stats = await repo.getStats();
 
@@ -502,7 +502,7 @@ capturesRoutes.get('/stats', async (c) => {
  * GET /captures/:id - Get a capture
  */
 capturesRoutes.get('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const repo = getCapturesRepo(userId);
@@ -520,7 +520,7 @@ capturesRoutes.get('/:id', async (c) => {
  */
 capturesRoutes.post('/:id/process', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = c.req.param('id');
     const body = validateBody(processCaptureSchema, await c.req.json());
 
@@ -551,7 +551,7 @@ capturesRoutes.post('/:id/process', async (c) => {
  * DELETE /captures/:id - Delete a capture
  */
 capturesRoutes.delete('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const repo = getCapturesRepo(userId);

--- a/packages/gateway/src/routes/profile.ts
+++ b/packages/gateway/src/routes/profile.ts
@@ -5,12 +5,12 @@
  * Enables comprehensive personalization of AI interactions.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import {
   apiResponse,
   apiError,
   ERROR_CODES,
-  getUserId,
   zodValidationError,
   getErrorMessage,
   parseJsonBody,
@@ -68,7 +68,7 @@ const app = new Hono();
  */
 app.get('/', async (c) => {
   try {
-    const store = await getPersonalMemoryStore(getUserId(c));
+    const store = await getPersonalMemoryStore(LOCAL_OWNER_ID);
     const profile = await store.getProfile();
 
     return apiResponse(c, profile);
@@ -89,7 +89,7 @@ app.get('/', async (c) => {
  */
 app.get('/summary', async (c) => {
   try {
-    const store = await getPersonalMemoryStore(getUserId(c));
+    const store = await getPersonalMemoryStore(LOCAL_OWNER_ID);
     const summary = await store.getProfileSummary();
 
     return apiResponse(c, { summary });
@@ -119,7 +119,7 @@ app.get('/category/:category', async (c) => {
   }
 
   try {
-    const store = await getPersonalMemoryStore(getUserId(c));
+    const store = await getPersonalMemoryStore(LOCAL_OWNER_ID);
     const entries = await store.getCategory(category as PersonalDataCategory);
 
     return apiResponse(c, {
@@ -154,7 +154,7 @@ app.post('/data', async (c) => {
 
     const { category, key, value, data, confidence, source, sensitive } = parsed.data;
 
-    const store = await getPersonalMemoryStore(getUserId(c));
+    const store = await getPersonalMemoryStore(LOCAL_OWNER_ID);
     const entry = await store.set(category as PersonalDataCategory, key, value as string, {
       data,
       confidence,
@@ -163,7 +163,7 @@ app.post('/data', async (c) => {
     });
 
     // Invalidate prompt cache so next AI call sees updated profile
-    getMemoryInjector().invalidateCache(getUserId(c));
+    getMemoryInjector().invalidateCache(LOCAL_OWNER_ID);
 
     return apiResponse(c, entry, 201);
   } catch (error) {
@@ -200,10 +200,10 @@ app.delete('/data', async (c) => {
 
     const { category, key } = parsed.data;
 
-    const store = await getPersonalMemoryStore(getUserId(c));
+    const store = await getPersonalMemoryStore(LOCAL_OWNER_ID);
     const deleted = await store.delete(category as PersonalDataCategory, key);
 
-    getMemoryInjector().invalidateCache(getUserId(c));
+    getMemoryInjector().invalidateCache(LOCAL_OWNER_ID);
 
     return apiResponse(c, { deleted });
   } catch (error) {
@@ -234,7 +234,7 @@ app.get('/search', async (c) => {
   }
 
   try {
-    const store = await getPersonalMemoryStore(getUserId(c));
+    const store = await getPersonalMemoryStore(LOCAL_OWNER_ID);
     const categories = categoriesParam
       ? (categoriesParam.split(',') as PersonalDataCategory[])
       : undefined;
@@ -269,7 +269,7 @@ app.post('/import', async (c) => {
 
     const { entries } = parsed.data;
 
-    const store = await getPersonalMemoryStore(getUserId(c));
+    const store = await getPersonalMemoryStore(LOCAL_OWNER_ID);
     const imported = await store.importData(
       entries as Array<{
         category: PersonalDataCategory;
@@ -279,7 +279,7 @@ app.post('/import', async (c) => {
       }>
     );
 
-    getMemoryInjector().invalidateCache(getUserId(c));
+    getMemoryInjector().invalidateCache(LOCAL_OWNER_ID);
 
     return apiResponse(
       c,
@@ -323,7 +323,7 @@ app.post('/inferred/confirm', async (c) => {
     if (!parsed.success) return zodValidationError(c, parsed.error.issues);
 
     const { category, key } = parsed.data;
-    const store = await getPersonalMemoryStore(getUserId(c));
+    const store = await getPersonalMemoryStore(LOCAL_OWNER_ID);
     const existing = await store.get(category as PersonalDataCategory, key);
     if (!existing) {
       return apiError(c, { code: ERROR_CODES.NOT_FOUND, message: 'Entry not found' }, 404);
@@ -347,7 +347,7 @@ app.post('/inferred/confirm', async (c) => {
       sensitive: existing.sensitive,
     });
 
-    getMemoryInjector().invalidateCache(getUserId(c));
+    getMemoryInjector().invalidateCache(LOCAL_OWNER_ID);
     return apiResponse(c, updated);
   } catch (error) {
     return apiError(
@@ -369,7 +369,7 @@ app.post('/inferred/confirm', async (c) => {
  */
 app.get('/inferred', async (c) => {
   try {
-    const store = await getPersonalMemoryStore(getUserId(c));
+    const store = await getPersonalMemoryStore(LOCAL_OWNER_ID);
     const all = await store.exportData();
     const entries = all
       .filter((e) => e.source === 'ai_inferred')
@@ -392,7 +392,7 @@ app.get('/inferred', async (c) => {
  */
 app.get('/export', async (c) => {
   try {
-    const store = await getPersonalMemoryStore(getUserId(c));
+    const store = await getPersonalMemoryStore(LOCAL_OWNER_ID);
     const data = await store.exportData();
 
     return apiResponse(c, {
@@ -433,7 +433,7 @@ app.post('/quick', async (c) => {
       autonomyLevel,
     } = parsed.data;
 
-    const store = await getPersonalMemoryStore(getUserId(c));
+    const store = await getPersonalMemoryStore(LOCAL_OWNER_ID);
     let count = 0;
 
     // Set provided values
@@ -470,7 +470,7 @@ app.post('/quick', async (c) => {
       count++;
     }
 
-    getMemoryInjector().invalidateCache(getUserId(c));
+    getMemoryInjector().invalidateCache(LOCAL_OWNER_ID);
 
     // Get updated profile
     const profile = await store.getProfile();

--- a/packages/gateway/src/routes/providers.ts
+++ b/packages/gateway/src/routes/providers.ts
@@ -5,12 +5,12 @@
  * Provider configs are loaded from JSON files in the core package
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { loadProviderConfig, getAvailableProviders } from '@ownpilot/core';
 import {
   apiResponse,
   apiError,
-  getUserId,
   ERROR_CODES,
   zodValidationError,
   getErrorMessage,
@@ -220,7 +220,7 @@ function getProviderIds(): string[] {
  * GET /providers - List all available providers
  */
 app.get('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const providerIds = getProviderIds();
 
   // Get all user overrides at once for efficiency
@@ -374,7 +374,7 @@ app.get('/categories', (c) => {
  */
 app.get('/:id', async (c) => {
   const id = c.req.param('id');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   // Check CLI chat providers first (cli-claude, cli-codex, cli-gemini)
   const cliProviders = detectCliChatProviders();
@@ -495,7 +495,7 @@ app.get('/:id/models', (c) => {
  */
 app.get('/:id/config', async (c) => {
   const id = c.req.param('id');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   // Handle CLI providers (cli-claude, cli-codex, cli-gemini)
   const cliProviders = detectCliChatProviders();
@@ -572,7 +572,7 @@ app.get('/:id/config', async (c) => {
  */
 app.put('/:id/config', async (c) => {
   const id = c.req.param('id');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   // CLI providers and regular providers both support config overrides
   const config = loadProviderConfig(id);
@@ -634,7 +634,7 @@ app.put('/:id/config', async (c) => {
  */
 app.delete('/:id/config', async (c) => {
   const id = c.req.param('id');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   const deleted = await modelConfigsRepo.deleteUserProviderConfig(userId, id);
 
@@ -649,7 +649,7 @@ app.delete('/:id/config', async (c) => {
  */
 app.patch('/:id/toggle', async (c) => {
   const id = c.req.param('id');
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const config = loadProviderConfig(id);
   const isCli = !config && detectCliChatProviders().some((p) => p.id === id);
 
@@ -695,7 +695,7 @@ app.patch('/:id/toggle', async (c) => {
  * GET /providers/overrides - Get all user provider overrides
  */
 app.get('/overrides/all', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const overrides = await modelConfigsRepo.listUserProviderConfigs(userId);
 
   return apiResponse(c, {

--- a/packages/gateway/src/routes/security.ts
+++ b/packages/gateway/src/routes/security.ts
@@ -9,6 +9,7 @@
  * POST /scan/workflow     — Single workflow security scan
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { analyzeToolCode, calculateSecurityScore } from '@ownpilot/core';
 import {
@@ -21,14 +22,7 @@ import {
   scanSingleTrigger,
   scanSingleWorkflow,
 } from '../services/security-scanner.js';
-import {
-  getUserId,
-  apiResponse,
-  apiError,
-  ERROR_CODES,
-  parseJsonBody,
-  notFoundError,
-} from './helpers.js';
+import { apiResponse, apiError, ERROR_CODES, parseJsonBody, notFoundError } from './helpers.js';
 
 export const securityRoutes = new Hono();
 
@@ -37,7 +31,7 @@ export const securityRoutes = new Hono();
 // =============================================================================
 
 securityRoutes.post('/scan', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const result = await scanPlatform(userId);
   return apiResponse(c, result);
 });
@@ -47,7 +41,7 @@ securityRoutes.post('/scan', async (c) => {
 // =============================================================================
 
 securityRoutes.post('/scan/extensions', (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const result = scanExtensions(userId);
   return apiResponse(c, result);
 });
@@ -57,7 +51,7 @@ securityRoutes.post('/scan/extensions', (c) => {
 // =============================================================================
 
 securityRoutes.post('/scan/custom-tools', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const result = await scanCustomTools(userId);
   return apiResponse(c, result);
 });
@@ -98,7 +92,7 @@ securityRoutes.post('/scan/custom-tool', async (c) => {
 // =============================================================================
 
 securityRoutes.post('/scan/triggers', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const result = await scanTriggers(userId);
   return apiResponse(c, result);
 });
@@ -108,7 +102,7 @@ securityRoutes.post('/scan/triggers', async (c) => {
 // =============================================================================
 
 securityRoutes.post('/scan/trigger', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = (await parseJsonBody(c)) as { triggerId: string } | null;
 
   if (!body?.triggerId) {
@@ -125,7 +119,7 @@ securityRoutes.post('/scan/trigger', async (c) => {
 // =============================================================================
 
 securityRoutes.post('/scan/workflows', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const result = await scanWorkflows(userId);
   return apiResponse(c, result);
 });
@@ -135,7 +129,7 @@ securityRoutes.post('/scan/workflows', async (c) => {
 // =============================================================================
 
 securityRoutes.post('/scan/workflow', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = (await parseJsonBody(c)) as { workflowId: string } | null;
 
   if (!body?.workflowId) {
@@ -152,7 +146,7 @@ securityRoutes.post('/scan/workflow', async (c) => {
 // =============================================================================
 
 securityRoutes.post('/scan/cli-tools', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const result = await scanCliPolicies(userId);
   return apiResponse(c, result);
 });

--- a/packages/gateway/src/routes/skills.test.ts
+++ b/packages/gateway/src/routes/skills.test.ts
@@ -74,7 +74,7 @@ const { skillsRoutes } = await import('./skills.js');
 // App setup
 // ---------------------------------------------------------------------------
 
-const USER_ID = 'user-1';
+const USER_ID = 'default';
 
 function createApp() {
   const app = new Hono();

--- a/packages/gateway/src/routes/skills.ts
+++ b/packages/gateway/src/routes/skills.ts
@@ -5,9 +5,10 @@
  * permission management, and update checking.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono, type Context } from 'hono';
 import { z } from 'zod';
-import { getUserId, apiResponse, apiError, ERROR_CODES, getIntParam } from './helpers.js';
+import { apiResponse, apiError, ERROR_CODES, getIntParam } from './helpers.js';
 import { getErrorMessage, getExtensionService } from '@ownpilot/core';
 import { getNpmInstaller } from '../services/skill/npm-installer.js';
 import {
@@ -31,7 +32,7 @@ const grantPermissionsSchema = z.object({
 export const skillsRoutes = new Hono();
 
 async function uninstallSkill(c: Context) {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   if (!id) {
@@ -100,7 +101,7 @@ skillsRoutes.get('/featured', async (c) => {
 
 skillsRoutes.post('/install-npm', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const body = validateBody(installNpmSchema, await c.req.json());
     const { packageName } = body;
 
@@ -156,7 +157,7 @@ skillsRoutes.get('/npm/:name', async (c) => {
 
 skillsRoutes.post('/check-updates', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const allExtensions = extensionsRepo.getAll().filter((e) => e.userId === userId);
     const installer = getNpmInstaller();
 
@@ -200,7 +201,7 @@ skillsRoutes.get('/permissions', (_c) => {
 
 skillsRoutes.get('/permissions/:id', (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = c.req.param('id');
     const ext = extensionsRepo.getById(id);
 
@@ -225,7 +226,7 @@ skillsRoutes.get('/permissions/:id', (c) => {
 
 skillsRoutes.post('/permissions/:id', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     const id = c.req.param('id');
     const body = validateBody(grantPermissionsSchema, await c.req.json());
     const grantedPermissions = body.grantedPermissions as SkillPermission[];

--- a/packages/gateway/src/routes/triggers.test.ts
+++ b/packages/gateway/src/routes/triggers.test.ts
@@ -79,7 +79,7 @@ function createApp() {
   app.use('*', requestId);
   // Simulate authenticated user
   app.use('*', async (c, next) => {
-    c.set('userId', 'u1');
+    c.set('userId', 'default');
     await next();
   });
   app.route('/triggers', triggersRoutes);
@@ -123,7 +123,7 @@ describe('Triggers Routes', () => {
 
       await app.request('/triggers?type=schedule&enabled=true&limit=5');
 
-      expect(mockTriggerService.listTriggers).toHaveBeenCalledWith('u1', {
+      expect(mockTriggerService.listTriggers).toHaveBeenCalledWith('default', {
         type: 'schedule',
         enabled: true,
         limit: 5,
@@ -136,7 +136,7 @@ describe('Triggers Routes', () => {
       await app.request('/triggers?enabled=false');
 
       expect(mockTriggerService.listTriggers).toHaveBeenCalledWith(
-        'u1',
+        'default',
         expect.objectContaining({
           enabled: false,
         })
@@ -410,7 +410,9 @@ describe('Triggers Routes', () => {
       const json = await res.json();
       expect(json.success).toBe(true);
       expect(json.data.message).toContain('enabled');
-      expect(mockTriggerService.updateTrigger).toHaveBeenCalledWith('u1', 't1', { enabled: true });
+      expect(mockTriggerService.updateTrigger).toHaveBeenCalledWith('default', 't1', {
+        enabled: true,
+      });
     });
 
     it('returns 404 when trigger not found', async () => {
@@ -434,7 +436,9 @@ describe('Triggers Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.data.message).toContain('disabled');
-      expect(mockTriggerService.updateTrigger).toHaveBeenCalledWith('u1', 't1', { enabled: false });
+      expect(mockTriggerService.updateTrigger).toHaveBeenCalledWith('default', 't1', {
+        enabled: false,
+      });
     });
 
     it('returns 404 when trigger not found', async () => {
@@ -577,7 +581,7 @@ describe('Triggers Routes', () => {
       const json = await res.json();
       expect(json.data.deletedCount).toBe(5);
       // Should use default of 30 days
-      expect(mockTriggerService.cleanupHistory).toHaveBeenCalledWith('u1', 30);
+      expect(mockTriggerService.cleanupHistory).toHaveBeenCalledWith('default', 30);
     });
 
     it('defaults to 30 when maxAgeDays is not a finite number', async () => {
@@ -592,7 +596,7 @@ describe('Triggers Routes', () => {
       expect(res.status).toBe(200);
       const json = await res.json();
       expect(json.data.deletedCount).toBe(3);
-      expect(mockTriggerService.cleanupHistory).toHaveBeenCalledWith('u1', 30);
+      expect(mockTriggerService.cleanupHistory).toHaveBeenCalledWith('default', 30);
     });
   });
 

--- a/packages/gateway/src/routes/triggers.ts
+++ b/packages/gateway/src/routes/triggers.ts
@@ -4,12 +4,12 @@
  * API for managing proactive triggers.
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { type CreateTriggerInput, type UpdateTriggerInput } from '../db/repositories/triggers.js';
 import { getTriggerEngine } from '../triggers/index.js';
 import { validateCronExpression, getTriggerService } from '@ownpilot/core';
 import {
-  getUserId,
   apiResponse,
   apiError,
   getIntParam,
@@ -33,7 +33,7 @@ export const triggersRoutes = new Hono();
  * GET /triggers - List triggers
  */
 triggersRoutes.get('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const type = validateQueryEnum(c.req.query('type'), [
     'schedule',
     'event',
@@ -60,7 +60,7 @@ triggersRoutes.get('/', async (c) => {
  * POST /triggers - Create a new trigger
  */
 triggersRoutes.post('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const rawBody = await parseJsonBody(c);
   const { validateBody, createTriggerSchema } = await import('../middleware/validation.js');
   const body = validateBody(createTriggerSchema, rawBody) as unknown as CreateTriggerInput;
@@ -110,7 +110,7 @@ triggersRoutes.post('/', async (c) => {
  * GET /triggers/stats - Get trigger statistics
  */
 triggersRoutes.get('/stats', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const service = getTriggerService();
   const stats = await service.getStats(userId);
 
@@ -121,7 +121,7 @@ triggersRoutes.get('/stats', async (c) => {
  * GET /triggers/history - Get recent trigger history
  */
 triggersRoutes.get('/history', pagination({ defaultLimit: 25, maxLimit: 200 }), async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const { limit, offset } = c.get('pagination')!;
   const status = validateQueryEnum(c.req.query('status'), [
     'success',
@@ -154,7 +154,7 @@ triggersRoutes.get('/history', pagination({ defaultLimit: 25, maxLimit: 200 }), 
  * GET /triggers/due - Get triggers that are due to fire
  */
 triggersRoutes.get('/due', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
 
   const service = getTriggerService();
   const triggers = await service.getDueTriggers(userId);
@@ -169,7 +169,7 @@ triggersRoutes.get('/due', async (c) => {
  * GET /triggers/:id - Get a specific trigger
  */
 triggersRoutes.get('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getTriggerService();
@@ -192,7 +192,7 @@ triggersRoutes.get('/:id', async (c) => {
  * PATCH /triggers/:id - Update a trigger
  */
 triggersRoutes.patch('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const body = await parseJsonBody<UpdateTriggerInput>(c);
   if (!body) {
@@ -237,7 +237,7 @@ triggersRoutes.patch('/:id', async (c) => {
  * POST /triggers/:id/enable - Enable a trigger
  */
 triggersRoutes.post('/:id/enable', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getTriggerService();
@@ -259,7 +259,7 @@ triggersRoutes.post('/:id/enable', async (c) => {
  * POST /triggers/:id/disable - Disable a trigger
  */
 triggersRoutes.post('/:id/disable', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getTriggerService();
@@ -281,7 +281,7 @@ triggersRoutes.post('/:id/disable', async (c) => {
  * POST /triggers/:id/fire - Manually fire a trigger
  */
 triggersRoutes.post('/:id/fire', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getTriggerService();
@@ -319,7 +319,7 @@ triggersRoutes.post('/:id/fire', async (c) => {
  * DELETE /triggers/:id - Delete a trigger
  */
 triggersRoutes.delete('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
 
   const service = getTriggerService();
@@ -340,7 +340,7 @@ triggersRoutes.delete('/:id', async (c) => {
  * GET /triggers/:id/history - Get history for a specific trigger
  */
 triggersRoutes.get('/:id/history', pagination({ defaultLimit: 25, maxLimit: 200 }), async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = c.req.param('id');
   const { limit, offset } = c.get('pagination')!;
   const status = validateQueryEnum(c.req.query('status'), [
@@ -380,7 +380,7 @@ triggersRoutes.get('/:id/history', pagination({ defaultLimit: 25, maxLimit: 200 
  * POST /triggers/cleanup - Clean up old history
  */
 triggersRoutes.post('/cleanup', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const body = await c.req
     .json<{ maxAgeDays?: number }>()
     .catch((): { maxAgeDays?: number } => ({}));
@@ -446,7 +446,7 @@ triggersRoutes.post('/engine/stop', (c) => {
  * POST /triggers/from-natural-language - Create a schedule trigger from NL description
  */
 triggersRoutes.post('/from-natural-language', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const rawBody = (await parseJsonBody<Record<string, unknown>>(c)) ?? {};
 
   if (

--- a/packages/gateway/src/routes/voice.test.ts
+++ b/packages/gateway/src/routes/voice.test.ts
@@ -38,7 +38,8 @@ function createApp() {
   app.use('*', requestId);
   app.use('*', async (c, next) => {
     // Simulate authenticated user for all voice routes
-    c.set('userId', 'user-1');
+    c.set('userId', 'default');
+    c.set('sessionAuthenticated', true);
     await next();
   });
   app.route('/voice', voiceRoutes);

--- a/packages/gateway/src/routes/voice.ts
+++ b/packages/gateway/src/routes/voice.ts
@@ -9,9 +9,10 @@
  *   POST /synthesize — send text → get audio binary
  */
 
+import { LOCAL_OWNER_ID } from '../config/defaults.js';
 import { Hono } from 'hono';
 import { getVoiceService } from '../services/voice-service.js';
-import { getUserId, apiResponse, apiError, ERROR_CODES, getErrorMessage } from './helpers.js';
+import { apiResponse, apiError, ERROR_CODES, getErrorMessage } from './helpers.js';
 import { validateBody, synthesizeVoiceSchema } from '../middleware/validation.js';
 import { createLoginThrottle } from '../utils/login-throttle.js';
 import { getClientIp } from '../utils/client-ip.js';
@@ -43,7 +44,7 @@ if (typeof voiceThrottleCleanup === 'object' && 'unref' in voiceThrottleCleanup)
 
 voiceRoutes.get('/config', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     // IDOR-017: Reject unauthenticated requests
     if (userId === 'default' && !c.get('sessionAuthenticated')) {
       return apiError(
@@ -62,7 +63,7 @@ voiceRoutes.get('/config', async (c) => {
 
 voiceRoutes.get('/status', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     // IDOR-017: Reject unauthenticated requests
     if (userId === 'default' && !c.get('sessionAuthenticated')) {
       return apiError(
@@ -81,7 +82,7 @@ voiceRoutes.get('/status', async (c) => {
 
 voiceRoutes.get('/voices', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     // IDOR-017: Reject unauthenticated requests
     if (userId === 'default' && !c.get('sessionAuthenticated')) {
       return apiError(
@@ -104,7 +105,7 @@ voiceRoutes.get('/voices', async (c) => {
 
 voiceRoutes.get('/diagnostics', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     // IDOR-017: Reject unauthenticated requests
     if (userId === 'default' && !c.get('sessionAuthenticated')) {
       return apiError(
@@ -127,7 +128,7 @@ voiceRoutes.get('/diagnostics', async (c) => {
 
 voiceRoutes.post('/transcribe', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     // IDOR-017: Reject unauthenticated requests
     if (userId === 'default' && !c.get('sessionAuthenticated')) {
       return apiError(
@@ -215,7 +216,7 @@ voiceRoutes.post('/transcribe', async (c) => {
 
 voiceRoutes.post('/synthesize', async (c) => {
   try {
-    const userId = getUserId(c);
+    const userId = LOCAL_OWNER_ID;
     // IDOR-017: Reject unauthenticated requests
     if (userId === 'default' && !c.get('sessionAuthenticated')) {
       return apiError(

--- a/packages/gateway/src/routes/workflow/index.test.ts
+++ b/packages/gateway/src/routes/workflow/index.test.ts
@@ -90,6 +90,7 @@ vi.mock('../../middleware/validation.js', () => ({
 
 vi.mock('../../config/defaults.js', () => ({
   MAX_PAGINATION_OFFSET: 10000,
+  LOCAL_OWNER_ID: 'default',
 }));
 
 vi.mock('./copilot.js', () => ({
@@ -111,7 +112,7 @@ function createApp() {
   app.use('*', requestId);
   // Simulate authenticated user
   app.use('*', async (c, next) => {
-    c.set('userId', 'u1');
+    c.set('userId', 'default');
     await next();
   });
   app.route('/workflows', workflowRoutes);
@@ -817,7 +818,7 @@ describe('Workflow Routes', () => {
       expect(mockService.executeWorkflow).toHaveBeenCalledOnce();
       const [calledId, calledUserId] = mockService.executeWorkflow.mock.calls[0];
       expect(calledId).toBe('wf-1');
-      expect(calledUserId).toBe('u1');
+      expect(calledUserId).toBe('default');
     });
 
     it('passes dryRun flag to executeWorkflow when query param is set', async () => {
@@ -1400,7 +1401,11 @@ describe('Workflow Routes', () => {
 
       expect(res.status).toBe(200);
       expect(res.headers.get('content-type')).toContain('text/event-stream');
-      expect(mockService.executeWorkflow).toHaveBeenCalledWith('wf-1', 'u1', expect.any(Function));
+      expect(mockService.executeWorkflow).toHaveBeenCalledWith(
+        'wf-1',
+        'default',
+        expect.any(Function)
+      );
     });
   });
 

--- a/packages/gateway/src/routes/workflow/index.ts
+++ b/packages/gateway/src/routes/workflow/index.ts
@@ -5,11 +5,11 @@
  * Execution streams progress via SSE for real-time node visualization.
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { streamSSE } from 'hono/streaming';
 import {
-  getUserId,
   apiResponse,
   apiError,
   notFoundError,
@@ -311,7 +311,7 @@ workflowRoutes.route('/copilot', workflowCopilotRoute);
 // ============================================================================
 
 workflowRoutes.get('/', pagination(), async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const { limit, offset } = c.get('pagination')!;
 
   const repo = createWorkflowsRepository(userId);
@@ -331,7 +331,7 @@ workflowRoutes.get('/', pagination(), async (c) => {
 // ============================================================================
 
 workflowRoutes.post('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const rawBody = await parseJsonBody(c);
   if (!rawBody)
     return apiError(c, { code: ERROR_CODES.BAD_REQUEST, message: 'Invalid JSON body' }, 400);
@@ -394,7 +394,7 @@ workflowRoutes.post('/', async (c) => {
 // ============================================================================
 
 workflowRoutes.get('/logs/recent', pagination(), async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const { limit, offset } = c.get('pagination')!;
 
   const repo = createWorkflowsRepository(userId);
@@ -414,7 +414,7 @@ workflowRoutes.get('/logs/recent', pagination(), async (c) => {
 // ============================================================================
 
 workflowRoutes.get('/logs/:logId', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const logId = sanitizeId(c.req.param('logId'));
 
   const repo = createWorkflowsRepository(userId);
@@ -429,7 +429,7 @@ workflowRoutes.get('/logs/:logId', async (c) => {
 // ============================================================================
 
 workflowRoutes.get('/active-tool-names', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const repo = createWorkflowsRepository(userId);
   const toolNamesArr = await repo.getActiveToolNames();
   const activeToolNames = new Set<string>(toolNamesArr);
@@ -442,7 +442,7 @@ workflowRoutes.get('/active-tool-names', async (c) => {
 // ============================================================================
 
 workflowRoutes.post('/:id/clone', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = sanitizeId(c.req.param('id'));
 
   const repo = createWorkflowsRepository(userId);
@@ -504,7 +504,7 @@ workflowRoutes.post('/:id/clone', async (c) => {
 // ============================================================================
 
 workflowRoutes.get('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = sanitizeId(c.req.param('id'));
 
   const repo = createWorkflowsRepository(userId);
@@ -519,7 +519,7 @@ workflowRoutes.get('/:id', async (c) => {
 // ============================================================================
 
 workflowRoutes.patch('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = sanitizeId(c.req.param('id'));
   const rawBody = await parseJsonBody(c);
   if (!rawBody)
@@ -594,7 +594,7 @@ workflowRoutes.patch('/:id', async (c) => {
 // ============================================================================
 
 workflowRoutes.delete('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = sanitizeId(c.req.param('id'));
 
   const repo = createWorkflowsRepository(userId);
@@ -610,7 +610,7 @@ workflowRoutes.delete('/:id', async (c) => {
 // ============================================================================
 
 workflowRoutes.post('/:id/execute', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = sanitizeId(c.req.param('id'));
   const dryRun = c.req.query('dryRun') === 'true';
 
@@ -663,7 +663,7 @@ workflowRoutes.post('/:id/execute', async (c) => {
 // ============================================================================
 
 workflowRoutes.post('/:id/cancel', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = sanitizeId(c.req.param('id'));
 
   // Verify workflow ownership before allowing cancel
@@ -690,7 +690,7 @@ workflowRoutes.post('/:id/cancel', async (c) => {
 // ============================================================================
 
 workflowRoutes.get('/:id/versions', pagination(), async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = sanitizeId(c.req.param('id'));
   const { limit, offset } = c.get('pagination')!;
 
@@ -713,7 +713,7 @@ workflowRoutes.get('/:id/versions', pagination(), async (c) => {
 });
 
 workflowRoutes.post('/:id/versions/:version/restore', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = sanitizeId(c.req.param('id'));
   const version = parseInt(c.req.param('version'), 10);
   if (isNaN(version) || version < 1) {
@@ -739,7 +739,7 @@ workflowRoutes.post('/:id/versions/:version/restore', async (c) => {
 // ============================================================================
 
 workflowRoutes.get('/:id/logs', pagination(), async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = sanitizeId(c.req.param('id'));
   const { limit, offset } = c.get('pagination')!;
 
@@ -766,7 +766,7 @@ workflowRoutes.get('/:id/logs', pagination(), async (c) => {
 // ============================================================================
 
 workflowRoutes.get('/approvals/pending', pagination(), async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const { limit, offset } = c.get('pagination')!;
 
   const repo = createWorkflowApprovalsRepository(userId);
@@ -785,7 +785,7 @@ workflowRoutes.get('/approvals/pending', pagination(), async (c) => {
 });
 
 workflowRoutes.get('/approvals/all', pagination(), async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const { limit, offset } = c.get('pagination')!;
 
   const repo = createWorkflowApprovalsRepository(userId);
@@ -801,7 +801,7 @@ workflowRoutes.get('/approvals/all', pagination(), async (c) => {
 });
 
 workflowRoutes.post('/approvals/:id/approve', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = sanitizeId(c.req.param('id'));
 
   const repo = createWorkflowApprovalsRepository(userId);
@@ -848,7 +848,7 @@ workflowRoutes.post('/approvals/:id/approve', async (c) => {
 });
 
 workflowRoutes.post('/approvals/:id/reject', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = sanitizeId(c.req.param('id'));
 
   const repo = createWorkflowApprovalsRepository(userId);
@@ -902,7 +902,7 @@ workflowRoutes.post('/:id/run', async (c) => {
     );
   }
 
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const id = sanitizeId(c.req.param('id'));
 
   let inputs: Record<string, unknown> | undefined;
@@ -1023,7 +1023,7 @@ workflowRoutes.get('/:id/run/:logId', async (c) => {
     );
   }
 
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const logId = sanitizeId(c.req.param('logId'));
 
   const repo = createWorkflowsRepository(userId);
@@ -1038,7 +1038,7 @@ workflowRoutes.get('/:id/run/:logId', async (c) => {
 // ============================================================================
 
 workflowRoutes.post('/logs/:logId/replay', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const logId = sanitizeId(c.req.param('logId'));
 
   const repo = createWorkflowsRepository(userId);

--- a/packages/gateway/src/routes/workspaces/container.test.ts
+++ b/packages/gateway/src/routes/workspaces/container.test.ts
@@ -21,7 +21,7 @@ import { workspaceContainerRoutes } from './container.js';
 function makeWorkspace(overrides: Record<string, unknown> = {}) {
   return {
     id: 'ws-1',
-    userId: 'user-1',
+    userId: 'default',
     name: 'Test',
     status: 'active',
     storagePath: '/tmp/ws-1',
@@ -43,7 +43,7 @@ describe('Workspace Container Routes', () => {
     vi.clearAllMocks();
     app = new Hono();
     app.use('*', async (c, next) => {
-      c.set('userId', 'user-1');
+      c.set('userId', 'default');
       await next();
     });
     app.route('/', workspaceContainerRoutes);
@@ -75,7 +75,7 @@ describe('Workspace Container Routes', () => {
       expect(json.data.containerId).toBe('ctr-new');
       expect(json.data.status).toBe('running');
       expect(mockOrchestrator.createContainer).toHaveBeenCalledWith(
-        'user-1',
+        'default',
         'ws-1',
         '/tmp/ws-1',
         ws.containerConfig

--- a/packages/gateway/src/routes/workspaces/container.ts
+++ b/packages/gateway/src/routes/workspaces/container.ts
@@ -8,17 +8,11 @@
  * GET /system/status           - Get sandbox system status
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import { WorkspacesRepository } from '../../db/repositories/workspaces.js';
 import { getOrchestrator, isDockerAvailable, type ContainerConfig } from '@ownpilot/core';
-import {
-  apiResponse,
-  apiError,
-  ERROR_CODES,
-  getIntParam,
-  getUserId,
-  getErrorMessage,
-} from '../helpers.js';
+import { apiResponse, apiError, ERROR_CODES, getIntParam, getErrorMessage } from '../helpers.js';
 
 const app = new Hono();
 
@@ -26,7 +20,7 @@ const app = new Hono();
  * POST /workspaces/:id/container/start - Start container
  */
 app.post('/:id/container/start', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   const repo = new WorkspacesRepository(userId);
 
@@ -85,7 +79,7 @@ app.post('/:id/container/start', async (c) => {
  * POST /workspaces/:id/container/stop - Stop container
  */
 app.post('/:id/container/stop', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   const repo = new WorkspacesRepository(userId);
 
@@ -129,7 +123,7 @@ app.post('/:id/container/stop', async (c) => {
  * GET /workspaces/:id/container/status - Get container status
  */
 app.get('/:id/container/status', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   const repo = new WorkspacesRepository(userId);
 
@@ -183,7 +177,7 @@ app.get('/:id/container/status', async (c) => {
  * GET /workspaces/:id/container/logs - Get container logs
  */
 app.get('/:id/container/logs', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   const tail = getIntParam(c, 'tail', 100, 1, 1000);
   const repo = new WorkspacesRepository(userId);

--- a/packages/gateway/src/routes/workspaces/crud.test.ts
+++ b/packages/gateway/src/routes/workspaces/crud.test.ts
@@ -90,7 +90,7 @@ const { workspaceCrudRoutes } = await import('./crud.js');
 
 const sampleWorkspace = {
   id: 'ws-1',
-  userId: 'user-1',
+  userId: 'default',
   name: 'My Workspace',
   description: 'Test workspace',
   status: 'active',
@@ -109,7 +109,7 @@ const sampleWorkspace = {
 function createApp() {
   const app = new Hono();
   app.use('*', async (c, next) => {
-    c.set('userId', 'user-1');
+    c.set('userId', 'default');
     await next();
   });
   app.route('/', workspaceCrudRoutes);
@@ -349,7 +349,7 @@ describe('Workspace CRUD Routes', () => {
 
     it('calls getStorageUsage with userId/workspaceId path', async () => {
       await app.request('/ws-1');
-      expect(mockStorage.getStorageUsage).toHaveBeenCalledWith('user-1/ws-1');
+      expect(mockStorage.getStorageUsage).toHaveBeenCalledWith('default/ws-1');
     });
   });
 

--- a/packages/gateway/src/routes/workspaces/crud.ts
+++ b/packages/gateway/src/routes/workspaces/crud.ts
@@ -8,6 +8,7 @@
  * DELETE /:id - Delete workspace
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import { WorkspacesRepository } from '../../db/repositories/workspaces.js';
 import {
@@ -18,14 +19,7 @@ import {
   type ContainerConfig,
   DEFAULT_CONTAINER_CONFIG,
 } from '@ownpilot/core';
-import {
-  apiResponse,
-  apiError,
-  ERROR_CODES,
-  getUserId,
-  getErrorMessage,
-  parseJsonBody,
-} from '../helpers.js';
+import { apiResponse, apiError, ERROR_CODES, getErrorMessage, parseJsonBody } from '../helpers.js';
 import { wsGateway } from '../../ws/server.js';
 import { sanitizeContainerConfig } from './shared.js';
 
@@ -35,7 +29,7 @@ const app = new Hono();
  * GET /workspaces - List user's workspaces
  */
 app.get('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const repo = new WorkspacesRepository(userId);
 
   try {
@@ -73,7 +67,7 @@ app.get('/', async (c) => {
  * POST /workspaces - Create a new workspace
  */
 app.post('/', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const repo = new WorkspacesRepository(userId);
 
   try {
@@ -157,7 +151,7 @@ app.post('/', async (c) => {
  * GET /workspaces/:id - Get workspace details
  */
 app.get('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   const repo = new WorkspacesRepository(userId);
 
@@ -206,7 +200,7 @@ app.get('/:id', async (c) => {
  * PATCH /workspaces/:id - Update workspace
  */
 app.patch('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   const repo = new WorkspacesRepository(userId);
 
@@ -278,7 +272,7 @@ app.patch('/:id', async (c) => {
  * DELETE /workspaces/:id - Delete workspace
  */
 app.delete('/:id', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   const repo = new WorkspacesRepository(userId);
 

--- a/packages/gateway/src/routes/workspaces/execution.test.ts
+++ b/packages/gateway/src/routes/workspaces/execution.test.ts
@@ -22,7 +22,7 @@ import { workspaceExecutionRoutes } from './execution.js';
 function makeWorkspace(overrides: Record<string, unknown> = {}) {
   return {
     id: 'ws-1',
-    userId: 'user-1',
+    userId: 'default',
     name: 'Test',
     status: 'active',
     storagePath: '/tmp/ws-1',
@@ -45,7 +45,7 @@ describe('Workspace Execution Routes', () => {
     vi.clearAllMocks();
     app = new Hono();
     app.use('*', async (c, next) => {
-      c.set('userId', 'user-1');
+      c.set('userId', 'default');
       await next();
     });
     app.route('/', workspaceExecutionRoutes);
@@ -203,7 +203,7 @@ describe('Workspace Execution Routes', () => {
       });
       expect(res.status).toBe(200);
       expect(mockStorage.writeFile).toHaveBeenCalledWith(
-        'user-1/ws-1',
+        'default/ws-1',
         'helper.py',
         'def foo(): pass'
       );
@@ -310,7 +310,7 @@ describe('Workspace Execution Routes', () => {
         {
           id: 'exec-1',
           workspaceId: 'ws-1',
-          userId: 'user-1',
+          userId: 'default',
           language: 'python',
           codeHash: 'abc123',
           status: 'completed',

--- a/packages/gateway/src/routes/workspaces/execution.ts
+++ b/packages/gateway/src/routes/workspaces/execution.ts
@@ -6,6 +6,7 @@
  * GET /:id/executions  - List executions
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import { WorkspacesRepository } from '../../db/repositories/workspaces.js';
 import {
@@ -20,7 +21,6 @@ import {
   apiError,
   ERROR_CODES,
   getIntParam,
-  getUserId,
   zodValidationError,
   getErrorMessage,
   parseJsonBody,
@@ -32,7 +32,7 @@ const app = new Hono();
  * GET /workspaces/:id/stats - Get workspace statistics
  */
 app.get('/:id/stats', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   const repo = new WorkspacesRepository(userId);
 
@@ -97,7 +97,7 @@ app.get('/:id/stats', async (c) => {
  * POST /workspaces/:id/execute - Execute code in workspace
  */
 app.post('/:id/execute', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   const repo = new WorkspacesRepository(userId);
 
@@ -215,7 +215,7 @@ app.post('/:id/execute', async (c) => {
  * GET /workspaces/:id/executions - List executions
  */
 app.get('/:id/executions', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   const limit = getIntParam(c, 'limit', 50, 1, 200);
   const repo = new WorkspacesRepository(userId);

--- a/packages/gateway/src/routes/workspaces/files.test.ts
+++ b/packages/gateway/src/routes/workspaces/files.test.ts
@@ -26,7 +26,7 @@ import { workspaceFileRoutes } from './files.js';
 function makeWorkspace(overrides: Record<string, unknown> = {}) {
   return {
     id: 'ws-1',
-    userId: 'user-1',
+    userId: 'default',
     name: 'Test Workspace',
     status: 'active',
     storagePath: '/tmp/ws-1',
@@ -46,7 +46,7 @@ describe('Workspace File Routes', () => {
     vi.clearAllMocks();
     app = new Hono();
     app.use('*', async (c, next) => {
-      c.set('userId', 'user-1');
+      c.set('userId', 'default');
       await next();
     });
     app.route('/workspaces', workspaceFileRoutes);
@@ -81,14 +81,14 @@ describe('Workspace File Routes', () => {
       expect(json.data.files).toHaveLength(2);
       expect(json.data.count).toBe(2);
       expect(json.data.path).toBe('.');
-      expect(mockStorage.listFiles).toHaveBeenCalledWith('user-1/ws-1', '.', false);
+      expect(mockStorage.listFiles).toHaveBeenCalledWith('default/ws-1', '.', false);
     });
     it('should list files with path and recursive params', async () => {
       mockRepo.get.mockResolvedValue(makeWorkspace());
       mockStorage.listFiles.mockResolvedValue([]);
       const res = await app.request('/workspaces/ws-1/files?path=src&recursive=true');
       expect(res.status).toBe(200);
-      expect(mockStorage.listFiles).toHaveBeenCalledWith('user-1/ws-1', 'src', true);
+      expect(mockStorage.listFiles).toHaveBeenCalledWith('default/ws-1', 'src', true);
     });
     it('should return 400 for directory traversal path', async () => {
       const res = await app.request('/workspaces/ws-1/files?path=../../etc/passwd');
@@ -188,7 +188,7 @@ describe('Workspace File Routes', () => {
       expect(json.data.path).toBe('new-file.txt');
       expect(json.data.written).toBe(true);
       expect(mockStorage.writeFile).toHaveBeenCalledWith(
-        'user-1/ws-1',
+        'default/ws-1',
         'new-file.txt',
         'hello world'
       );
@@ -277,7 +277,7 @@ describe('Workspace File Routes', () => {
       const json = await res.json();
       expect(json.data.path).toBe('old-file.txt');
       expect(json.data.deleted).toBe(true);
-      expect(mockStorage.deleteFile).toHaveBeenCalledWith('user-1/ws-1', 'old-file.txt');
+      expect(mockStorage.deleteFile).toHaveBeenCalledWith('default/ws-1', 'old-file.txt');
       expect(mockRepo.logAudit).toHaveBeenCalledWith('delete', 'file', 'old-file.txt');
     });
     it('should handle URL-normalized traversal paths', async () => {

--- a/packages/gateway/src/routes/workspaces/files.ts
+++ b/packages/gateway/src/routes/workspaces/files.ts
@@ -8,6 +8,7 @@
  * GET /:id/download    - Download workspace as ZIP
  */
 
+import { LOCAL_OWNER_ID } from '../../config/defaults.js';
 import { Hono } from 'hono';
 import { WorkspacesRepository } from '../../db/repositories/workspaces.js';
 import { getWorkspaceStorage, StorageSecurityError } from '@ownpilot/core';
@@ -15,7 +16,6 @@ import {
   apiResponse,
   apiError,
   ERROR_CODES,
-  getUserId,
   zodValidationError,
   getErrorMessage,
   parseJsonBody,
@@ -28,7 +28,7 @@ const app = new Hono();
  * GET /workspaces/:id/files - List files in workspace
  */
 app.get('/:id/files', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   const rawPath = c.req.query('path') || '.';
   const recursive = c.req.query('recursive') === 'true';
@@ -79,7 +79,7 @@ app.get('/:id/files', async (c) => {
  * GET /workspaces/:id/files/* - Read a file
  */
 app.get('/:id/files/*', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   const rawPath = c.req.path.replace(`/workspaces/${workspaceId}/files/`, '');
   const repo = new WorkspacesRepository(userId);
@@ -130,7 +130,7 @@ app.get('/:id/files/*', async (c) => {
  * PUT /workspaces/:id/files/* - Write a file
  */
 app.put('/:id/files/*', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   const rawPath = c.req.path.replace(`/workspaces/${workspaceId}/files/`, '');
   const repo = new WorkspacesRepository(userId);
@@ -193,7 +193,7 @@ app.put('/:id/files/*', async (c) => {
  * DELETE /workspaces/:id/files/* - Delete a file
  */
 app.delete('/:id/files/*', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   const rawPath = c.req.path.replace(`/workspaces/${workspaceId}/files/`, '');
   const repo = new WorkspacesRepository(userId);
@@ -248,7 +248,7 @@ app.delete('/:id/files/*', async (c) => {
  * GET /workspaces/:id/download - Download workspace as ZIP
  */
 app.get('/:id/download', async (c) => {
-  const userId = getUserId(c);
+  const userId = LOCAL_OWNER_ID;
   const workspaceId = c.req.param('id');
   const repo = new WorkspacesRepository(userId);
 


### PR DESCRIPTION
Finishes the in-progress single-tenant pivot: route handlers no longer derive an owner from the authenticated request — they use a fixed `LOCAL_OWNER_ID` (`'default'`). OwnPilot is a single-user/self-hosted gateway; the `user_id` column is kept for historical compatibility and possible future profile separation.

## Source (62 files)
- Add `LOCAL_OWNER_ID` to `config/defaults.ts`; remove `getUserId(c)` from `routes/helpers.ts`.
- Replace `const userId = getUserId(c)` → `LOCAL_OWNER_ID` across 64 route files.
- Routes keep their **residual ownership guards** (`resource.userId !== LOCAL_OWNER_ID → 404`) and owner-scoped list filters, so rows owned by any other `userId` (e.g. legacy data) are still rejected/filtered.

## Tests (34 files)
- Update assertions/middleware to expect `'default'` instead of the previously-injected authenticated userId.
- Add `c.set('sessionAuthenticated', true)` where routes now require it (voice, bridges, agents/command-center, custom-data — these 401 without it under the local-owner path).
- **Rewrite** obsolete cross-user isolation tests (mcp, extensions/integration) to verify the *residual* single-tenant guard (a resource owned by a non-`default` userId → 404 / filtered) instead of per-user denial.
- Add `LOCAL_OWNER_ID` to the workflow test's `config/defaults` mock (it was returning `undefined` → 500).

## ⚠️ Security note (by design)
This **removes per-request user scoping**. The auth middleware still sets `c.get('userId')` from the JWT `sub`, but routes ignore it. If ever deployed multi-user, all requests share the `'default'` store. This is the deliberate single-user product decision.

## Verification
- Gateway typecheck: clean
- Gateway tests: **17196 / 17196 pass**
- The one failing suite (`database/schema.test.ts`) is a **pre-existing, unrelated** `child_process`-mock collection error that fails identically on `main` (verified) — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)