### PR TITLE
chore(maintainability): declare rimraf in root devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^17.0.5",
     "prettier": "^3.8.1",
+    "rimraf": "^6.1.3",
     "turbo": "^2.9.14",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.58.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
       turbo:
         specifier: ^2.9.14
         version: 2.9.14
@@ -5709,7 +5712,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@types/node@25.5.0)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(vite@7.3.3(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.5(@types/node@22.19.15)(@vitest/coverage-v8@4.1.5)(happy-dom@20.8.9)(vite@7.3.3(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -6805,7 +6808,7 @@ snapshots:
 
   glob@13.0.6:
     dependencies:
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
 


### PR DESCRIPTION
The root `clean` script used `rimraf` without declaring it at the workspace root. Clears knip's last unlisted-binary warning. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)