### PR TITLE
fix(website): bump react-router to ^7.17.0 to clear 6 CVEs

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -14,7 +14,7 @@
         "lucide-react": "^0.513.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router": "^7.6.2",
+        "react-router": "^7.17.0",
         "tailwind-merge": "^3.3.0",
         "zustand": "^5.0.5"
       },
@@ -2364,9 +2364,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
-      "integrity": "sha512-td+xP4X2/6BJvZoX6xw++A2DdEi++YypA69bJUV5oVvqf6/9/9nNlD70YO1e9d3MyamJEBQFEzk6mbfDYbqrSA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",

--- a/website/package.json
+++ b/website/package.json
@@ -16,7 +16,7 @@
     "lucide-react": "^0.513.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router": "^7.6.2",
+    "react-router": "^7.17.0",
     "tailwind-merge": "^3.3.0",
     "zustand": "^5.0.5"
   },


### PR DESCRIPTION
## Summary

The marketing site (`website/` — a separate npm project from the pnpm monorepo) pinned `react-router: ^7.6.2` with the lockfile resolved at **7.13.1**, leaving **6 open Dependabot alerts** (4 high, 2 moderate). This bumps the floor to `^7.17.0` (latest 7.x, same major) and refreshes the lock.

> Note: PR #53 previously fixed react-router CVEs in the **UI** package (pnpm workspace). This is the separate `website/` npm project, which Dependabot tracks independently.

## Alerts cleared

| # | Severity | GHSA | Issue |
|---|----------|------|-------|
| 109 | high | GHSA-49rj-9fvp-4h2h | Unauth RCE via vendored turbo-stream `TYPE_ERROR` deserialization |
| 113 | high | GHSA-8x6r-g9mw-2r78 | DoS via unbounded path expansion in `__manifest` |
| 114 | high | GHSA-rxv8-25v2-qmq8 | DoS via reflected user input in single-fetch |
| 105 | high | GHSA-8646-j5j9-6r62 | XSS in unstable RSC redirect via `javascript:` targets |
| 107 | medium | GHSA-f22v-gfqf-p8f3 | Stored XSS via unescaped `Location` header in prerendered redirect |
| 111 | medium | GHSA-2j2x-hqr9-3h42 | Open redirect via protocol-relative `//` URL reinterpretation |

## Test plan

- ✅ `npm audit` → **0 vulnerabilities**
- ✅ `npm run build` (`tsc -b && vite build`) passes
- ✅ Lockfile intact (`lockfileVersion 3`, react-router 7.17.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)