### PR TITLE
chore(dead-code): clean unused type exports in gateway + ui

### DIFF
--- a/packages/gateway/src/acp/acp-handlers.ts
+++ b/packages/gateway/src/acp/acp-handlers.ts
@@ -46,7 +46,7 @@ const log = getLog('AcpHandlers');
 // TYPES
 // =============================================================================
 
-export interface AcpClientHandlerOptions {
+interface AcpClientHandlerOptions {
   ownerSessionId: string;
   cwd: string;
   env?: Record<string, string>;

--- a/packages/gateway/src/acp/types.ts
+++ b/packages/gateway/src/acp/types.ts
@@ -9,7 +9,6 @@ import type {
   ToolCallStatus,
   PlanEntryStatus,
   PlanEntryPriority,
-  StopReason,
   ContentBlock,
   SessionMode,
   SessionConfigOption,
@@ -134,7 +133,7 @@ export type AcpEventType =
   | 'coding-agent:acp:session-info';
 
 /** Base payload for all ACP events */
-export interface AcpEventBase {
+interface AcpEventBase {
   sessionId: string;
   timestamp: string;
 }
@@ -170,9 +169,6 @@ export interface AcpThoughtEvent extends AcpEventBase {
 }
 
 /** Prompt turn completed */
-export interface AcpCompleteEvent extends AcpEventBase {
-  stopReason: StopReason;
-}
 
 /** Permission request from agent */
 export interface AcpPermissionRequestEvent extends AcpEventBase {

--- a/packages/gateway/src/autonomy/approvals.ts
+++ b/packages/gateway/src/autonomy/approvals.ts
@@ -23,22 +23,13 @@ import { MS_PER_DAY, SCHEDULER_DEFAULT_TIMEOUT_MS } from '../config/defaults.js'
 // Approval Manager
 // ============================================================================
 
-export interface ApprovalManagerConfig {
+interface ApprovalManagerConfig {
   /** Default timeout for approvals in ms */
   defaultTimeout?: number;
   /** Maximum pending actions per user */
   maxPendingPerUser?: number;
   /** Enable auto-approval for low-risk actions */
   autoApproveLowRisk?: boolean;
-}
-
-export interface ApprovalManagerEvents {
-  'action:pending': (action: PendingAction) => void;
-  'action:approved': (action: PendingAction, decision: ApprovalDecision) => void;
-  'action:rejected': (action: PendingAction, decision: ApprovalDecision) => void;
-  'action:expired': (action: PendingAction) => void;
-  'action:auto_approved': (action: PendingAction) => void;
-  notification: (notification: AutonomyNotification) => void;
 }
 
 export class ApprovalManager extends EventEmitter {

--- a/packages/gateway/src/autonomy/autonomy-guard.ts
+++ b/packages/gateway/src/autonomy/autonomy-guard.ts
@@ -20,7 +20,7 @@ import { AutonomyLevel } from './types.js';
 // Types
 // ============================================================================
 
-export interface AutonomyDecision {
+interface AutonomyDecision {
   /** Whether the action is allowed to proceed */
   allowed: boolean;
   /** Whether approval is required */

--- a/packages/gateway/src/autonomy/engine.ts
+++ b/packages/gateway/src/autonomy/engine.ts
@@ -69,7 +69,7 @@ export const DEFAULT_PULSE_DIRECTIVES: PulseDirectives = {
 // Configuration
 // ============================================================================
 
-export interface AutonomyEngineConfig {
+interface AutonomyEngineConfig {
   userId: string;
   enabled?: boolean;
   minIntervalMs?: number;

--- a/packages/gateway/src/autonomy/evaluator.ts
+++ b/packages/gateway/src/autonomy/evaluator.ts
@@ -46,7 +46,7 @@ export interface Signal {
   severity: SignalSeverity;
 }
 
-export interface EvaluationResult {
+interface EvaluationResult {
   /** Whether to invoke the LLM */
   shouldCallLLM: boolean;
   /** Detected signals */

--- a/packages/gateway/src/channels/plugins/telegram/telegram-api.ts
+++ b/packages/gateway/src/channels/plugins/telegram/telegram-api.ts
@@ -94,7 +94,7 @@ async function convertAudioToOggOpus(audio: Buffer): Promise<Buffer> {
 // Types
 // ============================================================================
 
-export interface TelegramChannelConfig {
+interface TelegramChannelConfig {
   bot_token: string;
   allowed_users?: string;
   allowed_chats?: string;

--- a/packages/gateway/src/channels/plugins/telegram/webhook.ts
+++ b/packages/gateway/src/channels/plugins/telegram/webhook.ts
@@ -8,7 +8,7 @@
 
 import { webhookCallback, type Bot } from 'grammy';
 
-export interface WebhookHandler {
+interface WebhookHandler {
   secret: string;
   callback: (req: Request) => Promise<Response>;
 }

--- a/packages/gateway/src/channels/plugins/whatsapp/whatsapp-api.ts
+++ b/packages/gateway/src/channels/plugins/whatsapp/whatsapp-api.ts
@@ -135,7 +135,7 @@ interface WhatsAppBaileysConfig {
 // Group/Chat Listing Types
 // ============================================================================
 
-export interface WhatsAppGroupSummary {
+interface WhatsAppGroupSummary {
   id: string;
   subject: string;
   description: string | null;
@@ -149,7 +149,7 @@ export interface WhatsAppGroupSummary {
   linkedParent: string | null;
 }
 
-export interface WhatsAppGroupDetail extends WhatsAppGroupSummary {
+interface WhatsAppGroupDetail extends WhatsAppGroupSummary {
   participants: Array<{
     jid: string;
     phone: string;

--- a/packages/gateway/src/db/repositories/bookmarks.ts
+++ b/packages/gateway/src/db/repositories/bookmarks.ts
@@ -9,7 +9,7 @@ import { parseJsonField } from './base.js';
 import { CrudRepository, type CreateFields } from './crud-base.js';
 import type { UpdateField } from './query-helpers.js';
 
-export interface Bookmark {
+interface Bookmark {
   id: string;
   userId: string;
   url: string;
@@ -25,7 +25,7 @@ export interface Bookmark {
   updatedAt: Date;
 }
 
-export interface CreateBookmarkInput {
+interface CreateBookmarkInput {
   url: string;
   title: string;
   description?: string;
@@ -35,7 +35,7 @@ export interface CreateBookmarkInput {
   isFavorite?: boolean;
 }
 
-export interface UpdateBookmarkInput {
+interface UpdateBookmarkInput {
   url?: string;
   title?: string;
   description?: string;

--- a/packages/gateway/src/db/repositories/browser-workflows.ts
+++ b/packages/gateway/src/db/repositories/browser-workflows.ts
@@ -12,7 +12,7 @@ import type { BrowserAction } from '../../services/browser-service.js';
 // Types
 // ============================================================================
 
-export interface BrowserWorkflow {
+interface BrowserWorkflow {
   id: string;
   userId: string;
   name: string;
@@ -32,7 +32,7 @@ export interface WorkflowParameter {
   description: string;
 }
 
-export interface CreateBrowserWorkflowInput {
+interface CreateBrowserWorkflowInput {
   name: string;
   description?: string;
   steps: BrowserAction[];
@@ -40,7 +40,7 @@ export interface CreateBrowserWorkflowInput {
   triggerId?: string;
 }
 
-export interface UpdateBrowserWorkflowInput {
+interface UpdateBrowserWorkflowInput {
   name?: string;
   description?: string;
   steps?: BrowserAction[];

--- a/packages/gateway/src/db/repositories/captures.ts
+++ b/packages/gateway/src/db/repositories/captures.ts
@@ -10,7 +10,7 @@ import { BaseRepository, parseJsonField } from './base.js';
 // Types
 // =============================================================================
 
-export type CaptureType =
+type CaptureType =
   | 'idea'
   | 'thought'
   | 'todo'
@@ -19,9 +19,9 @@ export type CaptureType =
   | 'snippet'
   | 'question'
   | 'other';
-export type ProcessedAsType = 'note' | 'task' | 'bookmark' | 'discarded';
+type ProcessedAsType = 'note' | 'task' | 'bookmark' | 'discarded';
 
-export interface Capture {
+interface Capture {
   id: string;
   userId: string;
   content: string;
@@ -36,19 +36,19 @@ export interface Capture {
   processedAt?: Date;
 }
 
-export interface CreateCaptureInput {
+interface CreateCaptureInput {
   content: string;
   type?: CaptureType;
   tags?: string[];
   source?: string;
 }
 
-export interface ProcessCaptureInput {
+interface ProcessCaptureInput {
   processedAsType: ProcessedAsType;
   processedAsId?: string;
 }
 
-export interface CaptureQuery {
+interface CaptureQuery {
   type?: CaptureType;
   tag?: string;
   processed?: boolean;

--- a/packages/gateway/src/db/repositories/channels/assets.ts
+++ b/packages/gateway/src/db/repositories/channels/assets.ts
@@ -1,6 +1,6 @@
 import { BaseRepository, parseJsonField } from '../base.js';
 
-export interface ChannelAssetRecord {
+interface ChannelAssetRecord {
   id: string;
   channelMessageId: string;
   channelPluginId: string;

--- a/packages/gateway/src/db/repositories/channels/dm-pairing.ts
+++ b/packages/gateway/src/db/repositories/channels/dm-pairing.ts
@@ -14,7 +14,7 @@ import { BaseRepository } from '../base.js';
 // Entity Types
 // ============================================================================
 
-export interface DmPairingRequestEntity {
+interface DmPairingRequestEntity {
   id: string;
   platform: string;
   platformUserId: string;
@@ -24,7 +24,7 @@ export interface DmPairingRequestEntity {
   usedAt?: Date;
 }
 
-export interface CreateDmPairingRequestInput {
+interface CreateDmPairingRequestInput {
   platform: string;
   platformUserId: string;
   code: string;

--- a/packages/gateway/src/db/repositories/channels/index.ts
+++ b/packages/gateway/src/db/repositories/channels/index.ts
@@ -6,17 +6,6 @@
 
 import { BaseRepository } from '../base.js';
 
-export interface ChannelRow {
-  id: string;
-  type: string;
-  name: string;
-  status: string;
-  config: string;
-  created_at: string;
-  connected_at: string | null;
-  last_activity_at: string | null;
-}
-
 export class ChannelsRepository extends BaseRepository {
   /**
    * Upsert a channel row — creates if missing, updates status/name if exists.

--- a/packages/gateway/src/db/repositories/channels/messages.ts
+++ b/packages/gateway/src/db/repositories/channels/messages.ts
@@ -9,7 +9,7 @@ import { getLog } from '../../../services/log.js';
 
 const log = getLog('ChannelMessagesRepo');
 
-export interface ChannelMessage {
+interface ChannelMessage {
   id: string;
   channelId: string;
   externalId?: string;

--- a/packages/gateway/src/db/repositories/channels/sessions.ts
+++ b/packages/gateway/src/db/repositories/channels/sessions.ts
@@ -12,7 +12,7 @@ import { BaseRepository, parseJsonField } from '../base.js';
 // Entity Types
 // ============================================================================
 
-export interface ChannelSessionEntity {
+interface ChannelSessionEntity {
   id: string;
   channelUserId: string;
   channelPluginId: string;
@@ -24,7 +24,7 @@ export interface ChannelSessionEntity {
   lastMessageAt: Date | null;
 }
 
-export interface CreateChannelSessionInput {
+interface CreateChannelSessionInput {
   channelUserId: string;
   channelPluginId: string;
   platformChatId: string;

--- a/packages/gateway/src/db/repositories/channels/users.ts
+++ b/packages/gateway/src/db/repositories/channels/users.ts
@@ -30,7 +30,7 @@ export interface ChannelUserEntity {
   lastSeenAt: Date;
 }
 
-export interface CreateChannelUserInput {
+interface CreateChannelUserInput {
   ownpilotUserId?: string;
   platform: string;
   platformUserId: string;

--- a/packages/gateway/src/db/repositories/channels/verification.ts
+++ b/packages/gateway/src/db/repositories/channels/verification.ts
@@ -13,7 +13,7 @@ import { BaseRepository } from '../base.js';
 // Entity Types
 // ============================================================================
 
-export interface ChannelVerificationTokenEntity {
+interface ChannelVerificationTokenEntity {
   id: string;
   ownpilotUserId: string;
   token: string;

--- a/packages/gateway/src/db/repositories/chat/conversations.ts
+++ b/packages/gateway/src/db/repositories/chat/conversations.ts
@@ -4,7 +4,7 @@
 
 import { BaseRepository, parseJsonField } from '../base.js';
 
-export interface Conversation {
+interface Conversation {
   id: string;
   agentName: string;
   systemPrompt?: string;

--- a/packages/gateway/src/db/repositories/chat/index.ts
+++ b/packages/gateway/src/db/repositories/chat/index.ts
@@ -27,7 +27,7 @@ export interface Conversation {
   metadata: Record<string, unknown>;
 }
 
-export interface MessageAttachment {
+interface MessageAttachment {
   type: 'image' | 'file';
   mimeType?: string;
   filename?: string;
@@ -36,7 +36,7 @@ export interface MessageAttachment {
   path?: string;
 }
 
-export interface Message {
+interface Message {
   id: string;
   conversationId: string;
   role: 'system' | 'user' | 'assistant' | 'tool';
@@ -65,7 +65,7 @@ export interface CreateConversationInput {
   metadata?: Record<string, unknown>;
 }
 
-export interface CreateMessageInput {
+interface CreateMessageInput {
   conversationId: string;
   role: Message['role'];
   content: string;
@@ -86,7 +86,7 @@ export interface CreateMessageInput {
   createdAt?: string;
 }
 
-export interface ConversationQuery {
+interface ConversationQuery {
   agentId?: string;
   isArchived?: boolean;
   search?: string;

--- a/packages/gateway/src/db/repositories/chat/messages.ts
+++ b/packages/gateway/src/db/repositories/chat/messages.ts
@@ -4,7 +4,7 @@
 
 import { BaseRepository, parseJsonFieldNullable } from '../base.js';
 
-export interface MessageAttachment {
+interface MessageAttachment {
   type: 'image' | 'file';
   mimeType?: string;
   filename?: string;
@@ -13,7 +13,7 @@ export interface MessageAttachment {
   path?: string;
 }
 
-export interface Message {
+interface Message {
   id: string;
   conversationId: string;
   role: 'system' | 'user' | 'assistant' | 'tool';

--- a/packages/gateway/src/db/repositories/cli/providers.ts
+++ b/packages/gateway/src/db/repositories/cli/providers.ts
@@ -64,7 +64,7 @@ export interface CliProviderRecord {
   updatedAt: string;
 }
 
-export interface CreateCliProviderInput {
+interface CreateCliProviderInput {
   name: string;
   displayName: string;
   description?: string;
@@ -83,7 +83,7 @@ export interface CreateCliProviderInput {
   userId?: string;
 }
 
-export interface UpdateCliProviderInput {
+interface UpdateCliProviderInput {
   name?: string;
   displayName?: string;
   description?: string;

--- a/packages/gateway/src/db/repositories/cli/tool-policies.ts
+++ b/packages/gateway/src/db/repositories/cli/tool-policies.ts
@@ -25,7 +25,7 @@ interface PolicyRow {
 // PUBLIC TYPES
 // =============================================================================
 
-export interface ToolPolicyRecord {
+interface ToolPolicyRecord {
   toolName: string;
   policy: CliToolPolicy;
 }

--- a/packages/gateway/src/db/repositories/coding-agent/permissions.ts
+++ b/packages/gateway/src/db/repositories/coding-agent/permissions.ts
@@ -30,11 +30,11 @@ interface PermissionRow {
 // PUBLIC TYPES
 // =============================================================================
 
-export type IoFormat = 'text' | 'json' | 'stream-json';
-export type FsAccess = 'none' | 'read-only' | 'read-write' | 'full';
-export type Autonomy = 'supervised' | 'semi-auto' | 'full-auto';
+type IoFormat = 'text' | 'json' | 'stream-json';
+type FsAccess = 'none' | 'read-only' | 'read-write' | 'full';
+type Autonomy = 'supervised' | 'semi-auto' | 'full-auto';
 
-export interface CodingAgentPermissionRecord {
+interface CodingAgentPermissionRecord {
   id: string;
   userId: string;
   providerRef: string;
@@ -50,7 +50,7 @@ export interface CodingAgentPermissionRecord {
   updatedAt: string;
 }
 
-export interface UpsertPermissionInput {
+interface UpsertPermissionInput {
   providerRef: string;
   ioFormat?: IoFormat;
   fsAccess?: FsAccess;

--- a/packages/gateway/src/db/repositories/coding-agent/results.ts
+++ b/packages/gateway/src/db/repositories/coding-agent/results.ts
@@ -32,7 +32,7 @@ interface ResultRow {
 // PUBLIC TYPES
 // =============================================================================
 
-export interface CodingAgentResultRecord {
+interface CodingAgentResultRecord {
   id: string;
   userId: string;
   sessionId?: string;
@@ -50,7 +50,7 @@ export interface CodingAgentResultRecord {
   createdAt: string;
 }
 
-export interface SaveResultInput {
+interface SaveResultInput {
   id: string;
   userId?: string;
   sessionId?: string;

--- a/packages/gateway/src/db/repositories/contacts.ts
+++ b/packages/gateway/src/db/repositories/contacts.ts
@@ -8,7 +8,7 @@ import { BaseRepository, parseJsonField } from './base.js';
 import { buildUpdateStatement, type RawSetClause } from './query-helpers.js';
 import { MS_PER_DAY } from '../../config/defaults.js';
 
-export interface Contact {
+interface Contact {
   id: string;
   userId: string;
   name: string;
@@ -33,7 +33,7 @@ export interface Contact {
   updatedAt: Date;
 }
 
-export interface CreateContactInput {
+interface CreateContactInput {
   name: string;
   nickname?: string;
   email?: string;
@@ -53,7 +53,7 @@ export interface CreateContactInput {
   customFields?: Record<string, string>;
 }
 
-export interface UpdateContactInput {
+interface UpdateContactInput {
   name?: string;
   nickname?: string;
   email?: string;

--- a/packages/gateway/src/db/repositories/costs/index.ts
+++ b/packages/gateway/src/db/repositories/costs/index.ts
@@ -6,7 +6,7 @@
 
 import { BaseRepository } from '../base.js';
 
-export interface Cost {
+interface Cost {
   id: string;
   provider: string;
   model: string;
@@ -50,7 +50,7 @@ function rowToCost(row: CostRow): Cost {
   };
 }
 
-export interface CostSummary {
+interface CostSummary {
   provider: string;
   model: string;
   totalCalls: number;
@@ -60,7 +60,7 @@ export interface CostSummary {
   totalCost: number;
 }
 
-export interface DailyCost {
+interface DailyCost {
   date: string;
   totalCalls: number;
   totalTokens: number;

--- a/packages/gateway/src/db/repositories/costs/provider-metrics.ts
+++ b/packages/gateway/src/db/repositories/costs/provider-metrics.ts
@@ -10,23 +10,7 @@ import { BaseRepository } from '../base.js';
 
 const TABLE = 'provider_metrics';
 
-export interface ProviderMetric {
-  id: string;
-  providerId: string;
-  modelId: string;
-  recordedAt: Date;
-  latencyMs: number;
-  error: boolean;
-  errorType: string | null;
-  promptTokens: number | null;
-  completionTokens: number | null;
-  costUsd: number | null;
-  workflowId: string | null;
-  agentId: string | null;
-  userId: string | null;
-}
-
-export interface RecordMetricInput {
+interface RecordMetricInput {
   id: string;
   providerId: string;
   modelId: string;
@@ -41,7 +25,7 @@ export interface RecordMetricInput {
   userId?: string | null;
 }
 
-export interface RouteMetrics {
+interface RouteMetrics {
   providerId: string;
   modelId: string;
   avgLatencyMs: number;

--- a/packages/gateway/src/db/repositories/crew/memory.ts
+++ b/packages/gateway/src/db/repositories/crew/memory.ts
@@ -20,7 +20,7 @@ interface MemoryRow {
 
 // ── Record Type ─────────────────────────────────────
 
-export interface CrewMemoryEntry {
+interface CrewMemoryEntry {
   id: string;
   crewId: string;
   agentId: string;

--- a/packages/gateway/src/db/repositories/crew/tasks.ts
+++ b/packages/gateway/src/db/repositories/crew/tasks.ts
@@ -28,10 +28,10 @@ interface TaskRow {
 
 // ── Record Type ─────────────────────────────────────
 
-export type CrewTaskPriority = 'low' | 'normal' | 'high' | 'urgent';
-export type CrewTaskStatus = 'pending' | 'in_progress' | 'completed' | 'failed';
+type CrewTaskPriority = 'low' | 'normal' | 'high' | 'urgent';
+type CrewTaskStatus = 'pending' | 'in_progress' | 'completed' | 'failed';
 
-export interface CrewTask {
+interface CrewTask {
   id: string;
   crewId: string;
   createdBy: string;

--- a/packages/gateway/src/db/repositories/embedding-cache.ts
+++ b/packages/gateway/src/db/repositories/embedding-cache.ts
@@ -16,16 +16,6 @@ const log = getLog('EmbeddingCache');
 // Types
 // ============================================================================
 
-export interface EmbeddingCacheEntry {
-  id: string;
-  contentHash: string;
-  modelName: string;
-  embedding: number[];
-  createdAt: Date;
-  lastUsedAt: Date;
-  useCount: number;
-}
-
 interface EmbeddingCacheRow {
   id: string;
   content_hash: string;

--- a/packages/gateway/src/db/repositories/expenses.ts
+++ b/packages/gateway/src/db/repositories/expenses.ts
@@ -25,7 +25,7 @@ export type ExpenseCategory =
   | 'housing'
   | 'other';
 
-export interface Expense {
+interface Expense {
   id: string;
   userId: string;
   date: string;
@@ -42,7 +42,7 @@ export interface Expense {
   updatedAt: Date;
 }
 
-export interface CreateExpenseInput {
+interface CreateExpenseInput {
   date: string;
   amount: number;
   currency?: string;
@@ -55,7 +55,7 @@ export interface CreateExpenseInput {
   notes?: string;
 }
 
-export interface UpdateExpenseInput {
+interface UpdateExpenseInput {
   date?: string;
   amount?: number;
   currency?: string;
@@ -66,7 +66,7 @@ export interface UpdateExpenseInput {
   notes?: string;
 }
 
-export interface ExpenseQuery {
+interface ExpenseQuery {
   dateFrom?: string;
   dateTo?: string;
   category?: string;

--- a/packages/gateway/src/db/repositories/extensions.ts
+++ b/packages/gateway/src/db/repositories/extensions.ts
@@ -73,7 +73,7 @@ export interface ExtensionRecord {
   updatedAt: string;
 }
 
-export interface UpsertExtensionInput {
+interface UpsertExtensionInput {
   id: string;
   userId?: string;
   name: string;

--- a/packages/gateway/src/db/repositories/habits.ts
+++ b/packages/gateway/src/db/repositories/habits.ts
@@ -28,7 +28,7 @@ function safeParseArray(raw: unknown): number[] {
 
 export type HabitFrequency = 'daily' | 'weekly' | 'weekdays' | 'custom';
 
-export interface Habit {
+interface Habit {
   id: string;
   userId: string;
   name: string;
@@ -49,7 +49,7 @@ export interface Habit {
   updatedAt: Date;
 }
 
-export interface HabitLog {
+interface HabitLog {
   id: string;
   habitId: string;
   userId: string;
@@ -59,7 +59,7 @@ export interface HabitLog {
   loggedAt: Date;
 }
 
-export interface CreateHabitInput {
+interface CreateHabitInput {
   name: string;
   description?: string;
   frequency?: HabitFrequency;
@@ -86,13 +86,13 @@ export interface UpdateHabitInput {
   isArchived?: boolean;
 }
 
-export interface HabitQuery {
+interface HabitQuery {
   category?: string;
   isArchived?: boolean;
   limit?: number;
 }
 
-export interface HabitWithTodayStatus extends Habit {
+interface HabitWithTodayStatus extends Habit {
   completedToday: boolean;
   todayCount: number;
 }

--- a/packages/gateway/src/db/repositories/heartbeats/index.ts
+++ b/packages/gateway/src/db/repositories/heartbeats/index.ts
@@ -30,7 +30,7 @@ export interface Heartbeat {
   updatedAt: Date;
 }
 
-export interface CreateHeartbeatInput {
+interface CreateHeartbeatInput {
   name: string;
   scheduleText: string;
   cron: string;
@@ -41,7 +41,7 @@ export interface CreateHeartbeatInput {
   metadata?: Record<string, unknown>;
 }
 
-export interface UpdateHeartbeatInput {
+interface UpdateHeartbeatInput {
   name?: string;
   scheduleText?: string;
   cron?: string;

--- a/packages/gateway/src/db/repositories/idempotency-keys.ts
+++ b/packages/gateway/src/db/repositories/idempotency-keys.ts
@@ -10,7 +10,7 @@ import { BaseRepository } from './base.js';
 const TABLE = 'idempotency_keys';
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
-export interface IdempotencyRecord {
+interface IdempotencyRecord {
   key: string;
   result: unknown;
   createdAt: Date;

--- a/packages/gateway/src/db/repositories/interfaces.ts
+++ b/packages/gateway/src/db/repositories/interfaces.ts
@@ -66,29 +66,6 @@ export interface PaginatedResult<T> {
  * Repositories that implement this interface can still define additional
  * domain-specific methods (search, getActive, decay, etc.).
  */
-export interface IRepository<
-  TEntity,
-  TCreateInput = Partial<TEntity>,
-  TUpdateInput = Partial<TEntity>,
-> {
-  /** Get a single entity by ID. Returns null if not found. */
-  getById(id: string): Promise<TEntity | null>;
-
-  /** List entities with standard pagination and filtering. */
-  list(query?: StandardQuery): Promise<PaginatedResult<TEntity>>;
-
-  /** Create a new entity. Returns the created entity. */
-  create(input: TCreateInput): Promise<TEntity>;
-
-  /** Update an entity by ID. Returns the updated entity or null if not found. */
-  update(id: string, input: TUpdateInput): Promise<TEntity | null>;
-
-  /** Delete an entity by ID. Returns true if deleted, false if not found. */
-  delete(id: string): Promise<boolean>;
-
-  /** Count entities matching an optional filter. */
-  count(filter?: Record<string, unknown>): Promise<number>;
-}
 
 // ============================================================================
 // Helper: Build paginated result from items + total

--- a/packages/gateway/src/db/repositories/local-providers.ts
+++ b/packages/gateway/src/db/repositories/local-providers.ts
@@ -72,7 +72,7 @@ export interface LocalProvider {
   updatedAt: string;
 }
 
-export interface LocalModel {
+interface LocalModel {
   id: string;
   userId: string;
   localProviderId: string;
@@ -87,7 +87,7 @@ export interface LocalModel {
   updatedAt: string;
 }
 
-export interface CreateLocalProviderInput {
+interface CreateLocalProviderInput {
   userId?: string;
   name: string;
   providerType: LocalProviderType;
@@ -96,7 +96,7 @@ export interface CreateLocalProviderInput {
   discoveryEndpoint?: string;
 }
 
-export interface CreateLocalModelInput {
+interface CreateLocalModelInput {
   userId?: string;
   localProviderId: string;
   modelId: string;

--- a/packages/gateway/src/db/repositories/logs.ts
+++ b/packages/gateway/src/db/repositories/logs.ts
@@ -19,7 +19,7 @@ const MAX_ERROR_STACK_LEN = 2000;
 // TYPES
 // =====================================================
 
-export interface RequestLog {
+interface RequestLog {
   id: string;
   userId: string;
   conversationId: string | null;
@@ -42,7 +42,7 @@ export interface RequestLog {
   createdAt: Date;
 }
 
-export interface CreateLogInput {
+interface CreateLogInput {
   conversationId?: string;
   type: RequestLog['type'];
   provider?: string;
@@ -62,7 +62,7 @@ export interface CreateLogInput {
   userAgent?: string;
 }
 
-export interface LogQuery {
+interface LogQuery {
   type?: RequestLog['type'];
   conversationId?: string;
   provider?: string;
@@ -73,7 +73,7 @@ export interface LogQuery {
   offset?: number;
 }
 
-export interface LogStats {
+interface LogStats {
   totalRequests: number;
   errorCount: number;
   successCount: number;

--- a/packages/gateway/src/db/repositories/mcp-servers.ts
+++ b/packages/gateway/src/db/repositories/mcp-servers.ts
@@ -63,7 +63,7 @@ export interface McpServerRecord {
   updatedAt: string;
 }
 
-export interface CreateMcpServerInput {
+interface CreateMcpServerInput {
   name: string;
   displayName: string;
   transport: McpTransport;
@@ -77,7 +77,7 @@ export interface CreateMcpServerInput {
   userId?: string;
 }
 
-export interface UpdateMcpServerInput {
+interface UpdateMcpServerInput {
   name?: string;
   displayName?: string;
   transport?: McpTransport;

--- a/packages/gateway/src/db/repositories/memories.ts
+++ b/packages/gateway/src/db/repositories/memories.ts
@@ -11,7 +11,7 @@ import { getEventSystem } from '@ownpilot/core';
 import { RRF_K } from '../../config/defaults.js';
 
 export type MemoryType = 'fact' | 'preference' | 'conversation' | 'event' | 'skill';
-export type MatchType = 'hybrid' | 'vector' | 'fts' | 'keyword';
+type MatchType = 'hybrid' | 'vector' | 'fts' | 'keyword';
 
 export interface Memory {
   id: string;

--- a/packages/gateway/src/db/repositories/model-configs.ts
+++ b/packages/gateway/src/db/repositories/model-configs.ts
@@ -13,7 +13,7 @@ import type { ModelCapability } from '@ownpilot/core';
 // Types
 // ============================================================================
 
-export interface UserModelConfig {
+interface UserModelConfig {
   id: string;
   userId: string;
   providerId: string;
@@ -31,7 +31,7 @@ export interface UserModelConfig {
   updatedAt: Date;
 }
 
-export interface CustomProvider {
+interface CustomProvider {
   id: string;
   userId: string;
   providerId: string;
@@ -91,7 +91,7 @@ export interface CreateProviderInput {
 }
 
 // User provider config (overrides for built-in providers)
-export interface UserProviderConfig {
+interface UserProviderConfig {
   id: string;
   userId: string;
   providerId: string;
@@ -108,7 +108,7 @@ export interface UserProviderConfig {
   updatedAt: Date;
 }
 
-export interface CreateUserProviderConfigInput {
+interface CreateUserProviderConfigInput {
   userId?: string;
   providerId: string;
   baseUrl?: string;
@@ -122,7 +122,7 @@ export interface CreateUserProviderConfigInput {
   config?: Record<string, unknown>;
 }
 
-export interface UpdateUserProviderConfigInput {
+interface UpdateUserProviderConfigInput {
   baseUrl?: string;
   providerType?: string;
   isEnabled?: boolean;

--- a/packages/gateway/src/db/repositories/notes.ts
+++ b/packages/gateway/src/db/repositories/notes.ts
@@ -24,7 +24,7 @@ export interface Note {
   updatedAt: Date;
 }
 
-export interface CreateNoteInput {
+interface CreateNoteInput {
   title: string;
   content: string;
   contentType?: Note['contentType'];
@@ -34,7 +34,7 @@ export interface CreateNoteInput {
   color?: string;
 }
 
-export interface UpdateNoteInput {
+interface UpdateNoteInput {
   title?: string;
   content?: string;
   contentType?: Note['contentType'];

--- a/packages/gateway/src/db/repositories/orchestration-runs.ts
+++ b/packages/gateway/src/db/repositories/orchestration-runs.ts
@@ -61,7 +61,7 @@ export interface OrchestrationRunRecord {
   completedAt?: string;
 }
 
-export interface CreateRunInput {
+interface CreateRunInput {
   id: string;
   userId: string;
   goal: string;

--- a/packages/gateway/src/db/repositories/plugins.ts
+++ b/packages/gateway/src/db/repositories/plugins.ts
@@ -34,7 +34,7 @@ interface PluginRow {
 // PUBLIC TYPES
 // =============================================================================
 
-export interface PluginRecord {
+interface PluginRecord {
   id: string;
   name: string;
   version: string;
@@ -46,7 +46,7 @@ export interface PluginRecord {
   updatedAt: string;
 }
 
-export interface UpsertPluginInput {
+interface UpsertPluginInput {
   id: string;
   name: string;
   version: string;

--- a/packages/gateway/src/db/repositories/pomodoro.ts
+++ b/packages/gateway/src/db/repositories/pomodoro.ts
@@ -11,10 +11,10 @@ import { MS_PER_DAY } from '../../config/defaults.js';
 // Types
 // =============================================================================
 
-export type SessionType = 'work' | 'short_break' | 'long_break';
-export type SessionStatus = 'running' | 'completed' | 'interrupted';
+type SessionType = 'work' | 'short_break' | 'long_break';
+type SessionStatus = 'running' | 'completed' | 'interrupted';
 
-export interface PomodoroSession {
+interface PomodoroSession {
   id: string;
   userId: string;
   type: SessionType;
@@ -27,7 +27,7 @@ export interface PomodoroSession {
   interruptionReason?: string;
 }
 
-export interface PomodoroSettings {
+interface PomodoroSettings {
   userId: string;
   workDuration: number;
   shortBreakDuration: number;
@@ -38,7 +38,7 @@ export interface PomodoroSettings {
   updatedAt: Date;
 }
 
-export interface PomodoroDailyStats {
+interface PomodoroDailyStats {
   id: string;
   userId: string;
   date: string;
@@ -48,7 +48,7 @@ export interface PomodoroDailyStats {
   interruptions: number;
 }
 
-export interface CreateSessionInput {
+interface CreateSessionInput {
   type: SessionType;
   taskDescription?: string;
   durationMinutes: number;

--- a/packages/gateway/src/db/repositories/query-helpers.ts
+++ b/packages/gateway/src/db/repositories/query-helpers.ts
@@ -21,7 +21,7 @@ export interface RawSetClause {
   sql: string;
 }
 
-export interface UpdateStatement {
+interface UpdateStatement {
   /** The full parameterized SQL string, e.g. UPDATE t SET col=$1 WHERE id=$2 */
   sql: string;
   /** Ordered parameter values matching the $N placeholders */

--- a/packages/gateway/src/db/repositories/settings/index.ts
+++ b/packages/gateway/src/db/repositories/settings/index.ts
@@ -9,7 +9,7 @@ import { getLog } from '../../../services/log.js';
 
 const log = getLog('SettingsRepo');
 
-export interface Setting {
+interface Setting {
   key: string;
   value: unknown;
   updatedAt: Date;

--- a/packages/gateway/src/db/repositories/tasks.ts
+++ b/packages/gateway/src/db/repositories/tasks.ts
@@ -30,7 +30,7 @@ export interface Task {
   updatedAt: Date;
 }
 
-export interface CreateTaskInput {
+interface CreateTaskInput {
   title: string;
   description?: string;
   priority?: Task['priority'];
@@ -44,7 +44,7 @@ export interface CreateTaskInput {
   recurrence?: string;
 }
 
-export interface UpdateTaskInput {
+interface UpdateTaskInput {
   title?: string;
   description?: string;
   status?: Task['status'];

--- a/packages/gateway/src/db/repositories/triggers.ts
+++ b/packages/gateway/src/db/repositories/triggers.ts
@@ -42,7 +42,7 @@ export interface WebhookConfig {
 
 export type TriggerConfig = ScheduleConfig | EventConfig | ConditionConfig | WebhookConfig;
 
-export interface TriggerPreRun {
+interface TriggerPreRun {
   code: string;
   timeoutMs?: number;
 }

--- a/packages/gateway/src/db/repositories/ui-sessions.ts
+++ b/packages/gateway/src/db/repositories/ui-sessions.ts
@@ -7,7 +7,7 @@
 
 import { BaseRepository, ensureTable } from './base.js';
 
-export interface UISession {
+interface UISession {
   tokenHash: string;
   kind: string;
   userId: string;

--- a/packages/gateway/src/db/repositories/workflows/approvals.ts
+++ b/packages/gateway/src/db/repositories/workflows/approvals.ts
@@ -11,9 +11,9 @@ import { generateId } from '@ownpilot/core';
 // Types
 // ============================================================================
 
-export type ApprovalStatus = 'pending' | 'approved' | 'rejected';
+type ApprovalStatus = 'pending' | 'approved' | 'rejected';
 
-export interface WorkflowApproval {
+interface WorkflowApproval {
   id: string;
   workflowLogId: string;
   workflowId: string;
@@ -27,7 +27,7 @@ export interface WorkflowApproval {
   createdAt: Date;
 }
 
-export interface CreateApprovalInput {
+interface CreateApprovalInput {
   workflowLogId: string;
   workflowId: string;
   nodeId: string;

--- a/packages/gateway/src/db/repositories/workflows/index.ts
+++ b/packages/gateway/src/db/repositories/workflows/index.ts
@@ -150,14 +150,14 @@ export interface SwitchNodeData {
   timeoutMs?: number;
 }
 
-export interface ErrorHandlerNodeData {
+interface ErrorHandlerNodeData {
   label: string;
   description?: string;
   continueOnSuccess?: boolean;
   outputAlias?: string;
 }
 
-export interface SubWorkflowNodeData {
+interface SubWorkflowNodeData {
   label: string;
   subWorkflowId?: string;
   subWorkflowName?: string;
@@ -168,20 +168,20 @@ export interface SubWorkflowNodeData {
   timeoutMs?: number;
 }
 
-export interface ApprovalNodeData {
+interface ApprovalNodeData {
   label: string;
   approvalMessage?: string;
   timeoutMinutes?: number;
   description?: string;
 }
 
-export interface StickyNoteNodeData {
+interface StickyNoteNodeData {
   label: string;
   text?: string;
   color?: string;
 }
 
-export interface NotificationNodeData {
+interface NotificationNodeData {
   label: string;
   message?: string;
   severity?: 'info' | 'warning' | 'error' | 'success';
@@ -190,14 +190,14 @@ export interface NotificationNodeData {
   timeoutMs?: number;
 }
 
-export interface ParallelNodeData {
+interface ParallelNodeData {
   label: string;
   branchCount: number;
   branchLabels?: string[];
   description?: string;
 }
 
-export interface MergeNodeData {
+interface MergeNodeData {
   label: string;
   mode?: 'waitAll' | 'firstCompleted';
   description?: string;
@@ -352,7 +352,7 @@ export interface WorkflowLog {
   completedAt: Date | null;
 }
 
-export interface WorkflowVersion {
+interface WorkflowVersion {
   id: string;
   workflowId: string;
   version: number;
@@ -362,7 +362,7 @@ export interface WorkflowVersion {
   createdAt: Date;
 }
 
-export interface CreateWorkflowInput {
+interface CreateWorkflowInput {
   name: string;
   description?: string;
   nodes: WorkflowNode[];
@@ -372,7 +372,7 @@ export interface CreateWorkflowInput {
   inputSchema?: InputParameter[];
 }
 
-export interface UpdateWorkflowInput {
+interface UpdateWorkflowInput {
   name?: string;
   description?: string;
   nodes?: WorkflowNode[];

--- a/packages/gateway/src/db/repositories/workspaces.ts
+++ b/packages/gateway/src/db/repositories/workspaces.ts
@@ -13,11 +13,11 @@ import type { ContainerConfig } from '@ownpilot/core';
 // Types
 // ============================================================================
 
-export type WorkspaceStatus = 'active' | 'paused' | 'deleted';
-export type ContainerStatus = 'stopped' | 'starting' | 'running' | 'stopping' | 'error';
-export type ExecutionStatus = 'pending' | 'running' | 'completed' | 'failed' | 'timeout';
+type WorkspaceStatus = 'active' | 'paused' | 'deleted';
+type ContainerStatus = 'stopped' | 'starting' | 'running' | 'stopping' | 'error';
+type ExecutionStatus = 'pending' | 'running' | 'completed' | 'failed' | 'timeout';
 
-export interface UserWorkspace {
+interface UserWorkspace {
   id: string;
   userId: string;
   name: string;
@@ -31,7 +31,7 @@ export interface UserWorkspace {
   updatedAt: Date;
 }
 
-export interface CodeExecution {
+interface CodeExecution {
   id: string;
   workspaceId: string;
   userId: string;
@@ -45,7 +45,7 @@ export interface CodeExecution {
   createdAt: Date;
 }
 
-export interface CreateWorkspaceInput {
+interface CreateWorkspaceInput {
   userId?: string;
   name: string;
   description?: string;
@@ -53,7 +53,7 @@ export interface CreateWorkspaceInput {
   containerConfig: ContainerConfig;
 }
 
-export interface UpdateWorkspaceInput {
+interface UpdateWorkspaceInput {
   name?: string;
   description?: string;
   status?: WorkspaceStatus;

--- a/packages/gateway/src/db/seeds/default-agents.ts
+++ b/packages/gateway/src/db/seeds/default-agents.ts
@@ -18,7 +18,7 @@ const __dirname = path.dirname(__filename);
 // Path to JSON data file
 const DATA_FILE = path.join(__dirname, '..', '..', '..', 'data', 'seeds', 'default-agents.json');
 
-export interface AgentSeed {
+interface AgentSeed {
   id: string;
   name: string;
   systemPrompt: string;

--- a/packages/gateway/src/mcp/presets.ts
+++ b/packages/gateway/src/mcp/presets.ts
@@ -10,7 +10,7 @@
  * `POST /api/v1/mcp` config shape. Users can always edit the resulting row.
  */
 
-export type PresetEnvKind = 'secret' | 'plain';
+type PresetEnvKind = 'secret' | 'plain';
 
 export interface PresetEnvVar {
   name: string;
@@ -222,7 +222,7 @@ export function getMcpPreset(id: string): McpServerPreset | undefined {
  * Resolve a preset + user-supplied overrides into the row shape accepted by
  * `mcpServersRepo.create()`. Required env vars missing from `env` will throw.
  */
-export interface ResolvedPresetInstall {
+interface ResolvedPresetInstall {
   name: string;
   displayName: string;
   transport: 'stdio';
@@ -233,7 +233,7 @@ export interface ResolvedPresetInstall {
   autoConnect: boolean;
 }
 
-export interface PresetInstallOverrides {
+interface PresetInstallOverrides {
   name?: string;
   displayName?: string;
   extraArgs?: string[];

--- a/packages/gateway/src/mcp/register-cli-mcp.ts
+++ b/packages/gateway/src/mcp/register-cli-mcp.ts
@@ -27,14 +27,14 @@ import { isBinaryInstalled } from '../services/binary-utils.js';
 // Types
 // =============================================================================
 
-export interface McpRegistrationConfig {
+interface McpRegistrationConfig {
   /** OwnPilot gateway URL (default: http://localhost:8080) */
   gatewayUrl?: string;
   /** Path to the MCP server script */
   serverScript?: string;
 }
 
-export interface McpRegistrationResult {
+interface McpRegistrationResult {
   cli: string;
   success: boolean;
   configPath: string;

--- a/packages/gateway/src/mcp/workspace.ts
+++ b/packages/gateway/src/mcp/workspace.ts
@@ -24,7 +24,7 @@ import { getLog } from '../services/log.js';
 // Types
 // =============================================================================
 
-export interface WorkspaceConfig {
+interface WorkspaceConfig {
   /** OwnPilot gateway URL (default: http://localhost:8080) */
   gatewayUrl?: string;
   /** Base directory for workspaces (default: ~/.ownpilot/workspace) */
@@ -35,7 +35,7 @@ export interface WorkspaceConfig {
   sessionToken?: string;
 }
 
-export interface WorkspaceInfo {
+interface WorkspaceInfo {
   /** Workspace directory path */
   dir: string;
   /** MCP config file path */

--- a/packages/gateway/src/middleware/circuit-breaker.ts
+++ b/packages/gateway/src/middleware/circuit-breaker.ts
@@ -21,9 +21,9 @@ function secureRandom(): number {
   return Number.parseInt(randomBytes(4).toString('hex'), 16) / 0xffffffff;
 }
 
-export type CircuitState = 'CLOSED' | 'OPEN' | 'HALF_OPEN';
+type CircuitState = 'CLOSED' | 'OPEN' | 'HALF_OPEN';
 
-export interface CircuitBreakerConfig {
+interface CircuitBreakerConfig {
   /** Number of failures before opening the circuit (default: 5) */
   failureThreshold: number;
   /** Time in ms before attempting to close (default: 30000) */

--- a/packages/gateway/src/middleware/pagination.ts
+++ b/packages/gateway/src/middleware/pagination.ts
@@ -20,7 +20,7 @@ export interface PaginationParams {
   offset: number;
 }
 
-export interface PaginationConfig {
+interface PaginationConfig {
   /** Default limit when query param is missing (default: 20) */
   defaultLimit?: number;
   /** Maximum allowed limit value (default: 100) */

--- a/packages/gateway/src/plans/executor.ts
+++ b/packages/gateway/src/plans/executor.ts
@@ -32,7 +32,7 @@ const log = getLog('PlanExecutor');
 // Types
 // ============================================================================
 
-export interface ExecutorConfig {
+interface ExecutorConfig {
   userId?: string;
   /** Maximum concurrent step executions */
   maxConcurrent?: number;
@@ -53,12 +53,9 @@ interface StepExecutionContext {
   abortSignal?: AbortSignal;
 }
 
-export type StepHandler = (
-  config: StepConfig,
-  context: StepExecutionContext
-) => Promise<StepResult>;
+type StepHandler = (config: StepConfig, context: StepExecutionContext) => Promise<StepResult>;
 
-export interface StepResult {
+interface StepResult {
   success: boolean;
   data?: unknown;
   error?: string;
@@ -67,7 +64,7 @@ export interface StepResult {
   requiresApproval?: boolean;
 }
 
-export interface ExecutionResult {
+interface ExecutionResult {
   planId: string;
   status: PlanStatus;
   completedSteps: number;
@@ -75,19 +72,6 @@ export interface ExecutionResult {
   duration: number;
   results: Map<string, unknown>;
   error?: string;
-}
-
-export interface PlanExecutorEvents {
-  'plan:started': (plan: Plan) => void;
-  'plan:completed': (plan: Plan, result: ExecutionResult) => void;
-  'plan:failed': (plan: Plan, error: string) => void;
-  'plan:paused': (plan: Plan) => void;
-  'plan:resumed': (plan: Plan) => void;
-  'step:started': (plan: Plan, step: PlanStep) => void;
-  'step:completed': (plan: Plan, step: PlanStep, result: StepResult) => void;
-  'step:failed': (plan: Plan, step: PlanStep, error: string) => void;
-  'step:skipped': (plan: Plan, step: PlanStep, reason: string) => void;
-  'approval:required': (plan: Plan, step: PlanStep, context: unknown) => void;
 }
 
 // ============================================================================

--- a/packages/gateway/src/routes/chat/legacy-send.ts
+++ b/packages/gateway/src/routes/chat/legacy-send.ts
@@ -41,7 +41,7 @@ import { getLog } from '../../services/log.js';
 
 const log = getLog('ChatLegacySend');
 
-export interface LegacySendParams {
+interface LegacySendParams {
   c: Context;
   agent: NonNullable<Awaited<ReturnType<typeof import('../agents/index.js').getAgent>>>;
   body: ChatRequest & { provider?: string; model?: string; workspaceId?: string };

--- a/packages/gateway/src/routes/crud-factory.ts
+++ b/packages/gateway/src/routes/crud-factory.ts
@@ -33,13 +33,13 @@ import type { ServerEvents } from '../ws/types.js';
 // =============================================================================
 
 /** Valid entity names for data:changed broadcasts. */
-export type DataChangedEntity = ServerEvents['data:changed']['entity'];
+type DataChangedEntity = ServerEvents['data:changed']['entity'];
 
 /** Available CRUD method names. */
-export type CrudMethod = 'list' | 'get' | 'create' | 'update' | 'delete';
+type CrudMethod = 'list' | 'get' | 'create' | 'update' | 'delete';
 
 /** Configuration for the CRUD route factory. */
-export interface CrudRouteConfig<TService = unknown> {
+interface CrudRouteConfig<TService = unknown> {
   /** Entity name used for error messages, broadcast events, and response keys. e.g. 'heartbeat' */
   entity: DataChangedEntity;
 

--- a/packages/gateway/src/routes/database/shared.ts
+++ b/packages/gateway/src/routes/database/shared.ts
@@ -196,7 +196,7 @@ const CHILD_TABLES: Record<string, { parent: string; fkColumn: string }> = {
 };
 
 /** Distinguishes the per-row ownership strategy for a table. */
-export type TableScope = 'per-user' | 'child' | 'system';
+type TableScope = 'per-user' | 'child' | 'system';
 
 /**
  * Return the ownership scope of a table.
@@ -287,7 +287,7 @@ export const getBackupDir = () => {
   return dir;
 };
 
-export interface OperationStatus {
+interface OperationStatus {
   isRunning: boolean;
   operation?: 'backup' | 'restore' | 'migrate' | 'maintenance';
   lastRun?: string;

--- a/packages/gateway/src/routes/model-configs/shared.ts
+++ b/packages/gateway/src/routes/model-configs/shared.ts
@@ -17,7 +17,7 @@ import { hasApiKey, getConfiguredProviderIds } from '../settings.js';
 // Types
 // =============================================================================
 
-export interface MergedModel {
+interface MergedModel {
   providerId: string;
   providerName: string;
   modelId: string;
@@ -35,7 +35,7 @@ export interface MergedModel {
   source: 'builtin' | 'aggregator' | 'custom' | 'local';
 }
 
-export interface MergedProvider {
+interface MergedProvider {
   id: string;
   name: string;
   type: 'builtin' | 'aggregator' | 'custom' | 'local';

--- a/packages/gateway/src/routes/models.ts
+++ b/packages/gateway/src/routes/models.ts
@@ -74,7 +74,7 @@ async function fetchBridgeModels(
 /**
  * Model information
  */
-export interface ModelInfo {
+interface ModelInfo {
   id: string;
   name: string;
   provider: string;

--- a/packages/gateway/src/services/agent/registry.ts
+++ b/packages/gateway/src/services/agent/registry.ts
@@ -30,7 +30,7 @@ export interface AgentSummary {
 }
 
 /** Aggregated metrics across all agent types. */
-export interface SystemAgentMetrics {
+interface SystemAgentMetrics {
   totalActive: number;
   byType: Record<AgentType, number>;
   totalTokensUsed: number;

--- a/packages/gateway/src/services/agent/runner-utils.ts
+++ b/packages/gateway/src/services/agent/runner-utils.ts
@@ -144,7 +144,7 @@ export async function resolveProviderAndModel(
 // Agent Factory
 // ============================================================================
 
-export interface CreateAgentOptions {
+interface CreateAgentOptions {
   name: string;
   provider: string;
   model: string;
@@ -456,7 +456,7 @@ export function safeParseJson(str: string): Record<string, unknown> {
 /**
  * Generic tool call collector callback factory.
  */
-export interface CollectedToolCall {
+interface CollectedToolCall {
   tool: string;
   args: Record<string, unknown>;
   result: string;
@@ -503,7 +503,7 @@ export function buildDateTimeContext(): string {
 /**
  * Options for the unified agent execution pipeline.
  */
-export interface AgentPipelineOptions {
+interface AgentPipelineOptions {
   /** Fully configured Agent instance */
   agent: Agent;
   /** Message to send to the agent */
@@ -534,7 +534,7 @@ export interface AgentPipelineOptions {
 /**
  * Result from the unified agent execution pipeline.
  */
-export interface AgentPipelineResult {
+interface AgentPipelineResult {
   content: string;
   toolCalls: CollectedToolCall[];
   usage: { promptTokens: number; completionTokens: number } | null;

--- a/packages/gateway/src/services/agent/service.ts
+++ b/packages/gateway/src/services/agent/service.ts
@@ -873,7 +873,7 @@ export function getContextBreakdown(
 // =============================================================================
 
 /** Result of a compaction request — `session` is the post-compact SessionInfo. */
-export interface CompactionResult {
+interface CompactionResult {
   compacted: boolean;
   reason?: string;
   summary?: string;

--- a/packages/gateway/src/services/app-settings.ts
+++ b/packages/gateway/src/services/app-settings.ts
@@ -159,7 +159,7 @@ export async function deleteResolvedAuth(provider: string): Promise<void> {
  */
 export const PROVIDER_OAUTH_CONFIG_PREFIX = 'provider_oauth_config:';
 
-export interface ProviderOAuthConfigOverride {
+interface ProviderOAuthConfigOverride {
   deviceCodeUrl?: string;
   authorizationUrl?: string;
   tokenUrl?: string;

--- a/packages/gateway/src/services/auth/oauth-flow.ts
+++ b/packages/gateway/src/services/auth/oauth-flow.ts
@@ -131,7 +131,7 @@ export async function startDeviceFlow(provider: string): Promise<DeviceAuthoriza
   return response;
 }
 
-export type PollOutcome =
+type PollOutcome =
   | { status: 'success'; auth: ResolvedAuth }
   | { status: 'pending'; intervalSec: number }
   | { status: 'expired' }

--- a/packages/gateway/src/services/browser-service.ts
+++ b/packages/gateway/src/services/browser-service.ts
@@ -175,27 +175,17 @@ export interface BrowserAction {
   timeout?: number;
 }
 
-export interface BrowserResult {
-  success: boolean;
-  screenshot?: string;
-  extractedText?: string;
-  extractedData?: Record<string, unknown>;
-  url: string;
-  title: string;
-  error?: string;
-}
-
 export interface FormField {
   selector: string;
   value: string;
 }
 
-export interface ScreenshotOptions {
+interface ScreenshotOptions {
   fullPage?: boolean;
   selector?: string;
 }
 
-export interface BrowserConfigInfo {
+interface BrowserConfigInfo {
   available: boolean;
   executablePath: string | null;
   allowedDomains: string[];

--- a/packages/gateway/src/services/chunking.ts
+++ b/packages/gateway/src/services/chunking.ts
@@ -13,7 +13,7 @@ import { EMBEDDING_MAX_CHUNK_CHARS, EMBEDDING_MIN_CHUNK_CHARS } from '../config/
 // Types
 // ============================================================================
 
-export interface TextChunk {
+interface TextChunk {
   /** Chunk content (with heading context prepended) */
   text: string;
   /** Position in parent document (0-based) */

--- a/packages/gateway/src/services/claw/run-eval.ts
+++ b/packages/gateway/src/services/claw/run-eval.ts
@@ -14,14 +14,14 @@
 
 import type { ClawConfig, ClawHistoryEntry, ClawToolCall } from '@ownpilot/core';
 
-export interface ToolReliability {
+interface ToolReliability {
   tool: string;
   calls: number;
   failures: number;
   failureRate: number; // 0-1
 }
 
-export interface FailureSignature {
+interface FailureSignature {
   /** Normalized error prefix used to group similar failures. */
   signature: string;
   count: number;
@@ -35,7 +35,7 @@ export interface FailureSignature {
   firstSeen?: string;
 }
 
-export interface RepeatedFailure {
+interface RepeatedFailure {
   tool: string;
   signature: string;
   count: number;
@@ -44,7 +44,7 @@ export interface RepeatedFailure {
   lastSeen?: string;
 }
 
-export interface ClawRunEval {
+interface ClawRunEval {
   clawId?: string;
   sampleSize: number; // number of cycle entries evaluated
   cycles: { total: number; succeeded: number; failed: number; successRate: number };
@@ -269,7 +269,7 @@ export function evaluateClawRun(
 // Fleet aggregation
 // ============================================================================
 
-export interface FleetClawSummary {
+interface FleetClawSummary {
   clawId: string;
   name: string;
   reliabilityScore: number | null;
@@ -278,7 +278,7 @@ export interface FleetClawSummary {
   wastedCalls: number;
 }
 
-export interface FleetRepeatedFailure {
+interface FleetRepeatedFailure {
   tool: string;
   signature: string;
   count: number;
@@ -288,7 +288,7 @@ export interface FleetRepeatedFailure {
   lastSeen?: string;
 }
 
-export interface FleetEval {
+interface FleetEval {
   clawsEvaluated: number;
   totals: { cycles: number; toolCalls: number; toolsFailed: number; wastedCalls: number };
   fleetToolSuccessRate: number;

--- a/packages/gateway/src/services/claw/skill-distiller.ts
+++ b/packages/gateway/src/services/claw/skill-distiller.ts
@@ -33,7 +33,7 @@ export const MIN_TOOL_CALLS_FOR_SKILL = 5;
 /** A single LLM completion: returns the assistant text (empty string on failure). */
 export type CompleteFn = (messages: { system: string; user: string }) => Promise<string>;
 
-export interface DistillInput {
+interface DistillInput {
   config: ClawConfig;
   /** Mission / objective the run was working toward. */
   mission: string;
@@ -49,7 +49,7 @@ export interface DistillInput {
   extensionService?: ExtensionService;
 }
 
-export interface DistillResult {
+interface DistillResult {
   skillId: string;
   name: string;
 }
@@ -174,7 +174,7 @@ export async function distillSkillFromRun(input: DistillInput): Promise<DistillR
 // Retrieval
 // ---------------------------------------------------------------------------
 
-export interface LearnedSkillMatch {
+interface LearnedSkillMatch {
   id: string;
   name: string;
   description: string;

--- a/packages/gateway/src/services/claw/trajectory-export.ts
+++ b/packages/gateway/src/services/claw/trajectory-export.ts
@@ -14,14 +14,14 @@
 
 import type { ClawConfig, ClawHistoryEntry } from '@ownpilot/core';
 
-export type ShareGPTRole = 'system' | 'human' | 'gpt' | 'tool';
+type ShareGPTRole = 'system' | 'human' | 'gpt' | 'tool';
 
-export interface ShareGPTTurn {
+interface ShareGPTTurn {
   from: ShareGPTRole;
   value: string;
 }
 
-export interface ShareGPTTrajectory {
+interface ShareGPTTrajectory {
   id: string;
   mission: string;
   conversations: ShareGPTTurn[];

--- a/packages/gateway/src/services/cli/chat-provider.ts
+++ b/packages/gateway/src/services/cli/chat-provider.ts
@@ -76,7 +76,7 @@ export function escapeWindowsArg(arg: string): string {
   return escaped;
 }
 
-export interface CliChatProviderConfig {
+interface CliChatProviderConfig {
   /** CLI binary name */
   binary: CliChatBinary;
   /** Model to use (optional — uses CLI's default when omitted, recommended) */
@@ -98,7 +98,7 @@ export interface CliChatProviderConfig {
 }
 
 /** Attachment for ToolBridge support on a CLI provider */
-export interface ToolBridgeAttachment {
+interface ToolBridgeAttachment {
   tools: import('@ownpilot/core').ToolRegistry;
   toolDefinitions: readonly import('@ownpilot/core').ToolDefinition[];
   conversationId: string;
@@ -107,7 +107,7 @@ export interface ToolBridgeAttachment {
 }
 
 /** CLI provider definition with metadata */
-export interface CliChatProviderDefinition {
+interface CliChatProviderDefinition {
   id: string;
   binary: CliChatBinary;
   displayName: string;

--- a/packages/gateway/src/services/cli/tool-bridge.ts
+++ b/packages/gateway/src/services/cli/tool-bridge.ts
@@ -38,7 +38,7 @@ const TOOL_RESULTS_TYPE = 'ownpilot_tool_results';
 // Types
 // =============================================================================
 
-export interface ToolBridgeConfig {
+interface ToolBridgeConfig {
   /** Tool registry with registered executors */
   tools: ToolRegistry;
   /** Which tool definitions to expose (subset of registry) */
@@ -61,7 +61,7 @@ export interface ToolBridgeConfig {
   onToolEnd?: (toolCall: ToolCall, result: ToolResult) => void;
 }
 
-export interface ParsedToolCall {
+interface ParsedToolCall {
   name: string;
   arguments: Record<string, unknown>;
 }
@@ -82,7 +82,7 @@ interface ParsedBridgeResponse {
   error?: string;
 }
 
-export interface ToolBridgeResult {
+interface ToolBridgeResult {
   /** Final text response (tool calls stripped) */
   content: string;
   /** All tool calls made across all rounds */

--- a/packages/gateway/src/services/coding-agent/pty.ts
+++ b/packages/gateway/src/services/coding-agent/pty.ts
@@ -181,7 +181,7 @@ export async function runWithPty(
 // =============================================================================
 
 /** Callbacks for streaming PTY output */
-export interface PtyStreamCallbacks {
+interface PtyStreamCallbacks {
   /** Raw PTY data (includes ANSI — xterm.js renders it) */
   onData: (data: string) => void;
   /** Process exited */

--- a/packages/gateway/src/services/composio-service.ts
+++ b/packages/gateway/src/services/composio-service.ts
@@ -13,7 +13,7 @@ const log = getLog('Composio');
 const APPS_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
 // Types matching the SDK's response shapes (avoids importing internal SDK types)
-export interface ComposioApp {
+interface ComposioApp {
   slug: string;
   name: string;
   description?: string;
@@ -21,7 +21,7 @@ export interface ComposioApp {
   categories?: string[];
 }
 
-export interface ComposioConnection {
+interface ComposioConnection {
   id: string;
   appName: string;
   status: string;
@@ -29,7 +29,7 @@ export interface ComposioConnection {
   updatedAt?: string;
 }
 
-export interface ComposioActionInfo {
+interface ComposioActionInfo {
   slug: string;
   name: string;
   description: string;
@@ -38,7 +38,7 @@ export interface ComposioActionInfo {
   tags?: string[];
 }
 
-export interface ComposioConnectionRequest {
+interface ComposioConnectionRequest {
   redirectUrl: string | null;
   connectedAccountId: string;
   connectionStatus: string;

--- a/packages/gateway/src/services/conversation-service.ts
+++ b/packages/gateway/src/services/conversation-service.ts
@@ -61,7 +61,7 @@ export interface SaveStreamingParams extends Omit<SaveChatParams, 'streaming' | 
 // Service
 // ─────────────────────────────────────────────
 
-export interface RawChatAttachment {
+interface RawChatAttachment {
   type: string;
   data?: string;
   mimeType?: string;

--- a/packages/gateway/src/services/custom/data-service.ts
+++ b/packages/gateway/src/services/custom/data-service.ts
@@ -18,7 +18,7 @@ import {
 // Types
 // ============================================================================
 
-export interface TableStats {
+interface TableStats {
   recordCount: number;
   firstRecord?: string;
   lastRecord?: string;
@@ -294,11 +294,7 @@ export class CustomDataService implements IDatabaseService {
 // Error Type
 // ============================================================================
 
-export type CustomDataServiceErrorCode =
-  | 'VALIDATION_ERROR'
-  | 'NOT_FOUND'
-  | 'PROTECTED'
-  | 'INTERNAL_ERROR';
+type CustomDataServiceErrorCode = 'VALIDATION_ERROR' | 'NOT_FOUND' | 'PROTECTED' | 'INTERNAL_ERROR';
 
 export class CustomDataServiceError extends Error {
   constructor(

--- a/packages/gateway/src/services/edge/mqtt-client.ts
+++ b/packages/gateway/src/services/edge/mqtt-client.ts
@@ -25,7 +25,7 @@ type MqttClient = {
 
 type MqttConnectFn = (url: string, opts?: Record<string, unknown>) => MqttClient;
 
-export type MqttMessageHandler = (topic: string, payload: unknown) => void;
+type MqttMessageHandler = (topic: string, payload: unknown) => void;
 
 // =============================================================================
 // Topic Helpers

--- a/packages/gateway/src/services/embedding/service.ts
+++ b/packages/gateway/src/services/embedding/service.ts
@@ -27,7 +27,7 @@ const log = getLog('EmbeddingService');
 // Types
 // ============================================================================
 
-export interface EmbeddingResult {
+interface EmbeddingResult {
   embedding: number[];
   cached: boolean;
 }

--- a/packages/gateway/src/services/extension/gate.ts
+++ b/packages/gateway/src/services/extension/gate.ts
@@ -20,7 +20,7 @@ export interface ExtensionGateResult {
   missing: { os?: string; binaries?: string[]; env?: string[] };
 }
 
-export interface GateDeps {
+interface GateDeps {
   platform: NodeJS.Platform;
   env: NodeJS.ProcessEnv;
   hasBinary: (bin: string) => boolean;

--- a/packages/gateway/src/services/extension/sandbox.ts
+++ b/packages/gateway/src/services/extension/sandbox.ts
@@ -21,7 +21,7 @@ const DEFAULT_CPU_TIMEOUT = 10_000; // 10s per script.runInContext
 // Types
 // =============================================================================
 
-export interface SandboxExecutionOptions {
+interface SandboxExecutionOptions {
   extensionId: string;
   toolName: string;
   code: string;
@@ -36,7 +36,7 @@ export interface SandboxExecutionOptions {
   maxExecutionTime?: number;
 }
 
-export interface SandboxExecutionResult {
+interface SandboxExecutionResult {
   success: boolean;
   result?: unknown;
   error?: string;
@@ -278,7 +278,7 @@ if (!isMainThread && parentPort) {
 // =============================================================================
 
 /** Callback for handling tool calls from sandboxed code */
-export type CallToolHandler = (
+type CallToolHandler = (
   toolName: string,
   args: Record<string, unknown>,
   extensionIdentity: { extensionId: string; ownerUserId: string; grantedPermissions: string[] }

--- a/packages/gateway/src/services/extension/scanner.ts
+++ b/packages/gateway/src/services/extension/scanner.ts
@@ -68,7 +68,7 @@ function getBundledExampleSkillsDirectory(): string | null {
  *   bundled < managed < personal < workspace
  * (`project` reserved for a future repo-local tier).
  */
-export type SkillTier = 'bundled' | 'managed' | 'personal' | 'project' | 'workspace';
+type SkillTier = 'bundled' | 'managed' | 'personal' | 'project' | 'workspace';
 
 /** Higher number = higher precedence (wins on duplicate id). */
 export const SKILL_TIER_RANK: Record<SkillTier, number> = {
@@ -79,7 +79,7 @@ export const SKILL_TIER_RANK: Record<SkillTier, number> = {
   workspace: 4,
 };
 
-export interface ScanDirectory {
+interface ScanDirectory {
   dir: string;
   tier: SkillTier;
 }

--- a/packages/gateway/src/services/extension/service.ts
+++ b/packages/gateway/src/services/extension/service.ts
@@ -43,7 +43,7 @@ const log = getLog('ExtService');
 // Types
 // =============================================================================
 
-export type ExtensionErrorCode = 'VALIDATION_ERROR' | 'NOT_FOUND' | 'ALREADY_EXISTS' | 'IO_ERROR';
+type ExtensionErrorCode = 'VALIDATION_ERROR' | 'NOT_FOUND' | 'ALREADY_EXISTS' | 'IO_ERROR';
 
 export class ExtensionError extends Error {
   constructor(

--- a/packages/gateway/src/services/extension/types.ts
+++ b/packages/gateway/src/services/extension/types.ts
@@ -214,7 +214,7 @@ export interface ExtensionConfigField {
 const EXTENSION_ID_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 const TOOL_NAME_PATTERN = /^[a-z0-9_.]+$/;
 
-export interface ValidationResult {
+interface ValidationResult {
   valid: boolean;
   errors: string[];
 }

--- a/packages/gateway/src/services/goal-service.ts
+++ b/packages/gateway/src/services/goal-service.ts
@@ -24,11 +24,11 @@ import {
 // Types
 // ============================================================================
 
-export interface GoalWithSteps extends Goal {
+interface GoalWithSteps extends Goal {
   steps: GoalStep[];
 }
 
-export interface GoalStats {
+interface GoalStats {
   total: number;
   byStatus: Record<GoalStatus, number>;
   completedThisWeek: number;
@@ -36,7 +36,7 @@ export interface GoalStats {
   overdueCount: number;
 }
 
-export interface DecomposeStepInput {
+interface DecomposeStepInput {
   title: string;
   description?: string;
 }
@@ -259,7 +259,7 @@ export class GoalService implements IGoalService {
 // Error Type
 // ============================================================================
 
-export type GoalServiceErrorCode = 'VALIDATION_ERROR' | 'NOT_FOUND' | 'INTERNAL_ERROR';
+type GoalServiceErrorCode = 'VALIDATION_ERROR' | 'NOT_FOUND' | 'INTERNAL_ERROR';
 
 export class GoalServiceError extends Error {
   constructor(

--- a/packages/gateway/src/services/heartbeat/context.ts
+++ b/packages/gateway/src/services/heartbeat/context.ts
@@ -9,7 +9,7 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 
-export interface HeartbeatExecutionContext {
+interface HeartbeatExecutionContext {
   agentId: string;
   crewId?: string;
   workspaceId?: string;

--- a/packages/gateway/src/services/heartbeat/parser.ts
+++ b/packages/gateway/src/services/heartbeat/parser.ts
@@ -11,19 +11,19 @@ import { validateCronExpression } from '@ownpilot/core';
 // Types
 // ============================================================================
 
-export interface ScheduleParseResult {
+interface ScheduleParseResult {
   cron: string;
   normalized: string; // Human-readable normalized form
 }
 
-export interface ParsedHeartbeatEntry {
+interface ParsedHeartbeatEntry {
   scheduleText: string;
   cron: string;
   taskDescription: string;
   normalized: string;
 }
 
-export interface ParseError {
+interface ParseError {
   scheduleText: string;
   error: string;
 }

--- a/packages/gateway/src/services/heartbeat/service.ts
+++ b/packages/gateway/src/services/heartbeat/service.ts
@@ -20,7 +20,7 @@ const log = getLog('HeartbeatService');
 // Types
 // ============================================================================
 
-export interface CreateHeartbeatServiceInput {
+interface CreateHeartbeatServiceInput {
   scheduleText: string;
   taskDescription: string;
   name?: string;
@@ -28,7 +28,7 @@ export interface CreateHeartbeatServiceInput {
   tags?: string[];
 }
 
-export interface UpdateHeartbeatServiceInput {
+interface UpdateHeartbeatServiceInput {
   scheduleText?: string;
   taskDescription?: string;
   name?: string;
@@ -293,7 +293,7 @@ export class HeartbeatService {
 // Error Type
 // ============================================================================
 
-export type HeartbeatServiceErrorCode = 'VALIDATION_ERROR' | 'PARSE_ERROR' | 'NOT_FOUND';
+type HeartbeatServiceErrorCode = 'VALIDATION_ERROR' | 'PARSE_ERROR' | 'NOT_FOUND';
 
 export class HeartbeatServiceError extends Error {
   constructor(

--- a/packages/gateway/src/services/job-queue-service.ts
+++ b/packages/gateway/src/services/job-queue-service.ts
@@ -15,16 +15,16 @@ const log = getLog('JobQueueService');
 const DEFAULT_QUEUE = 'default';
 const SYSTEM_QUEUE = 'system';
 
-export interface EnqueueOptions {
+interface EnqueueOptions {
   queue?: string;
   priority?: number;
   maxAttempts?: number;
   runAfter?: Date;
 }
 
-export type JobHandler = (job: JobRecord) => Promise<Record<string, unknown>>;
+type JobHandler = (job: JobRecord) => Promise<Record<string, unknown>>;
 
-export interface WorkerOptions {
+interface WorkerOptions {
   queue?: string;
   concurrency?: number;
   name?: string;

--- a/packages/gateway/src/services/llm/model-routing.ts
+++ b/packages/gateway/src/services/llm/model-routing.ts
@@ -31,14 +31,14 @@ export const VALID_PROCESSES: readonly RoutingProcess[] = [
   'pulse',
 ] as const;
 
-export interface ProcessRouting {
+interface ProcessRouting {
   provider: string | null;
   model: string | null;
   fallbackProvider: string | null;
   fallbackModel: string | null;
 }
 
-export interface ResolvedRouting extends ProcessRouting {
+interface ResolvedRouting extends ProcessRouting {
   /** Where the primary provider/model came from */
   source: 'process' | 'channel' | 'global' | 'first-configured';
 }

--- a/packages/gateway/src/services/llm/semaphore.ts
+++ b/packages/gateway/src/services/llm/semaphore.ts
@@ -27,11 +27,6 @@ const DEFAULT_MAX_SLOTS = 3;
  * Info about an active (or queued) LLM call, used by the UI to render
  * a live "which claw is using the LLM right now" strip.
  */
-export interface LlmSlotInfo {
-  agentId: string;
-  /** 'active' = currently in LLM call, 'queued' = waiting for a slot */
-  state: 'active' | 'queued';
-}
 
 /**
  * Global LLM concurrency limiter.

--- a/packages/gateway/src/services/mcp/client.ts
+++ b/packages/gateway/src/services/mcp/client.ts
@@ -28,7 +28,7 @@ const log = getLog('McpClient');
 // TYPES
 // =============================================================================
 
-export interface McpToolInfo {
+interface McpToolInfo {
   name: string;
   description?: string;
   inputSchema?: Record<string, unknown>;

--- a/packages/gateway/src/services/memory-service.ts
+++ b/packages/gateway/src/services/memory-service.ts
@@ -24,7 +24,7 @@ const log = getLog('MemoryService');
 // Types
 // ============================================================================
 
-export interface MemoryStats {
+interface MemoryStats {
   total: number;
   byType: Record<MemoryType, number>;
   avgImportance: number;
@@ -431,7 +431,7 @@ export class MemoryService implements IMemoryService {
 // Error Type
 // ============================================================================
 
-export type MemoryServiceErrorCode = 'VALIDATION_ERROR' | 'NOT_FOUND' | 'INTERNAL_ERROR';
+type MemoryServiceErrorCode = 'VALIDATION_ERROR' | 'NOT_FOUND' | 'INTERNAL_ERROR';
 
 export class MemoryServiceError extends Error {
   constructor(

--- a/packages/gateway/src/services/memory/engine.ts
+++ b/packages/gateway/src/services/memory/engine.ts
@@ -29,13 +29,13 @@ import { createMemoriesRepository } from '../../db/repositories/memories.js';
 
 const log = getLog('MemoryEngine');
 
-export interface ExtractResult {
+interface ExtractResult {
   extracted: number;
   created: number;
   deduplicated: number;
 }
 
-export interface ConsolidateResult {
+interface ConsolidateResult {
   scanned: number;
   clusters: number;
   merged: number;
@@ -45,13 +45,13 @@ export interface ConsolidateResult {
   skippedReason?: string;
 }
 
-export interface RecallSource {
+interface RecallSource {
   id: string;
   content: string;
   score: number;
 }
 
-export interface RecallResult {
+interface RecallResult {
   summary: string;
   sources: RecallSource[];
 }

--- a/packages/gateway/src/services/metric/pulse.ts
+++ b/packages/gateway/src/services/metric/pulse.ts
@@ -28,7 +28,7 @@ interface TrackedClaw {
   registeredAt: number;
 }
 
-export interface PulseClawStatus {
+interface PulseClawStatus {
   clawId: string;
   state: ClawState;
   circuitState: 'closed' | 'open' | 'half-open';

--- a/packages/gateway/src/services/orphan-reconciliation.ts
+++ b/packages/gateway/src/services/orphan-reconciliation.ts
@@ -33,7 +33,7 @@ const ORPHAN_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 // Types
 // ============================================================================
 
-export interface ReconciliationResult {
+interface ReconciliationResult {
   system: string;
   orphaned: number;
   recovered: number;

--- a/packages/gateway/src/services/pairing-service.ts
+++ b/packages/gateway/src/services/pairing-service.ts
@@ -95,7 +95,7 @@ export async function isOwner(platform: string, platformUserId: string): Promise
   return owner !== null && owner === platformUserId;
 }
 
-export interface ClaimResult {
+interface ClaimResult {
   success: boolean;
   alreadyClaimed: boolean;
   message: string;

--- a/packages/gateway/src/services/permission/execution-approval.ts
+++ b/packages/gateway/src/services/permission/execution-approval.ts
@@ -18,7 +18,7 @@ const APPROVAL_TIMEOUT_MS = 120_000;
 const MAX_PENDING = 1000;
 
 /** Atomic decision recorded the moment an approval is resolved. */
-export interface ApprovalDecision {
+interface ApprovalDecision {
   approved: boolean;
   decidedBy: string;
   decidedAt: number;
@@ -47,7 +47,7 @@ export class ApprovalCapExceededError extends Error {
 }
 
 /** Discriminated result of resolveApproval — caller maps each reason to an HTTP code. */
-export type ResolveResult =
+type ResolveResult =
   | { ok: true; decision: ApprovalDecision }
   | {
       ok: false;

--- a/packages/gateway/src/services/plan-service.ts
+++ b/packages/gateway/src/services/plan-service.ts
@@ -27,11 +27,11 @@ import {
 // Types
 // ============================================================================
 
-export interface PlanWithSteps extends Plan {
+interface PlanWithSteps extends Plan {
   steps: PlanStep[];
 }
 
-export interface PlanStats {
+interface PlanStats {
   total: number;
   byStatus: Record<string, number>;
   completionRate: number;
@@ -236,7 +236,7 @@ export class PlanService implements IPlanService {
 // Error Type
 // ============================================================================
 
-export type PlanServiceErrorCode = 'VALIDATION_ERROR' | 'NOT_FOUND' | 'INTERNAL_ERROR';
+type PlanServiceErrorCode = 'VALIDATION_ERROR' | 'NOT_FOUND' | 'INTERNAL_ERROR';
 
 export class PlanServiceError extends Error {
   constructor(

--- a/packages/gateway/src/services/retention-service.ts
+++ b/packages/gateway/src/services/retention-service.ts
@@ -20,7 +20,7 @@ import { JobQueueService } from './job-queue-service.js';
 
 const log = getLog('RetentionService');
 
-export interface RetentionResult {
+interface RetentionResult {
   table: string;
   deleted: number;
   retentionDays: number;

--- a/packages/gateway/src/services/security-scanner.ts
+++ b/packages/gateway/src/services/security-scanner.ts
@@ -32,23 +32,23 @@ const log = getLog('SecurityScanner');
 // TYPES
 // =============================================================================
 
-export type SeverityLevel = 'safe' | 'low' | 'medium' | 'high' | 'critical';
+type SeverityLevel = 'safe' | 'low' | 'medium' | 'high' | 'critical';
 
-export interface RiskItem {
+interface RiskItem {
   source: string;
   sourceId?: string;
   severity: SeverityLevel;
   description: string;
 }
 
-export interface SectionScanResult<T = unknown> {
+interface SectionScanResult<T = unknown> {
   count: number;
   issues: number;
   score: number;
   items: T[];
 }
 
-export interface ExtensionScanItem {
+interface ExtensionScanItem {
   id: string;
   name: string;
   format: string;
@@ -59,7 +59,7 @@ export interface ExtensionScanItem {
   warnings: string[];
 }
 
-export interface CustomToolScanItem {
+interface CustomToolScanItem {
   id: string;
   name: string;
   status: string;
@@ -69,7 +69,7 @@ export interface CustomToolScanItem {
   permissions: string[];
 }
 
-export interface TriggerScanItem {
+interface TriggerScanItem {
   id: string;
   name: string;
   type: string;
@@ -79,7 +79,7 @@ export interface TriggerScanItem {
   risks: string[];
 }
 
-export interface WorkflowScanItem {
+interface WorkflowScanItem {
   id: string;
   name: string;
   status: string;
@@ -88,7 +88,7 @@ export interface WorkflowScanItem {
   riskyNodes: string[];
 }
 
-export interface CliToolScanItem {
+interface CliToolScanItem {
   name: string;
   catalogRisk: string;
   policy: string;
@@ -96,7 +96,7 @@ export interface CliToolScanItem {
   issue?: string;
 }
 
-export interface PlatformScanResult {
+interface PlatformScanResult {
   overallScore: number;
   overallLevel: SeverityLevel;
   scannedAt: string;

--- a/packages/gateway/src/services/skill/npm-installer.ts
+++ b/packages/gateway/src/services/skill/npm-installer.ts
@@ -28,7 +28,7 @@ const MAX_DOWNLOAD_REDIRECTS = 5;
 // Types
 // =============================================================================
 
-export interface NpmPackageInfo {
+interface NpmPackageInfo {
   name: string;
   version: string;
   description: string;
@@ -44,12 +44,12 @@ export interface NpmPackageInfo {
   };
 }
 
-export interface NpmSearchResult {
+interface NpmSearchResult {
   packages: NpmSearchPackage[];
   total: number;
 }
 
-export interface NpmSearchPackage {
+interface NpmSearchPackage {
   name: string;
   version: string;
   description: string;
@@ -59,7 +59,7 @@ export interface NpmSearchPackage {
   links?: { npm?: string; homepage?: string; repository?: string };
 }
 
-export interface NpmInstallResult {
+interface NpmInstallResult {
   success: boolean;
   extensionId?: string;
   error?: string;

--- a/packages/gateway/src/services/skill/security-audit.ts
+++ b/packages/gateway/src/services/skill/security-audit.ts
@@ -20,9 +20,9 @@ const log = getLog('SkillSecurityAudit');
 // Types
 // =============================================================================
 
-export type SkillRiskLevel = 'low' | 'medium' | 'high' | 'critical';
+type SkillRiskLevel = 'low' | 'medium' | 'high' | 'critical';
 
-export interface SkillSecurityResult {
+interface SkillSecurityResult {
   /** Whether the skill should be blocked from installation */
   blocked: boolean;
   /** Reasons for blocking (empty if not blocked) */

--- a/packages/gateway/src/services/tool/permission.ts
+++ b/packages/gateway/src/services/tool/permission.ts
@@ -25,14 +25,14 @@ const log = getLog('ToolPermissionService');
 // Types
 // =============================================================================
 
-export type PermissionDenialCode =
+type PermissionDenialCode =
   | 'TOOL_GROUP_DISABLED'
   | 'EXECUTION_BLOCKED'
   | 'CLI_POLICY_BLOCKED'
   | 'SKILL_NOT_ALLOWED'
   | 'REQUIRES_APPROVAL';
 
-export type PermissionResult =
+type PermissionResult =
   | { allowed: true }
   | { allowed: false; reason: string; code: PermissionDenialCode };
 

--- a/packages/gateway/src/services/tool/templates.ts
+++ b/packages/gateway/src/services/tool/templates.ts
@@ -9,7 +9,7 @@
 // Types
 // =============================================================================
 
-export interface ToolTemplate {
+interface ToolTemplate {
   id: string;
   name: string;
   displayName: string;

--- a/packages/gateway/src/services/trigger-service.ts
+++ b/packages/gateway/src/services/trigger-service.ts
@@ -22,7 +22,7 @@ import {
 // Types
 // ============================================================================
 
-export interface TriggerStats {
+interface TriggerStats {
   total: number;
   enabled: number;
   byType: Record<string, number>;
@@ -178,7 +178,7 @@ export class TriggerService implements ITriggerService {
 // Error Type
 // ============================================================================
 
-export type TriggerServiceErrorCode = 'VALIDATION_ERROR' | 'NOT_FOUND' | 'INTERNAL_ERROR';
+type TriggerServiceErrorCode = 'VALIDATION_ERROR' | 'NOT_FOUND' | 'INTERNAL_ERROR';
 
 export class TriggerServiceError extends Error {
   constructor(

--- a/packages/gateway/src/services/tunnel-service.ts
+++ b/packages/gateway/src/services/tunnel-service.ts
@@ -17,20 +17,20 @@ const log = getLog('TunnelService');
 // Types
 // ============================================================================
 
-export interface TunnelConfig {
+interface TunnelConfig {
   port: number;
   password?: string;
   hostname?: string;
 }
 
-export interface TunnelStatus {
+interface TunnelStatus {
   status: 'stopped' | 'starting' | 'running' | 'error';
   url?: string | null;
   error?: string | null;
   startedAt?: Date | null;
 }
 
-export interface ITunnelService {
+interface ITunnelService {
   start(password?: string): Promise<TunnelStatus>;
   stop(): Promise<void>;
   getStatus(): TunnelStatus;

--- a/packages/gateway/src/services/voice-service.ts
+++ b/packages/gateway/src/services/voice-service.ts
@@ -27,32 +27,32 @@ const log = getLog('VoiceService');
 // Types
 // =============================================================================
 
-export interface TranscribeOptions {
+interface TranscribeOptions {
   language?: string;
   prompt?: string;
 }
 
-export interface TranscribeResult {
+interface TranscribeResult {
   text: string;
   language?: string;
   duration?: number;
   segments?: Array<{ start: number; end: number; text: string }>;
 }
 
-export interface SynthesizeOptions {
+interface SynthesizeOptions {
   voice?: string;
   model?: string;
   speed?: number;
   format?: string;
 }
 
-export interface SynthesizeResult {
+interface SynthesizeResult {
   audio: Buffer;
   format: string;
   contentType: string;
 }
 
-export interface VoiceConfigInfo {
+interface VoiceConfigInfo {
   available: boolean;
   provider: string | null;
   sttSupported: boolean;

--- a/packages/gateway/src/services/workflow/workflow-service.ts
+++ b/packages/gateway/src/services/workflow/workflow-service.ts
@@ -60,7 +60,7 @@ import type { WorkflowProgressEvent } from './types.js';
 
 const log = getLog('WorkflowService');
 
-export interface WorkflowServiceOptions {
+interface WorkflowServiceOptions {
   /** Poll interval for the jobified-level wait loop (ms). */
   jobifiedPollIntervalMs?: number;
   /**

--- a/packages/gateway/src/tools/claw/plan-executors.ts
+++ b/packages/gateway/src/tools/claw/plan-executors.ts
@@ -121,7 +121,7 @@ export function buildValidatedTasks(raw: unknown): ClawTask[] {
 }
 
 /** Parsed/validated subtask spec for a split operation. */
-export interface ValidatedSubtask {
+interface ValidatedSubtask {
   title: string;
   successCriteria?: string;
 }

--- a/packages/gateway/src/tools/custom-tools.ts
+++ b/packages/gateway/src/tools/custom-tools.ts
@@ -34,7 +34,7 @@ import type { ToolExecutionResult as BaseToolExecutionResult } from '../services
  * Result shape for the meta-tool executors. Extends the base shape with
  * approval/confirmation flags that the LLM-facing flow needs.
  */
-export interface ToolExecutionResult extends BaseToolExecutionResult {
+interface ToolExecutionResult extends BaseToolExecutionResult {
   requiresApproval?: boolean;
   requiresConfirmation?: boolean;
   pendingToolId?: string;

--- a/packages/gateway/src/tools/overrides/audio.ts
+++ b/packages/gateway/src/tools/overrides/audio.ts
@@ -91,7 +91,7 @@ async function ensureAudioService(): Promise<void> {
 // API Key Resolution
 // ============================================================================
 
-export interface AudioApiConfig {
+interface AudioApiConfig {
   apiKey?: string;
   baseUrl: string;
   providerType: string;

--- a/packages/gateway/src/tools/provider-manifest.ts
+++ b/packages/gateway/src/tools/provider-manifest.ts
@@ -25,7 +25,7 @@ import {
   createSkillToolProvider,
 } from '../services/tool-providers/index.js';
 
-export interface ProviderEntry {
+interface ProviderEntry {
   /** Human-readable name for logging */
   name: string;
   /** Factory that creates the ToolProvider. Always receives userId. */

--- a/packages/gateway/src/tools/registry/semantic-search.ts
+++ b/packages/gateway/src/tools/registry/semantic-search.ts
@@ -52,12 +52,12 @@ function contentHash(text: string): string {
   return createHash('sha1').update(text).digest('hex');
 }
 
-export interface SemanticMatch {
+interface SemanticMatch {
   def: ToolDefinition;
   score: number;
 }
 
-export interface SemanticSearchResult {
+interface SemanticSearchResult {
   matches: SemanticMatch[];
   /** True iff every tool was successfully embedded. False signals partial. */
   complete: boolean;

--- a/packages/gateway/src/tracing/index.ts
+++ b/packages/gateway/src/tracing/index.ts
@@ -16,7 +16,7 @@ import { AsyncLocalStorage } from 'async_hooks';
 // Types
 // =============================================================================
 
-export type TraceEventType =
+type TraceEventType =
   | 'tool_call'
   | 'tool_result'
   | 'db_read'

--- a/packages/gateway/src/triggers/engine.ts
+++ b/packages/gateway/src/triggers/engine.ts
@@ -59,23 +59,23 @@ interface PreRunGate {
 // Types
 // ============================================================================
 
-export interface TriggerEngineConfig {
+interface TriggerEngineConfig {
   pollIntervalMs?: number;
   conditionCheckIntervalMs?: number;
   enabled?: boolean;
   userId?: string;
 }
 
-export interface ActionResult {
+interface ActionResult {
   success: boolean;
   message?: string;
   data?: unknown;
   error?: string;
 }
 
-export type EventHandler = (event: TriggerEvent) => void;
+type EventHandler = (event: TriggerEvent) => void;
 
-export interface TriggerEvent {
+interface TriggerEvent {
   type: string;
   payload: Record<string, unknown>;
   timestamp: Date;
@@ -85,7 +85,7 @@ export interface TriggerEvent {
 // Trigger Engine
 // ============================================================================
 
-export type ChatHandler = (message: string, payload: Record<string, unknown>) => Promise<unknown>;
+type ChatHandler = (message: string, payload: Record<string, unknown>) => Promise<unknown>;
 
 export class TriggerEngine {
   private config: Required<TriggerEngineConfig>;

--- a/packages/gateway/src/types/index.ts
+++ b/packages/gateway/src/types/index.ts
@@ -74,7 +74,7 @@ export interface ChatRequest {
 /**
  * Request trace information for debugging
  */
-export interface TraceInfo {
+interface TraceInfo {
   /** Total duration in ms */
   duration: number;
   /** Tool calls made */
@@ -255,19 +255,6 @@ export interface AgentInfo {
 /**
  * Agent detail response (with full config)
  */
-export interface AgentDetail extends AgentInfo {
-  systemPrompt: string;
-  config: {
-    maxTokens: number;
-    temperature: number;
-    maxTurns: number;
-    maxToolCalls: number;
-    /** Explicit tool names (optional) */
-    tools?: string[];
-    /** Tool group IDs (optional) */
-    toolGroups?: string[];
-  };
-}
 
 /**
  * Conversation info

--- a/packages/gateway/src/utils/login-throttle.ts
+++ b/packages/gateway/src/utils/login-throttle.ts
@@ -3,22 +3,22 @@
  * Per-IP attempt cap with window and lockout support.
  */
 
-export interface LoginThrottleOptions {
+interface LoginThrottleOptions {
   maxAttempts: number;
   windowMs: number;
   lockoutMs: number;
 }
 
-export interface LoginThrottleCheck {
+interface LoginThrottleCheck {
   allowed: true;
 }
 
-export interface LoginThrottleDenied {
+interface LoginThrottleDenied {
   allowed: false;
   retryAfterMs: number;
 }
 
-export type LoginThrottleResult = LoginThrottleCheck | LoginThrottleDenied;
+type LoginThrottleResult = LoginThrottleCheck | LoginThrottleDenied;
 
 interface ThrottleEntry {
   count: number;

--- a/packages/gateway/src/utils/memory-extraction.ts
+++ b/packages/gateway/src/utils/memory-extraction.ts
@@ -8,15 +8,15 @@
 
 const VALID_TYPES = new Set(['fact', 'preference', 'conversation', 'event', 'skill']);
 
-export type MemoryType = 'fact' | 'preference' | 'conversation' | 'event' | 'skill';
+type MemoryType = 'fact' | 'preference' | 'conversation' | 'event' | 'skill';
 
-export interface MemoryItem {
+interface MemoryItem {
   type: MemoryType;
   content: string;
   importance?: number;
 }
 
-export interface MemoryExtractionResult {
+interface MemoryExtractionResult {
   /** Response content with <memories> tag stripped */
   content: string;
   /** Extracted memory items, empty array if none found */

--- a/packages/gateway/src/utils/safe-fetch.ts
+++ b/packages/gateway/src/utils/safe-fetch.ts
@@ -25,7 +25,7 @@ export const DEFAULT_MAX_REQUEST_BODY_SIZE = 10 * 1024 * 1024;
  * `signal` is honored when provided; otherwise safeFetch installs its own
  * AbortController tied to `timeoutMs`.
  */
-export interface SafeFetchOptions extends Omit<RequestInit, 'redirect'> {
+interface SafeFetchOptions extends Omit<RequestInit, 'redirect'> {
   /** Maximum redirects to follow (default 5). 0 = no redirects. */
   maxRedirects?: number;
   /** Request timeout in ms (default 30000). */

--- a/packages/gateway/src/utils/suggestions.ts
+++ b/packages/gateway/src/utils/suggestions.ts
@@ -6,12 +6,12 @@
  * tag at the end of its response. This utility parses and strips the tag.
  */
 
-export interface Suggestion {
+interface Suggestion {
   title: string;
   detail: string;
 }
 
-export interface SuggestionExtractionResult {
+interface SuggestionExtractionResult {
   /** Response content with <suggestions> tag stripped */
   content: string;
   /** Extracted suggestions, empty array if none found */

--- a/packages/gateway/src/utils/trusted-proxy.ts
+++ b/packages/gateway/src/utils/trusted-proxy.ts
@@ -14,7 +14,7 @@
 
 import { isProxyAwareConfigured } from './client-ip.js';
 
-export interface RequestLike {
+interface RequestLike {
   url: string;
   header: (name: string) => string | undefined;
 }

--- a/packages/gateway/src/utils/ui-session-cookie.ts
+++ b/packages/gateway/src/utils/ui-session-cookie.ts
@@ -4,12 +4,12 @@ import { isSecureRequest } from './trusted-proxy.js';
 
 export const UI_SESSION_COOKIE = 'ownpilot_ui_session';
 
-export interface UiSessionAuth {
+interface UiSessionAuth {
   token?: string;
   source: 'header' | 'cookie' | 'none';
 }
 
-export interface UiSessionAuthOptions {
+interface UiSessionAuthOptions {
   allowHeader?: boolean;
 }
 

--- a/packages/gateway/src/workspace/file-workspace.ts
+++ b/packages/gateway/src/workspace/file-workspace.ts
@@ -45,7 +45,7 @@ const log = getLog('FileWorkspace');
 // Workspace subdirectories
 const WORKSPACE_SUBDIRS: WorkspaceSubdir[] = ['scripts', 'output', 'temp', 'downloads'];
 
-export interface FileWorkspaceConfig {
+interface FileWorkspaceConfig {
   dataDir: string;
   workspaceDir: string;
   scriptsDir: string;
@@ -290,7 +290,7 @@ export function validateWritePath(filePath: string): {
 /**
  * Session workspace metadata
  */
-export interface SessionWorkspaceMeta {
+interface SessionWorkspaceMeta {
   id: string;
   name: string;
   createdAt: string;

--- a/packages/gateway/src/ws/server.ts
+++ b/packages/gateway/src/ws/server.ts
@@ -131,7 +131,7 @@ const VALID_CLIENT_EVENTS = new Set<string>([
   'webchat:message',
 ]);
 
-export interface WSGatewayConfig {
+interface WSGatewayConfig {
   /** Port for standalone WebSocket server (if not using HTTP upgrade) */
   port?: number;
   /** Path for WebSocket endpoint when using HTTP upgrade */

--- a/packages/gateway/src/ws/types.ts
+++ b/packages/gateway/src/ws/types.ts
@@ -104,14 +104,6 @@ export type AgentState = 'idle' | 'thinking' | 'executing' | 'waiting' | 'error'
 /**
  * Agent info
  */
-export interface AgentInfo {
-  readonly id: string;
-  readonly name: string;
-  readonly provider: string;
-  readonly model: string;
-  readonly state: AgentState;
-  readonly currentTask?: string;
-}
 
 /**
  * Workspace info

--- a/packages/ui/src/api/endpoints/canvas.ts
+++ b/packages/ui/src/api/endpoints/canvas.ts
@@ -29,7 +29,7 @@ export interface CanvasElement {
   updatedAt: string;
 }
 
-export interface CreateCanvasElementInput {
+interface CreateCanvasElementInput {
   type: CanvasElementType;
   content?: string;
   x?: number;
@@ -40,7 +40,7 @@ export interface CreateCanvasElementInput {
   style?: Record<string, unknown> | null;
 }
 
-export interface UpdateCanvasElementInput {
+interface UpdateCanvasElementInput {
   type?: CanvasElementType;
   content?: string;
   x?: number;

--- a/packages/ui/src/api/endpoints/claws.ts
+++ b/packages/ui/src/api/endpoints/claws.ts
@@ -184,12 +184,12 @@ export interface ClawHistoryEntry {
   executedAt: string;
 }
 
-export interface ShareGPTTurn {
+interface ShareGPTTurn {
   from: 'system' | 'human' | 'gpt' | 'tool';
   value: string;
 }
 
-export interface ShareGPTTrajectory {
+interface ShareGPTTrajectory {
   id: string;
   mission: string;
   conversations: ShareGPTTurn[];
@@ -319,7 +319,7 @@ export interface ClawDoctorResponse {
   skipped: string[];
 }
 
-export interface ClawApplyRecommendationsResponse {
+interface ClawApplyRecommendationsResponse {
   applied: string[];
   skipped: string[];
   claw: ClawConfig;

--- a/packages/ui/src/api/endpoints/coding-agents.ts
+++ b/packages/ui/src/api/endpoints/coding-agents.ts
@@ -105,13 +105,13 @@ export interface AcpPlan {
   updatedAt: string;
 }
 
-export interface AcpData {
+interface AcpData {
   toolCalls: AcpToolCall[];
   plan: AcpPlan | null;
   isAcp: boolean;
 }
 
-export interface AcpPromptResult {
+interface AcpPromptResult {
   stopReason: string;
   output: string;
 }

--- a/packages/ui/src/api/endpoints/extensions.ts
+++ b/packages/ui/src/api/endpoints/extensions.ts
@@ -5,7 +5,7 @@
 import { apiClient } from '../client';
 import type { ExtensionInfo } from '../types';
 
-export interface LlmAuditRisk {
+interface LlmAuditRisk {
   severity: 'low' | 'medium' | 'high' | 'critical';
   description: string;
   mitigation?: string;
@@ -53,7 +53,7 @@ export interface FileTreeResult {
   tree: FileEntry[];
 }
 
-export interface FileContentResult {
+interface FileContentResult {
   path: string;
   content: string;
   language: string;

--- a/packages/ui/src/api/endpoints/mcp.ts
+++ b/packages/ui/src/api/endpoints/mcp.ts
@@ -74,7 +74,7 @@ export interface McpServerInfo {
   >;
 }
 
-export type McpPresetEnvKind = 'secret' | 'plain';
+type McpPresetEnvKind = 'secret' | 'plain';
 
 export interface McpPresetEnvVar {
   name: string;

--- a/packages/ui/src/api/endpoints/personal-data.ts
+++ b/packages/ui/src/api/endpoints/personal-data.ts
@@ -80,7 +80,7 @@ export interface HabitWithTodayStatus extends Habit {
   todayCount: number;
 }
 
-export interface HabitLog {
+interface HabitLog {
   id: string;
   habitId: string;
   date: string;
@@ -125,7 +125,7 @@ export interface PomodoroSession {
   completedAt?: string;
 }
 
-export interface PomodoroSettings {
+interface PomodoroSettings {
   workDuration: number;
   shortBreakDuration: number;
   longBreakDuration: number;

--- a/packages/ui/src/api/endpoints/souls.ts
+++ b/packages/ui/src/api/endpoints/souls.ts
@@ -227,7 +227,7 @@ export interface CrewTemplate {
 // Souls API
 // =============================================================================
 
-export interface DeploySoulInput {
+interface DeploySoulInput {
   identity: {
     name: string;
     emoji?: string;
@@ -283,7 +283,7 @@ export interface DeploySoulInput {
   };
 }
 
-export interface DeploySoulResponse {
+interface DeploySoulResponse {
   agentId: string;
   soul: AgentSoul;
   provider: string;
@@ -291,7 +291,7 @@ export interface DeploySoulResponse {
   triggerCreated: boolean;
 }
 
-export interface ToolInfo {
+interface ToolInfo {
   name: string;
   description?: string;
   category: string;
@@ -299,7 +299,7 @@ export interface ToolInfo {
   provider?: string;
 }
 
-export interface ToolsResponse {
+interface ToolsResponse {
   tools: ToolInfo[];
   allowed: string[];
   blocked: string[];
@@ -311,7 +311,7 @@ export interface ToolsResponse {
   };
 }
 
-export interface CommandResponse {
+interface CommandResponse {
   command: {
     id: string;
     timestamp: string;
@@ -323,7 +323,7 @@ export interface CommandResponse {
   agentId: string;
 }
 
-export interface AgentStatsResponse {
+interface AgentStatsResponse {
   agentId: string;
   soulVersion: number;
   heartbeat: {

--- a/packages/ui/src/api/endpoints/tunnel.ts
+++ b/packages/ui/src/api/endpoints/tunnel.ts
@@ -11,7 +11,7 @@ export interface TunnelStatus {
   startedAt?: string | null;
 }
 
-export interface TunnelStartResponse {
+interface TunnelStartResponse {
   url: string;
   status: string;
 }

--- a/packages/ui/src/api/endpoints/workflows.ts
+++ b/packages/ui/src/api/endpoints/workflows.ts
@@ -118,7 +118,7 @@ export const workflowsApi = {
     apiClient.get<WorkflowLog>(`/workflows/${id}/run/${logId}`),
 };
 
-export interface WorkflowCopilotRequest {
+interface WorkflowCopilotRequest {
   messages: Array<{ role: 'user' | 'assistant'; content: string }>;
   currentWorkflow?: { name: string; nodes: unknown[]; edges: unknown[] };
   availableTools?: string[];

--- a/packages/ui/src/api/types/workflows.ts
+++ b/packages/ui/src/api/types/workflows.ts
@@ -9,7 +9,7 @@ export type WorkflowLogStatus =
   | 'awaiting_approval';
 export type NodeExecutionStatus = 'pending' | 'running' | 'success' | 'error' | 'skipped';
 
-export interface WorkflowNodeDataCommon {
+interface WorkflowNodeDataCommon {
   label: string;
   description?: string;
   retryCount?: number;
@@ -80,7 +80,7 @@ export interface WorkflowTransformerNodeData {
   timeoutMs?: number;
 }
 
-export interface WorkflowForEachNodeData {
+interface WorkflowForEachNodeData {
   label: string;
   arrayExpression: string;
   itemVariable?: string;
@@ -92,7 +92,7 @@ export interface WorkflowForEachNodeData {
   outputAlias?: string;
 }
 
-export interface WorkflowHttpRequestNodeData extends WorkflowNodeDataCommon {
+interface WorkflowHttpRequestNodeData extends WorkflowNodeDataCommon {
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
   url: string;
   headers?: Record<string, string>;
@@ -109,81 +109,81 @@ export interface WorkflowHttpRequestNodeData extends WorkflowNodeDataCommon {
   maxResponseSize?: number;
 }
 
-export interface WorkflowDelayNodeData extends WorkflowNodeDataCommon {
+interface WorkflowDelayNodeData extends WorkflowNodeDataCommon {
   duration: string;
   unit: 'seconds' | 'minutes' | 'hours';
 }
 
-export interface WorkflowSwitchNodeData extends WorkflowNodeDataCommon {
+interface WorkflowSwitchNodeData extends WorkflowNodeDataCommon {
   expression: string;
   cases: Array<{ label: string; value: string }>;
 }
 
-export interface WorkflowErrorHandlerNodeData extends WorkflowNodeDataCommon {
+interface WorkflowErrorHandlerNodeData extends WorkflowNodeDataCommon {
   continueOnSuccess?: boolean;
 }
 
-export interface WorkflowSubWorkflowNodeData extends WorkflowNodeDataCommon {
+interface WorkflowSubWorkflowNodeData extends WorkflowNodeDataCommon {
   subWorkflowId?: string;
   subWorkflowName?: string;
   inputMapping?: Record<string, string>;
   maxDepth?: number;
 }
 
-export interface WorkflowApprovalNodeData extends WorkflowNodeDataCommon {
+interface WorkflowApprovalNodeData extends WorkflowNodeDataCommon {
   approvalMessage?: string;
   timeoutMinutes?: number;
 }
 
-export interface WorkflowStickyNoteNodeData {
+interface WorkflowStickyNoteNodeData {
   label: string;
   text?: string;
   color?: string;
 }
 
-export interface WorkflowNotificationNodeData extends WorkflowNodeDataCommon {
+interface WorkflowNotificationNodeData extends WorkflowNodeDataCommon {
   message?: string;
   severity?: 'info' | 'warning' | 'error' | 'success';
 }
 
-export interface WorkflowParallelNodeData extends WorkflowNodeDataCommon {
+interface WorkflowParallelNodeData extends WorkflowNodeDataCommon {
   branchCount: number;
   branchLabels?: string[];
 }
 
-export interface WorkflowMergeNodeData extends WorkflowNodeDataCommon {
+interface WorkflowMergeNodeData extends WorkflowNodeDataCommon {
   mode?: 'waitAll' | 'firstCompleted';
 }
 
-export interface WorkflowDataStoreNodeData extends WorkflowNodeDataCommon {
+interface WorkflowDataStoreNodeData extends WorkflowNodeDataCommon {
   operation: 'get' | 'set' | 'delete' | 'list' | 'has';
   key?: string;
   value?: unknown;
   namespace?: string;
 }
 
-export interface WorkflowSchemaValidatorNodeData extends WorkflowNodeDataCommon {
+interface WorkflowSchemaValidatorNodeData extends WorkflowNodeDataCommon {
   schema: Record<string, unknown>;
   strict?: boolean;
 }
 
-export interface WorkflowFilterNodeData extends WorkflowNodeDataCommon {
+interface WorkflowFilterNodeData extends WorkflowNodeDataCommon {
   arrayExpression: string;
   condition: string;
 }
 
-export interface WorkflowMapNodeData extends WorkflowNodeDataCommon {
+interface WorkflowMapNodeData extends WorkflowNodeDataCommon {
   arrayExpression: string;
   expression: string;
 }
 
-export interface WorkflowAggregateNodeData extends WorkflowNodeDataCommon {
+interface WorkflowAggregateNodeData extends WorkflowNodeDataCommon {
   arrayExpression: string;
   operation: 'sum' | 'count' | 'avg' | 'min' | 'max' | 'groupBy' | 'flatten' | 'unique';
   field?: string;
 }
 
-export interface WorkflowWebhookResponseNodeData extends WorkflowNodeDataCommon {
+interface WorkflowWebhookResponseNodeData extends WorkflowNodeDataCommon {
   statusCode?: number;
   body?: string;
   headers?: Record<string, string>;

--- a/packages/ui/src/components/AddLocalProviderDialog.tsx
+++ b/packages/ui/src/components/AddLocalProviderDialog.tsx
@@ -6,7 +6,7 @@ import type { LocalProviderTemplate } from '../api';
 // Types
 // ============================================================================
 
-export interface AddLocalProviderDialogProps {
+interface AddLocalProviderDialogProps {
   templates: LocalProviderTemplate[];
   onAdd: (template: LocalProviderTemplate, customUrl?: string, customApiKey?: string) => void;
   onClose: () => void;

--- a/packages/ui/src/components/AgentDetailPanel.tsx
+++ b/packages/ui/src/components/AgentDetailPanel.tsx
@@ -7,7 +7,7 @@
 import { Bot, Play } from './icons';
 import type { Agent } from '../types';
 
-export interface AgentDetailPanelProps {
+interface AgentDetailPanelProps {
   agent: Agent;
   onClose: () => void;
   onChat: () => void;

--- a/packages/ui/src/components/ConfigureServiceModal.tsx
+++ b/packages/ui/src/components/ConfigureServiceModal.tsx
@@ -47,7 +47,7 @@ function getCategoryColor(category: string): string {
 // ConfigureServiceModal
 // ---------------------------------------------------------------------------
 
-export interface ConfigureServiceModalProps {
+interface ConfigureServiceModalProps {
   service: ConfigServiceView;
   activeEntryId: string | null;
   entryFormValues: Record<string, unknown>;

--- a/packages/ui/src/components/CreateAgentModal.tsx
+++ b/packages/ui/src/components/CreateAgentModal.tsx
@@ -10,7 +10,7 @@ import { agentsApi, modelsApi, toolsApi } from '../api';
 import { useModalClose } from '../hooks';
 import type { Agent, Tool, ModelInfo } from '../types';
 
-export interface CreateAgentModalProps {
+interface CreateAgentModalProps {
   onClose: () => void;
   onCreated: (agent: Agent) => void;
 }

--- a/packages/ui/src/components/EditAgentModal.tsx
+++ b/packages/ui/src/components/EditAgentModal.tsx
@@ -10,7 +10,7 @@ import { agentsApi, modelsApi, toolsApi } from '../api';
 import { useModalClose } from '../hooks';
 import type { Agent, Tool, ModelInfo, AgentDetail } from '../types';
 
-export interface EditAgentModalProps {
+interface EditAgentModalProps {
   agentId: string;
   onClose: () => void;
   onUpdated: (agent: Agent) => void;

--- a/packages/ui/src/components/EditModelModal.tsx
+++ b/packages/ui/src/components/EditModelModal.tsx
@@ -34,7 +34,7 @@ const CAPABILITY_ICONS: Record<ModelCapability, React.ReactNode> = {
 // Types
 // ============================================================================
 
-export interface EditModelModalProps {
+interface EditModelModalProps {
   model: MergedModel;
   capabilities: CapabilityDef[];
   onSave: (model: MergedModel, updates: Record<string, unknown>) => void;

--- a/packages/ui/src/components/EmptyState.tsx
+++ b/packages/ui/src/components/EmptyState.tsx
@@ -1,13 +1,13 @@
 import type { ComponentType } from 'react';
 
-export interface EmptyStateAction {
+interface EmptyStateAction {
   label: string;
   onClick: () => void;
   icon?: ComponentType<{ className?: string }>;
   variant?: 'primary' | 'secondary' | 'ghost';
 }
 
-export interface EmptyStateProps {
+interface EmptyStateProps {
   icon: ComponentType<{ className?: string }>;
   title: string;
   description?: string;

--- a/packages/ui/src/components/FleetStatusIndicator.tsx
+++ b/packages/ui/src/components/FleetStatusIndicator.tsx
@@ -25,9 +25,9 @@ import { useGateway } from '../hooks/useWebSocket';
 const REFLECT_THRESHOLD = 2;
 const STALL_THRESHOLD = 5;
 
-export type AttentionReason = 'escalation' | 'reflection' | 'stalled' | 'failed';
+type AttentionReason = 'escalation' | 'reflection' | 'stalled' | 'failed';
 
-export interface AttentionBreakdown {
+interface AttentionBreakdown {
   escalation: number;
   reflection: number;
   stalled: number;
@@ -35,7 +35,7 @@ export interface AttentionBreakdown {
   total: number;
 }
 
-export interface AttentionEntry {
+interface AttentionEntry {
   claw: ClawConfig;
   reason: AttentionReason;
   /** Short context for the row ("3 consecutive errors", "7 cycles stuck"). */

--- a/packages/ui/src/components/MarkdownContent.tsx
+++ b/packages/ui/src/components/MarkdownContent.tsx
@@ -121,7 +121,7 @@ interface MarkdownTable {
   nextIndex: number;
 }
 
-interface ParsedWidget {
+export interface ParsedWidget {
   name: string;
   data: unknown;
 }

--- a/packages/ui/src/components/PageHomeTab.tsx
+++ b/packages/ui/src/components/PageHomeTab.tsx
@@ -12,24 +12,24 @@ import { Zap, CheckCircle2 } from './icons';
 // Types
 // =============================================================================
 
-export interface HeroIcon {
+interface HeroIcon {
   icon: ComponentType<{ className?: string }>;
   color: string; // e.g. 'text-primary bg-primary/10'
 }
 
-export interface FeatureCard {
+interface FeatureCard {
   icon: ComponentType<{ className?: string }>;
   color: string; // icon wrapper classes e.g. 'text-violet-500 bg-violet-500/10'
   title: string;
   description: string;
 }
 
-export interface GettingStartedStep {
+interface GettingStartedStep {
   title: string;
   detail: string;
 }
 
-export interface QuickAction {
+interface QuickAction {
   icon: ComponentType<{ className?: string }>;
   label: string;
   description: string;
@@ -37,14 +37,14 @@ export interface QuickAction {
   onClick: () => void;
 }
 
-export interface InfoBox {
+interface InfoBox {
   icon: ComponentType<{ className?: string }>;
   title: string;
   description: string;
   color: 'blue' | 'amber' | 'green' | 'violet';
 }
 
-export interface PageHomeTabProps {
+interface PageHomeTabProps {
   /** 3 hero icon badges */
   heroIcons: [HeroIcon, HeroIcon, HeroIcon];
   /** Main headline */

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -43,7 +43,7 @@ import { ignoreError } from '../utils/ignore-error';
 /** Data sections get a divider before them (if not first visible section) */
 const DATA_GROUPS = new Set(['data', 'ai', 'tools', 'personal', 'system']);
 
-export interface SidebarProps {
+interface SidebarProps {
   isMobile: boolean;
   isOpen: boolean;
   onClose: () => void;

--- a/packages/ui/src/components/ToastProvider.tsx
+++ b/packages/ui/src/components/ToastProvider.tsx
@@ -22,9 +22,9 @@ import {
 import { Check, X, AlertCircle, AlertTriangle, Info } from './icons';
 
 // Re-export types for external usage
-export type ToastType = 'success' | 'error' | 'warning' | 'info';
+type ToastType = 'success' | 'error' | 'warning' | 'info';
 
-export interface NotificationHistoryItem {
+interface NotificationHistoryItem {
   id: string;
   type: ToastType;
   title?: string;

--- a/packages/ui/src/components/TriggerHistoryModal.tsx
+++ b/packages/ui/src/components/TriggerHistoryModal.tsx
@@ -5,7 +5,7 @@ import { useModalClose } from '../hooks';
 import { ChevronDown, ChevronRight, ChevronLeft } from './icons';
 import { LoadingSpinner } from './LoadingSpinner';
 
-export interface TriggerHistoryModalProps {
+interface TriggerHistoryModalProps {
   triggerId: string;
   triggerName: string;
   history: TriggerHistoryEntry[];

--- a/packages/ui/src/components/TriggerModal.tsx
+++ b/packages/ui/src/components/TriggerModal.tsx
@@ -71,7 +71,7 @@ export function validateCron(cron: string): { valid: boolean; error?: string } {
   return { valid: true };
 }
 
-export interface TriggerModalProps {
+interface TriggerModalProps {
   trigger: Trigger | null;
   onClose: () => void;
   onSave: () => void;

--- a/packages/ui/src/components/widgets/ChartWidget.tsx
+++ b/packages/ui/src/components/widgets/ChartWidget.tsx
@@ -7,7 +7,7 @@ interface Props {
   title?: string;
 }
 
-interface ChartData {
+export interface ChartData {
   type: 'bar' | 'line' | 'pie' | 'area' | 'scatter' | 'donut';
   data: unknown[];
   xKey?: string;

--- a/packages/ui/src/components/widgets/HtmlWidget.tsx
+++ b/packages/ui/src/components/widgets/HtmlWidget.tsx
@@ -13,7 +13,7 @@ interface Props {
   title?: string;
 }
 
-interface HtmlData {
+export interface HtmlData {
   html: string;
   title?: string;
 }

--- a/packages/ui/src/components/workflows/CodeNode.tsx
+++ b/packages/ui/src/components/workflows/CodeNode.tsx
@@ -21,7 +21,7 @@ export interface CodeNodeData extends Record<string, unknown> {
   executionOutput?: unknown;
 }
 
-export type CodeNodeType = Node<CodeNodeData>;
+type CodeNodeType = Node<CodeNodeData>;
 
 const languageConfig: Record<string, { label: string; color: string; bg: string }> = {
   javascript: { label: 'JS', color: 'text-amber-300', bg: 'bg-amber-500/20' },

--- a/packages/ui/src/components/workflows/ConditionNode.tsx
+++ b/packages/ui/src/components/workflows/ConditionNode.tsx
@@ -22,7 +22,7 @@ export interface ConditionNodeData extends Record<string, unknown> {
   branchTaken?: string;
 }
 
-export type ConditionNodeType = Node<ConditionNodeData>;
+type ConditionNodeType = Node<ConditionNodeData>;
 
 const statusStyles: Record<NodeExecutionStatus, { border: string; bg: string }> = {
   pending: { border: 'border-emerald-300 dark:border-emerald-700', bg: '' },

--- a/packages/ui/src/components/workflows/NodeSearchPalette.tsx
+++ b/packages/ui/src/components/workflows/NodeSearchPalette.tsx
@@ -30,7 +30,7 @@ import {
   Send,
 } from '../icons';
 
-export interface SearchableItem {
+interface SearchableItem {
   type: 'node' | 'tool';
   nodeType?: string;
   toolName?: string;

--- a/packages/ui/src/components/workflows/TransformerNode.tsx
+++ b/packages/ui/src/components/workflows/TransformerNode.tsx
@@ -20,7 +20,7 @@ export interface TransformerNodeData extends Record<string, unknown> {
   executionOutput?: unknown;
 }
 
-export type TransformerNodeType = Node<TransformerNodeData>;
+type TransformerNodeType = Node<TransformerNodeData>;
 
 const statusStyles: Record<NodeExecutionStatus, { border: string; bg: string }> = {
   pending: { border: 'border-amber-300 dark:border-amber-700', bg: '' },

--- a/packages/ui/src/components/workflows/TriggerNode.tsx
+++ b/packages/ui/src/components/workflows/TriggerNode.tsx
@@ -31,7 +31,7 @@ export interface TriggerNodeData extends Record<string, unknown> {
   executionStatus?: string;
 }
 
-export type TriggerNodeType = Node<TriggerNodeData>;
+type TriggerNodeType = Node<TriggerNodeData>;
 
 const triggerIcons: Record<string, React.ComponentType<{ className?: string }>> = {
   manual: Play,

--- a/packages/ui/src/components/workflows/WorkflowCopilotPanel.tsx
+++ b/packages/ui/src/components/workflows/WorkflowCopilotPanel.tsx
@@ -30,7 +30,7 @@ interface CopilotMessage {
 
 export type { WorkflowDefinition } from './workflowDefinition';
 
-export interface WorkflowCopilotPanelProps {
+interface WorkflowCopilotPanelProps {
   workflowName: string;
   nodes: Node[];
   edges: Edge[];

--- a/packages/ui/src/components/workflows/panels/DelayConfigPanel.tsx
+++ b/packages/ui/src/components/workflows/panels/DelayConfigPanel.tsx
@@ -23,7 +23,7 @@ import {
 
 type DelayUnit = 'seconds' | 'minutes' | 'hours';
 
-interface DelayNodeData {
+export interface DelayNodeData {
   label?: string;
   duration?: string;
   unit?: DelayUnit;

--- a/packages/ui/src/components/workflows/panels/ErrorHandlerConfigPanel.tsx
+++ b/packages/ui/src/components/workflows/panels/ErrorHandlerConfigPanel.tsx
@@ -20,7 +20,7 @@ import {
 // Types
 // ============================================================================
 
-interface ErrorHandlerNodeData {
+export interface ErrorHandlerNodeData {
   label?: string;
   description?: string;
   continueOnSuccess?: boolean;

--- a/packages/ui/src/components/workflows/panels/HttpRequestConfigPanel.tsx
+++ b/packages/ui/src/components/workflows/panels/HttpRequestConfigPanel.tsx
@@ -32,7 +32,7 @@ interface KeyValuePair {
   value: string;
 }
 
-interface HttpRequestNodeData {
+export interface HttpRequestNodeData {
   label?: string;
   method?: HttpMethod;
   url?: string;

--- a/packages/ui/src/constants/local-files-data.ts
+++ b/packages/ui/src/constants/local-files-data.ts
@@ -42,12 +42,12 @@ export interface IoTDevice {
   description: string;
 }
 
-export interface DeviceSeparator {
+interface DeviceSeparator {
   id: string;
   type: 'separator';
 }
 
-export type EdgeDeviceEntry = MachineDevice | IoTDevice | DeviceSeparator;
+type EdgeDeviceEntry = MachineDevice | IoTDevice | DeviceSeparator;
 
 function isSeparator(
   entry: BookmarkEntry | EdgeDeviceEntry

--- a/packages/ui/src/constants/page-layouts.ts
+++ b/packages/ui/src/constants/page-layouts.ts
@@ -7,13 +7,13 @@
  * Add new pages incrementally — unlisted pages show "Layout not mapped yet".
  */
 
-export interface PageSubComponent {
+interface PageSubComponent {
   name: string;
   file: string;
   lines: number; // approximate total lines
 }
 
-export interface PageSection {
+interface PageSection {
   id: string;
   label: string;
   lines: [number, number]; // [startLine, endLine] in main file
@@ -22,7 +22,7 @@ export interface PageSection {
   subComponents?: PageSubComponent[];
 }
 
-export interface PageLayout {
+interface PageLayout {
   path: string; // route path (e.g. "/")
   label: string; // display name (e.g. "Chat")
   file: string; // main file relative to packages/ui/src/

--- a/packages/ui/src/hooks/useAcpSession.ts
+++ b/packages/ui/src/hooks/useAcpSession.ts
@@ -36,7 +36,7 @@ export interface AcpPermissionRequest {
   timestamp: string;
 }
 
-export interface AcpSessionState {
+interface AcpSessionState {
   /** Whether this session uses ACP */
   isAcp: boolean;
   /** All tool calls (accumulated) */

--- a/packages/ui/src/hooks/useChatStore.tsx
+++ b/packages/ui/src/hooks/useChatStore.tsx
@@ -99,7 +99,7 @@ interface ChatState {
 }
 
 /** Serialized snapshot of a conversation's UI state (stored when switching away) */
-export interface ChatSessionSnapshot {
+interface ChatSessionSnapshot {
   messages: Message[];
   sessionId: string | null;
   sessionInfo: SessionInfo | null;
@@ -117,7 +117,7 @@ export interface ChatSessionSnapshot {
 }
 
 /** Tab entry for the session tab bar */
-export interface SessionTab {
+interface SessionTab {
   id: string;
   title: string;
   createdAt: number;

--- a/packages/ui/src/hooks/usePageContext.ts
+++ b/packages/ui/src/hooks/usePageContext.ts
@@ -14,7 +14,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useLocation } from 'react-router-dom';
 import { fileWorkspacesApi, codingAgentsApi, clawsApi } from '../api';
 
-export interface PageContext {
+interface PageContext {
   type: 'workspace' | 'coding-agent' | 'claw' | null;
   name?: string;
   path?: string;

--- a/packages/ui/src/hooks/usePageCopilotContext.ts
+++ b/packages/ui/src/hooks/usePageCopilotContext.ts
@@ -15,7 +15,7 @@ import { useLocation } from 'react-router-dom';
 import { PAGE_COPILOT_REGISTRY } from '../constants/page-copilot-registry';
 import type { PageCopilotConfig, PageContextData } from '../types/page-copilot';
 
-export interface UsePageCopilotContextResult {
+interface UsePageCopilotContextResult {
   config: PageCopilotConfig | null;
   contextData: PageContextData | null;
   isLoading: boolean;

--- a/packages/ui/src/hooks/useSidebarChat.tsx
+++ b/packages/ui/src/hooks/useSidebarChat.tsx
@@ -21,7 +21,7 @@ import { usePageCopilotContext } from './usePageCopilotContext';
 import { cleanStreamingChatContent, stripChatInternalTags } from '../utils/chat-content';
 import { ignoreError } from '../utils/ignore-error';
 
-export interface SidebarMessage {
+interface SidebarMessage {
   id: string;
   role: 'user' | 'assistant';
   content: string;

--- a/packages/ui/src/hooks/useSidebarRecents.ts
+++ b/packages/ui/src/hooks/useSidebarRecents.ts
@@ -24,7 +24,7 @@ export function getConvTitle(conv: Conversation): string {
   return 'New Conversation';
 }
 
-export interface DateGroup {
+interface DateGroup {
   label: string;
   items: Conversation[];
 }
@@ -62,7 +62,7 @@ function groupByDate(convs: Conversation[]): DateGroup[] {
 
 export type SourceFilter = 'all' | 'web' | 'whatsapp' | 'telegram';
 
-export interface SidebarRecentsState {
+interface SidebarRecentsState {
   conversations: Conversation[];
   groups: DateGroup[];
   total: number;

--- a/packages/ui/src/hooks/useVoice.ts
+++ b/packages/ui/src/hooks/useVoice.ts
@@ -9,7 +9,7 @@ import { useState, useRef, useCallback } from 'react';
 import { voiceApi } from '../api/endpoints/voice';
 import { useVoiceAvailability } from './useVoiceAvailability';
 
-export interface UseVoiceReturn {
+interface UseVoiceReturn {
   isRecording: boolean;
   isTranscribing: boolean;
   isSupported: boolean;

--- a/packages/ui/src/hooks/useWebSocket.tsx
+++ b/packages/ui/src/hooks/useWebSocket.tsx
@@ -17,21 +17,21 @@ import { onSessionChanged } from '../utils/session-events';
 
 export type ConnectionStatus = 'connecting' | 'connected' | 'disconnected' | 'error';
 
-export interface WSMessage<T = unknown> {
+interface WSMessage<T = unknown> {
   type: string;
   payload: T;
   timestamp: string;
   correlationId?: string;
 }
 
-export interface UseWebSocketOptions {
+interface UseWebSocketOptions {
   url?: string;
   reconnect?: boolean;
   reconnectDelay?: number;
   maxReconnectAttempts?: number;
 }
 
-export interface UseWebSocketResult {
+interface UseWebSocketResult {
   status: ConnectionStatus;
   sessionId: string | null;
   send: <T>(type: string, payload: T) => void;

--- a/packages/ui/src/pages/autonomous/hooks/useAgentStatus.ts
+++ b/packages/ui/src/pages/autonomous/hooks/useAgentStatus.ts
@@ -5,7 +5,7 @@
 import { useEffect, useRef } from 'react';
 import { useGateway } from '../../../hooks/useWebSocket';
 
-export interface AgentUpdatePayload {
+interface AgentUpdatePayload {
   agentId: string;
   state: string;
   cyclesCompleted: number;

--- a/packages/ui/src/pages/autonomous/hooks/useAgents.ts
+++ b/packages/ui/src/pages/autonomous/hooks/useAgents.ts
@@ -8,7 +8,7 @@ import type { AgentSoul, AgentCrew } from '../../../api/endpoints/souls';
 import { fromSoul } from '../types';
 import type { UnifiedAgent } from '../types';
 
-export interface UseAgentsResult {
+interface UseAgentsResult {
   agents: UnifiedAgent[];
   souls: AgentSoul[];
   crews: AgentCrew[];

--- a/packages/ui/src/pages/extensions/constants.ts
+++ b/packages/ui/src/pages/extensions/constants.ts
@@ -38,14 +38,3 @@ let toolDraftCounter = 0;
 export function nextToolDraftId(): string {
   return `tool-${Date.now()}-${++toolDraftCounter}`;
 }
-
-export interface ToolDraft {
-  id: string;
-  name: string;
-  description: string;
-  parameters: string;
-  code: string;
-  permissions: string[];
-  requiresApproval: boolean;
-  expanded: boolean;
-}

--- a/packages/ui/src/pages/skills/CreateTab.tsx
+++ b/packages/ui/src/pages/skills/CreateTab.tsx
@@ -22,7 +22,7 @@ const STEPS: { id: WizardStep; label: string; optional?: boolean }[] = [
 
 const DRAFT_STORAGE_KEY = 'skills-hub-wizard-draft';
 
-interface WizardDraft {
+export interface WizardDraft {
   format: SkillFormat | null;
   draftContent: string;
   draftName: string;

--- a/packages/ui/src/pages/workflows/WorkflowCanvas.tsx
+++ b/packages/ui/src/pages/workflows/WorkflowCanvas.tsx
@@ -16,7 +16,7 @@ import {
 
 import { nodeTypes, defaultEdgeOptions } from './shared';
 
-export interface WorkflowCanvasProps {
+interface WorkflowCanvasProps {
   nodes: Node[];
   edges: Edge[];
   isExecuting: boolean;

--- a/packages/ui/src/pages/workflows/WorkflowEditorToolbar.tsx
+++ b/packages/ui/src/pages/workflows/WorkflowEditorToolbar.tsx
@@ -19,7 +19,7 @@ import {
   Layout,
 } from '../../components/icons';
 
-export interface WorkflowEditorToolbarProps {
+interface WorkflowEditorToolbarProps {
   workflowName: string;
   setWorkflowName: (name: string) => void;
   hasUnsavedChanges: boolean;

--- a/packages/ui/src/pages/workflows/useWorkflowCanvas.ts
+++ b/packages/ui/src/pages/workflows/useWorkflowCanvas.ts
@@ -20,7 +20,7 @@ import { formatToolName } from '../../utils/formatters';
 import { autoArrangeNodes } from '../../components/workflows';
 import { getEdgeLabelProps } from './shared';
 
-export interface WorkflowCanvasParams {
+interface WorkflowCanvasParams {
   nodes: Node[];
   edges: Edge[];
   setNodes: React.Dispatch<React.SetStateAction<Node[]>>;

--- a/packages/ui/src/pages/workflows/useWorkflowExecution.ts
+++ b/packages/ui/src/pages/workflows/useWorkflowExecution.ts
@@ -11,7 +11,7 @@ import type { Workflow, WorkflowProgressEvent } from '../../api';
 import type { TriggerNodeData } from '../../components/workflows';
 import { serializeWorkflowCanvas } from './workflowPersistence';
 
-export interface WorkflowExecutionParams {
+interface WorkflowExecutionParams {
   id: string | undefined;
   workflow: Workflow | null;
   nodes: Node[];

--- a/packages/ui/src/pages/workflows/useWorkflowHistory.ts
+++ b/packages/ui/src/pages/workflows/useWorkflowHistory.ts
@@ -7,7 +7,7 @@ import type { Edge, Node } from '@xyflow/react';
 
 const MAX_HISTORY = 50;
 
-export interface WorkflowHistoryParams {
+interface WorkflowHistoryParams {
   nodes: Node[];
   edges: Edge[];
   variables: Record<string, unknown>;

--- a/packages/ui/src/pages/workflows/useWorkflowKeyboard.ts
+++ b/packages/ui/src/pages/workflows/useWorkflowKeyboard.ts
@@ -5,7 +5,7 @@
 import { useEffect } from 'react';
 import type { Edge, Node } from '@xyflow/react';
 
-export interface WorkflowKeyboardParams {
+interface WorkflowKeyboardParams {
   nodes: Node[];
   edges: Edge[];
   setNodes: React.Dispatch<React.SetStateAction<Node[]>>;

--- a/packages/ui/src/pages/workflows/useWorkflowNodes.ts
+++ b/packages/ui/src/pages/workflows/useWorkflowNodes.ts
@@ -10,7 +10,7 @@ import { apiClient, triggersApi } from '../../api';
 import { formatToolName } from '../../utils/formatters';
 import type { TriggerNodeData } from '../../components/workflows';
 
-export interface WorkflowNodesParams {
+interface WorkflowNodesParams {
   nodes: Node[];
   setNodes: React.Dispatch<React.SetStateAction<Node[]>>;
   setSelectedNodeId: (id: string | null) => void;

--- a/packages/ui/src/types/index.ts
+++ b/packages/ui/src/types/index.ts
@@ -219,10 +219,3 @@ export interface ChatResponse {
   /** Final thinking/reasoning content for models that send it in the done event */
   thinkingContent?: string;
 }
-
-export interface StreamChunk {
-  type: 'text' | 'tool_call' | 'done' | 'error';
-  content?: string;
-  toolCall?: ToolCall;
-  error?: string;
-}

--- a/packages/ui/src/types/layout-config.ts
+++ b/packages/ui/src/types/layout-config.ts
@@ -52,7 +52,7 @@ export type SidebarPinnedConfig =
 export const MAX_PINNED_ITEMS = 15;
 
 /** Built-in sidebar section identifiers (footer is structural, not configurable) */
-export type SidebarSectionId =
+type SidebarSectionId =
   // Core (always-visible UI controls)
   | 'search'
   | 'scheduled'

--- a/packages/ui/src/utils/chat-content.ts
+++ b/packages/ui/src/utils/chat-content.ts
@@ -118,7 +118,7 @@ export interface ParsedMarkerWidget {
   markerText: string;
 }
 
-export interface ParsedMarkerSuggestion {
+interface ParsedMarkerSuggestion {
   type: 'suggestion';
   items: Array<{ title: string; detail: string }>;
   markerText: string;

--- a/packages/ui/src/utils/session-events.ts
+++ b/packages/ui/src/utils/session-events.ts
@@ -1,6 +1,6 @@
 export const SESSION_CHANGED_EVENT = 'ownpilot:session-changed';
 
-export interface SessionChangedDetail {
+interface SessionChangedDetail {
   authenticated: boolean;
 }
 

--- a/packages/ui/src/utils/sse-parser.ts
+++ b/packages/ui/src/utils/sse-parser.ts
@@ -5,7 +5,7 @@
  * Shared between useChatStore and useChat hooks.
  */
 
-export type SSEEventType =
+type SSEEventType =
   | { kind: 'progress'; data: { type: string; [key: string]: unknown } }
   | {
       kind: 'approval';


### PR DESCRIPTION
Completes the unused-type-export cleanup across the backend+frontend (after core/cli in #60), using the compile-verified method: de-export top-level `export interface/type`, run full-monorepo `typecheck`, then **TS6196** ⇒ fully-dead (delete), **TS2305/2459/2694/2724/4053** ⇒ used cross-file/inline-import/public-return (revert).

**gateway:** de-export module-private types; delete 13 fully-dead types (AcpCompleteEvent, AgentDetail, AgentInfo, ApprovalManagerEvents, BrowserResult, ChannelRow, EmbeddingCacheEntry, IRepository, LlmSlotInfo, PlanExecutorEvents, ProviderMetric, + orphaned StopReason import). Kept exported: inline-`import()` types + JobStats (public return type).

**ui:** de-export 72 module-private types; delete 2 dead (ToolDraft — orphaned by ExtensionsPage removal; StreamChunk). 139 knip-flagged types reverted as false-positives (UI imports types by name; knip under-counts).

This is type-only (erased at runtime) — verified safe by full `pnpm release:verify`: build + typecheck + lint + **17,226 gateway / 9,428 core / 347 ui / 347 cli** tests, all green. The knip "unused exported types" surface is now driven to zero across all four packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)