### PR TITLE
chore(dead-code): remove dead website Card/CodeBlock exports

### DIFF
--- a/website/src/components/layout/DocsSidebar.tsx
+++ b/website/src/components/layout/DocsSidebar.tsx
@@ -3,14 +3,14 @@ import { Link, useLocation } from 'react-router';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
-export interface NavItem {
+interface NavItem {
   title: string;
   href?: string;
   items?: NavItem[];
   badge?: string;
 }
 
-export const docsNav: NavItem[] = [
+const docsNav: NavItem[] = [
   {
     title: 'Getting Started',
     items: [

--- a/website/src/components/ui/Card.tsx
+++ b/website/src/components/ui/Card.tsx
@@ -27,37 +27,3 @@ export function Card({ children, className, hover, glass }: CardProps) {
     </div>
   );
 }
-
-export function CardHeader({
-  children,
-  className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
-  return <div className={cn('mb-4', className)}>{children}</div>;
-}
-
-export function CardTitle({
-  children,
-  className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
-  return (
-    <h3 className={cn('text-base font-semibold text-[var(--color-text)]', className)}>
-      {children}
-    </h3>
-  );
-}
-
-export function CardDescription({
-  children,
-  className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
-  return <p className={cn('text-sm text-[var(--color-text-muted)] mt-1', className)}>{children}</p>;
-}

--- a/website/src/components/ui/CodeBlock.tsx
+++ b/website/src/components/ui/CodeBlock.tsx
@@ -82,23 +82,3 @@ export function CodeBlock({ code, language = 'bash', filename, className }: Code
     </div>
   );
 }
-
-interface InlineCodeProps {
-  children: React.ReactNode;
-  className?: string;
-}
-
-export function InlineCode({ children, className }: InlineCodeProps) {
-  return (
-    <code
-      className={cn(
-        'px-1.5 py-0.5 rounded-md text-sm font-mono',
-        'bg-[var(--color-code-bg)] text-[var(--color-code-text)]',
-        'border border-[var(--color-border)]',
-        className
-      )}
-    >
-      {children}
-    </code>
-  );
-}


### PR DESCRIPTION
Final package in the dead-code sweep — the standalone `website` app (not in the turbo pipeline, so verified with its own `tsc -b`).

- Delete 4 unused components (`CardHeader`, `CardTitle`, `CardDescription`, `InlineCode`) + orphaned `InlineCodeProps` — TS6133/TS6196-confirmed dead.
- De-export `docsNav` + `NavItem` (used only within DocsSidebar).

`website tsc -b` + `vite build` + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)