### PR TITLE
refactor(cli): route all gateway calls through the shared gateway-client

### DIFF
--- a/packages/cli/src/commands/channel.ts
+++ b/packages/cli/src/commands/channel.ts
@@ -38,18 +38,7 @@ interface SetupResponse {
 // Authorization header (OWNPILOT_API_KEY / OWNPILOT_JWT) is attached
 // consistently across every CLI subcommand that talks to the gateway.
 
-import { apiFetch, gatewayUnreachableMessage } from './gateway-client.js';
-
-function ensureGatewayError(error: unknown): never {
-  const hint = gatewayUnreachableMessage(error);
-  if (hint) {
-    console.error(hint);
-  } else {
-    const msg = error instanceof Error ? error.message : String(error);
-    console.error(`\nError: ${msg}\n`);
-  }
-  process.exit(1);
-}
+import { apiFetch, ensureGatewayError } from './gateway-client.js';
 
 // ============================================================================
 // Helpers

--- a/packages/cli/src/commands/claw.test.ts
+++ b/packages/cli/src/commands/claw.test.ts
@@ -14,8 +14,7 @@ function apiErr(status = 500) {
   return {
     ok: false,
     status,
-    text: async () => 'Server error',
-    statusText: 'Internal Server Error',
+    json: async () => ({ error: { code: 'INTERNAL_ERROR', message: 'Server error' } }),
   };
 }
 
@@ -489,7 +488,7 @@ describe('Claw CLI Commands', () => {
   describe('API failures', () => {
     it('throws when gateway returns an error', async () => {
       mockFetch.mockResolvedValueOnce(apiErr(500));
-      await expect(clawList()).rejects.toThrow(/failed.*500/);
+      await expect(clawList()).rejects.toThrow(/Server error/);
     });
   });
 });

--- a/packages/cli/src/commands/claw.ts
+++ b/packages/cli/src/commands/claw.ts
@@ -2,26 +2,17 @@
  * Claw CLI commands — drive autonomous Claw runtimes from the terminal.
  *
  * These commands interact with the gateway REST API (/api/v1/claws). The
- * gateway must be running and reachable at OWNPILOT_API_URL (default
- * http://localhost:8080/api/v1).
+ * gateway must be running and reachable at OWNPILOT_GATEWAY_URL (default
+ * http://localhost:8080).
  */
 
-const API_BASE = process.env.OWNPILOT_API_URL || 'http://localhost:8080/api/v1';
+import { apiFetch, getBaseUrl } from './gateway-client.js';
 
+/** Thin wrapper over the shared gateway client preserving the local call shape. */
 async function api(path: string, method = 'GET', body?: unknown): Promise<unknown> {
-  const opts: RequestInit = {
-    method,
-    headers: { 'Content-Type': 'application/json' },
-  };
-  if (body) opts.body = JSON.stringify(body);
-  const res = await fetch(`${API_BASE}${path}`, opts);
-  if (!res.ok) {
-    const text = await res.text().catch(() => res.statusText);
-    throw new Error(`API ${method} ${path} failed (${res.status}): ${text}`);
-  }
-  const json = (await res.json()) as { success: boolean; data: unknown; error?: unknown };
-  if (!json.success) throw new Error(`API error: ${JSON.stringify(json.error)}`);
-  return json.data;
+  const options: RequestInit = { method };
+  if (body !== undefined) options.body = JSON.stringify(body);
+  return apiFetch<unknown>(path, options);
 }
 
 interface ClawSummary {
@@ -239,17 +230,15 @@ export async function clawDenyEscalation(id: string, ...reasonParts: string[]): 
 // ─── Live event watch ───────────────────────────────────────────────────
 
 /**
- * Derive the WebSocket URL from `OWNPILOT_API_URL` (which is the HTTP
- * base, e.g. `http://localhost:8080/api/v1`). The gateway's WS endpoint
- * lives at `/ws` on the root, not under `/api/v1`, so we strip the API
- * prefix when present.
+ * Derive the WebSocket URL from the shared gateway base URL
+ * (`OWNPILOT_GATEWAY_URL`, e.g. `http://localhost:8080`). The gateway's WS
+ * endpoint lives at `/ws` on the server root.
  */
 function deriveWsUrl(): string {
   const explicit = process.env.OWNPILOT_WS_URL;
   if (explicit) return explicit;
-  const url = new URL(API_BASE);
+  const url = new URL(getBaseUrl());
   url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
-  // Strip the /api/v1 suffix so we land on /ws at the server root.
   url.pathname = '/ws';
   url.search = '';
   return url.toString();

--- a/packages/cli/src/commands/gateway-client.ts
+++ b/packages/cli/src/commands/gateway-client.ts
@@ -14,7 +14,7 @@
  * `ownpilot server` itself runs fine.
  */
 
-function getBaseUrl(): string {
+export function getBaseUrl(): string {
   return process.env.OWNPILOT_GATEWAY_URL ?? 'http://localhost:8080';
 }
 
@@ -77,4 +77,20 @@ export function gatewayUnreachableMessage(error: unknown): string | null {
     );
   }
   return null;
+}
+
+/**
+ * Print a user-facing error for a failed gateway call and exit(1). Shows the
+ * "is the gateway running?" hint for connection errors, otherwise the raw
+ * error message.
+ */
+export function ensureGatewayError(error: unknown): never {
+  const hint = gatewayUnreachableMessage(error);
+  if (hint) {
+    console.error(hint);
+  } else {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(`\nError: ${msg}\n`);
+  }
+  process.exit(1);
 }

--- a/packages/cli/src/commands/skill.ts
+++ b/packages/cli/src/commands/skill.ts
@@ -49,18 +49,7 @@ interface PermissionInfo {
 // ============================================================================
 // apiFetch + auth-header attachment lives in `./gateway-client.ts`.
 
-import { apiFetch, gatewayUnreachableMessage } from './gateway-client.js';
-
-function ensureGatewayError(error: unknown): never {
-  const hint = gatewayUnreachableMessage(error);
-  if (hint) {
-    console.error(hint);
-  } else {
-    const msg = error instanceof Error ? error.message : String(error);
-    console.error(`\nError: ${msg}\n`);
-  }
-  process.exit(1);
-}
+import { apiFetch, ensureGatewayError } from './gateway-client.js';
 
 async function listExtensions(): Promise<ExtensionInfo[]> {
   const data = await apiFetch<ExtensionInfo[] | ExtensionsListResponse>('/extensions');

--- a/packages/cli/src/commands/soul.test.ts
+++ b/packages/cli/src/commands/soul.test.ts
@@ -19,8 +19,7 @@ function apiErr(status = 500) {
   return {
     ok: false,
     status,
-    text: async () => 'Server error',
-    statusText: 'Internal Server Error',
+    json: async () => ({ error: { code: 'INTERNAL_ERROR', message: 'Server error' } }),
   };
 }
 
@@ -343,7 +342,7 @@ describe('Soul CLI Commands', () => {
   describe('API errors', () => {
     it('throws on non-ok response', async () => {
       mockFetch.mockResolvedValueOnce(apiErr(500));
-      await expect(soulList()).rejects.toThrow(/failed.*500/);
+      await expect(soulList()).rejects.toThrow(/Server error/);
     });
   });
 });

--- a/packages/cli/src/commands/soul.ts
+++ b/packages/cli/src/commands/soul.ts
@@ -4,22 +4,13 @@
  * These commands interact with the gateway REST API.
  */
 
-const API_BASE = process.env.OWNPILOT_API_URL || 'http://localhost:8080/api/v1';
+import { apiFetch } from './gateway-client.js';
 
+/** Thin wrapper over the shared gateway client preserving the local call shape. */
 async function api(path: string, method = 'GET', body?: unknown): Promise<unknown> {
-  const opts: RequestInit = {
-    method,
-    headers: { 'Content-Type': 'application/json' },
-  };
-  if (body) opts.body = JSON.stringify(body);
-  const res = await fetch(`${API_BASE}${path}`, opts);
-  if (!res.ok) {
-    const text = await res.text().catch(() => res.statusText);
-    throw new Error(`API ${method} ${path} failed (${res.status}): ${text}`);
-  }
-  const json = (await res.json()) as { success: boolean; data: unknown; error?: unknown };
-  if (!json.success) throw new Error(`API error: ${JSON.stringify(json.error)}`);
-  return json.data;
+  const options: RequestInit = { method };
+  if (body !== undefined) options.body = JSON.stringify(body);
+  return apiFetch<unknown>(path, options);
 }
 
 // ─── Soul commands ──────────────────────────────────────────────────────

--- a/packages/cli/src/commands/tunnel-wizard.ts
+++ b/packages/cli/src/commands/tunnel-wizard.ts
@@ -29,18 +29,7 @@ interface TunnelStartResponse {
 // ============================================================================
 // apiFetch + auth-header attachment lives in `./gateway-client.ts`.
 
-import { apiFetch, gatewayUnreachableMessage } from './gateway-client.js';
-
-function ensureGatewayError(error: unknown): never {
-  const hint = gatewayUnreachableMessage(error);
-  if (hint) {
-    console.error(hint);
-  } else {
-    const msg = error instanceof Error ? error.message : String(error);
-    console.error(`\nError: ${msg}\n`);
-  }
-  process.exit(1);
-}
+import { apiFetch, ensureGatewayError } from './gateway-client.js';
 
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
## Summary
- `soul.ts` and `claw.ts` predate `gateway-client.ts` and each carried a private `api()` fetch wrapper with no auth-header attachment — every soul/crew/heartbeat/claw subcommand silently 401'd against an `--auth`-protected gateway. Both now use the shared `apiFetch()`.
- The nonstandard `OWNPILOT_API_URL` env var (only ever used by these two files, never documented) is removed in favor of the standard `OWNPILOT_GATEWAY_URL`. `claw watch` derives its WS URL from the shared base via the new `getBaseUrl()` export.
- `ensureGatewayError()` is now exported from `gateway-client.ts`; three identical local copies (skill.ts, channel.ts, tunnel-wizard.ts) deleted.

## Behavior notes
- Failed-call error messages now use the gateway's error envelope (`message` field) instead of `API GET /x failed (500): <text>`.

## Test plan
- [x] CLI suite 347/347
- [x] `pnpm --filter @ownpilot/cli typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)