### PR TITLE
refactor(core): break 2 runtime import cycles (costs, plugins)

### DIFF
--- a/packages/core/src/costs/tools.test.ts
+++ b/packages/core/src/costs/tools.test.ts
@@ -5,10 +5,17 @@ import type { ToolContext } from '../agent/types.js';
 // Mocks
 // ---------------------------------------------------------------------------
 
-vi.mock('./index.js', () => ({
+vi.mock('./helpers.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   formatCost: vi.fn((v: number) => `$${v.toFixed(2)}`),
   formatTokens: vi.fn((v: number) => `${v}`),
+}));
+vi.mock('./recommendations.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   generateRecommendations: vi.fn(),
+}));
+vi.mock('./model-pricing.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   MODEL_PRICING: [
     {
       provider: 'openai',
@@ -74,7 +81,7 @@ import {
   createCostToolExecutors,
   createCostTools,
 } from './tools.js';
-import { generateRecommendations } from './index.js';
+import { generateRecommendations } from './recommendations.js';
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/core/src/costs/tools.ts
+++ b/packages/core/src/costs/tools.ts
@@ -5,8 +5,12 @@
  */
 
 import type { ToolDefinition, ToolExecutor, ToolContext } from '../agent/types.js';
-import type { UsageTracker, BudgetManager, UsageSummary } from './index.js';
-import { formatCost, formatTokens, generateRecommendations, MODEL_PRICING } from './index.js';
+import type { UsageTracker } from './usage-tracker.js';
+import type { BudgetManager } from './budget-manager.js';
+import type { UsageSummary } from './types.js';
+import { formatCost, formatTokens } from './helpers.js';
+import { generateRecommendations } from './recommendations.js';
+import { MODEL_PRICING } from './model-pricing.js';
 
 // =============================================================================
 // Tool Definitions

--- a/packages/core/src/plugins/core-plugin.ts
+++ b/packages/core/src/plugins/core-plugin.ts
@@ -9,10 +9,10 @@
  * instead of the default 'semi-trusted' used for third-party plugins.
  */
 
-import { createPlugin } from './index.js';
+import { createPlugin } from './registry.js';
 import { ALL_TOOLS } from '../agent/tools/index.js';
 import { CORE_TOOLS, CORE_EXECUTORS } from '../agent/tools.js';
-import type { PluginManifest, Plugin } from './index.js';
+import type { PluginManifest, Plugin } from './types.js';
 
 /**
  * Build the CorePlugin manifest + implementation.


### PR DESCRIPTION
Breaks the two genuine **runtime** import cycles in core — cases where a module imported *values* from its own barrel `index.ts` (which re-exports that module), a fragile pattern that only works by export-ordering luck and risks TDZ.

- `costs/tools.ts` imported `formatCost`/`formatTokens`/`generateRecommendations`/`MODEL_PRICING` from `./index.js` → import from source modules (`./helpers`, `./recommendations`, `./model-pricing`). `tools.test.ts` updated to mock the source modules instead of the barrel.
- `plugins/core-plugin.ts` imported `createPlugin` from `./index.js` → `./registry.js`.

madge core cycles 57 → 55. The remaining are **type-only `import type` edges (erased at runtime, safe by design)** or cross-module practically-safe ordering — not runtime TDZ risks; documented as a separate, carefully-scoped initiative rather than chased blindly.

Full `pnpm release:verify` green (build + typecheck + lint + 9,428 core / 17,226 gateway / 347 ui / 347 cli tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)