### PR TITLE
fix(extensions): repair silently-broken removal-marker queries (PG param type inference)

### DIFF
--- a/packages/gateway/src/db/repositories/extensions.ts
+++ b/packages/gateway/src/db/repositories/extensions.ts
@@ -271,7 +271,7 @@ export class ExtensionsRepository extends BaseRepository {
     await this.execute(
       `DELETE FROM user_extension_removals
        WHERE user_id = $1
-         AND (extension_id = $2 OR ($3 IS NOT NULL AND source_path = $3))`,
+         AND (extension_id = $2 OR ($3::text IS NOT NULL AND source_path = $3))`,
       [userId, extensionId, sourcePath ?? null]
     );
   }
@@ -283,8 +283,8 @@ export class ExtensionsRepository extends BaseRepository {
       `SELECT user_id, extension_id, source_path, removed_at
        FROM user_extension_removals
        WHERE user_id = $1
-         AND (($2 IS NOT NULL AND extension_id = $2)
-           OR ($3 IS NOT NULL AND source_path = $3))
+         AND (($2::text IS NOT NULL AND extension_id = $2)
+           OR ($3::text IS NOT NULL AND source_path = $3))
        LIMIT 1`,
       [userId, extensionId ?? null, sourcePath ?? null]
     );


### PR DESCRIPTION
Found by booting the gateway end-to-end (unit tests mock the repo, so this was invisible to them): **40 `could not determine data type of parameter $2/$3` errors at startup**, one pair per installed extension, from `ExtensionService`'s removal-marker check/clear.

## Root cause
`extensions.ts` `isRemoved()` / `clearRemoval()` use `$N IS NOT NULL` guards on bare params:
```sql
... AND (($2 IS NOT NULL AND extension_id = $2) OR ($3 IS NOT NULL AND source_path = $3))
```
node-postgres sends parameters untyped, and `$N IS NOT NULL` gives Postgres nothing to infer from → it can't determine the type and throws. The errors were caught and logged as warnings, so the **removal-marker feature was silently non-functional**: `isRemoved` always returned `false` and `clearRemoval` always no-op'd — a "removed" extension was never actually detected as removed.

## Fix
Add `::text` casts to the `IS NOT NULL` operands so PG can determine the parameter types.

## Verification
- Before: 40 errors on gateway boot. After: **0** (re-booted to confirm), gateway healthy.
- Gateway typecheck clean; 325 extension repo/service tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)