### PR TITLE
fix(ws): close key-length timing side-channel in WebSocket auth

### DIFF
--- a/packages/gateway/src/middleware/auth.ts
+++ b/packages/gateway/src/middleware/auth.ts
@@ -29,8 +29,12 @@ const MAX_API_KEY_LENGTH = 256;
  * an attacker can't distinguish key lengths via comparison timing.
  *
  * Returns true if `candidate` matches any key in `validKeys`.
+ *
+ * Exported so non-HTTP entry points (e.g. the WebSocket upgrade handler)
+ * share the same hardened comparison instead of re-implementing a
+ * length-leaking variant.
  */
-function apiKeyMatches(candidate: string, validKeys: string[]): boolean {
+export function apiKeyMatches(candidate: string, validKeys: string[]): boolean {
   if (candidate.length === 0 || candidate.length > MAX_API_KEY_LENGTH) return false;
   const candidateDigest = createHash('sha256').update(candidate, 'utf8').digest();
   let result = false;

--- a/packages/gateway/src/ws/server.ts
+++ b/packages/gateway/src/ws/server.ts
@@ -9,7 +9,7 @@ import type { IncomingMessage } from 'node:http';
 import type { Server as HttpServer } from 'node:http';
 import type { Server as HttpsServer } from 'node:https';
 import type { Http2SecureServer, Http2Server } from 'node:http2';
-import { timingSafeEqual } from 'node:crypto';
+import { apiKeyMatches } from '../middleware/auth.js';
 import {
   validateSession as validateUiSession,
   isPasswordConfigured,
@@ -78,12 +78,10 @@ async function validateWsAuth(auth: WsAuth): Promise<boolean> {
 
   // Auth enabled but no token provided
   if (!auth.apiToken) return false;
-  // Timing-safe comparison against all valid keys
-  const tokenBuf = Buffer.from(auth.apiToken);
-  return apiKeys.some((key) => {
-    const keyBuf = Buffer.from(key);
-    return tokenBuf.length === keyBuf.length && timingSafeEqual(tokenBuf, keyBuf);
-  });
+  // Shared H-S14 hardened compare: hashes both sides to a fixed-size digest
+  // before timingSafeEqual, so neither the match nor the key length leaks via
+  // timing (the previous raw length-gated compare revealed valid-key lengths).
+  return apiKeyMatches(auth.apiToken, apiKeys);
 }
 
 function getCookieValue(cookieHeader: string | undefined, name: string): string | null {


### PR DESCRIPTION
The WebSocket upgrade auth compared the token to each API key with a raw `tokenBuf.length === keyBuf.length && timingSafeEqual(...)`. The length pre-check short-circuits, leaking valid-key lengths via timing — the exact issue the HTTP path already fixed under **H-S14** (hash both sides to a fixed-size SHA-256 digest before `timingSafeEqual`).

## Change
- Export the hardened `apiKeyMatches` helper from `middleware/auth.ts`.
- Reuse it in `validateWsAuth` (ws/server.ts) instead of the bespoke length-leaking compare. Also bounds candidate length (`MAX_API_KEY_LENGTH`).
- Drop the now-unused `timingSafeEqual` import.

## Verification
- No circular import (auth middleware doesn't depend on ws).
- Gateway typecheck clean.
- WS + auth tests: **236/236**. Behavior unchanged for valid/invalid tokens — only the timing property changes (not deterministically testable, hence no new test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)