### PR TITLE
refactor(core): extract shared provider plumbing into providers/shared.ts

### DIFF
--- a/packages/core/src/agent/base-provider.ts
+++ b/packages/core/src/agent/base-provider.ts
@@ -20,6 +20,7 @@ import type { IProvider, ProviderHealthResult } from './provider-types.js';
 import type { RetryConfig } from './retry.js';
 import { logRetry } from './debug.js';
 import { sanitizeToolName, desanitizeToolName, normalizeToolArguments } from './tool-namespace.js';
+import { approximateTokenCount } from './providers/shared.js';
 
 /**
  * Default retry configuration for AI provider calls
@@ -62,20 +63,7 @@ export abstract class BaseProvider implements IProvider {
    * Approximate token count (rough estimate: ~4 chars per token)
    */
   countTokens(messages: readonly Message[]): number {
-    let totalChars = 0;
-    for (const msg of messages) {
-      if (typeof msg.content === 'string') {
-        totalChars += msg.content.length;
-      } else {
-        for (const part of msg.content) {
-          if (part.type === 'text') {
-            totalChars += part.text.length;
-          }
-        }
-      }
-    }
-    // Rough approximation: ~4 characters per token
-    return Math.ceil(totalChars / 4);
+    return approximateTokenCount(messages);
   }
 
   abstract getModels(): Promise<Result<string[], InternalError>>;

--- a/packages/core/src/agent/providers/anthropic-provider.ts
+++ b/packages/core/src/agent/providers/anthropic-provider.ts
@@ -30,6 +30,7 @@ import {
 } from '../debug.js';
 import { getErrorMessage } from '../../services/error-utils.js';
 import { sanitizeToolName, desanitizeToolName } from '../tool-namespace.js';
+import { readSseData, runProviderHealthCheck } from './shared.js';
 
 /**
  * Anthropic API response types
@@ -104,62 +105,25 @@ export class AnthropicProvider extends BaseProvider {
   }
 
   async healthCheck(): Promise<Result<ProviderHealthResult, InternalError>> {
-    const start = Date.now();
-    const timeoutMs = 5000;
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
-    try {
-      if (!this.isReady()) {
-        clearTimeout(timeoutId);
-        return ok({
-          providerId: 'anthropic',
-          status: 'unavailable',
-          error: 'API key not configured',
-          checkedAt: new Date(),
-        });
-      }
-
-      const response = await fetch(`${this.config.baseUrl}/messages`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-api-key': this.config.apiKey ?? '',
-          'anthropic-version': '2023-06-01',
-          'anthropic-dangerous-direct-browser-access': 'true',
-        },
-        body: JSON.stringify({ model: 'claude-3-5-haiku-20241022', max_tokens: 1, messages: [] }),
-        signal: controller.signal,
-      });
-      clearTimeout(timeoutId);
-
-      if (response.ok) {
-        return ok({
-          providerId: 'anthropic',
-          status: 'ok',
-          latencyMs: Date.now() - start,
-          checkedAt: new Date(),
-        });
-      }
-
+    return runProviderHealthCheck({
+      providerId: 'anthropic',
+      ready: this.isReady(),
+      notConfiguredError: 'API key not configured',
       // 401 is auth error — still means the endpoint is reachable
-      const isAuthError = response.status === 401;
-      return ok({
-        providerId: 'anthropic',
-        status: isAuthError ? 'ok' : 'unavailable',
-        error: isAuthError ? undefined : `HTTP ${response.status}: ${response.statusText}`,
-        latencyMs: Date.now() - start,
-        checkedAt: new Date(),
-      });
-    } catch (err) {
-      clearTimeout(timeoutId);
-      return ok({
-        providerId: 'anthropic',
-        status: 'unavailable',
-        error: err instanceof Error ? err.message : String(err),
-        checkedAt: new Date(),
-      });
-    }
+      authErrorIsOk: true,
+      request: (signal) =>
+        fetch(`${this.config.baseUrl}/messages`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': this.config.apiKey ?? '',
+            'anthropic-version': '2023-06-01',
+            'anthropic-dangerous-direct-browser-access': 'true',
+          },
+          body: JSON.stringify({ model: 'claude-3-5-haiku-20241022', max_tokens: 1, messages: [] }),
+          signal,
+        }),
+    });
   }
 
   async complete(
@@ -398,146 +362,120 @@ export class AnthropicProvider extends BaseProvider {
         return;
       }
 
-      const reader = response.body.getReader();
-      try {
-        const decoder = new TextDecoder();
-        let buffer = '';
-        // Track tool calls across content blocks
-        const toolCallBlocks: Array<{ id: string; name: string; arguments: string }> = [];
-        let currentToolBlockIndex = -1;
-        // Track input tokens from message_start
-        let inputTokens = 0;
-        // Track thinking blocks for tool use roundtrips
-        const thinkingBlocks: Record<string, unknown>[] = [];
-        // Current thinking block being streamed
-        let currentThinkingText = '';
-        let currentThinkingSignature = '';
-        // Track current content block type
-        let currentBlockType: string | undefined;
+      // Track tool calls across content blocks
+      const toolCallBlocks: Array<{ id: string; name: string; arguments: string }> = [];
+      let currentToolBlockIndex = -1;
+      // Track input tokens from message_start
+      let inputTokens = 0;
+      // Track thinking blocks for tool use roundtrips
+      const thinkingBlocks: Record<string, unknown>[] = [];
+      // Current thinking block being streamed
+      let currentThinkingText = '';
+      let currentThinkingSignature = '';
+      // Track current content block type
+      let currentBlockType: string | undefined;
 
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split('\n');
-          buffer = lines.pop() ?? '';
-
-          for (const line of lines) {
-            if (!line.startsWith('data: ')) continue;
-            const data = line.slice(6).trim();
-            if (!data) continue;
-
-            try {
-              const parsed = JSON.parse(data) as AnthropicStreamEvent;
-
-              if (parsed.type === 'message_start') {
-                // Capture input token count from the initial message
-                inputTokens = parsed.message?.usage?.input_tokens ?? 0;
-              } else if (parsed.type === 'content_block_start') {
-                currentBlockType = parsed.content_block?.type;
-
-                if (currentBlockType === 'tool_use') {
-                  // Track tool_use blocks as they start
-                  currentToolBlockIndex = parsed.index ?? toolCallBlocks.length;
-                  toolCallBlocks[currentToolBlockIndex] = {
-                    id: parsed.content_block?.id ?? '',
-                    name: parsed.content_block?.name
-                      ? desanitizeToolName(parsed.content_block.name)
-                      : '',
-                    arguments: '',
-                  };
-                } else if (currentBlockType === 'thinking') {
-                  // Reset current thinking accumulator
-                  currentThinkingText = '';
-                  currentThinkingSignature = '';
-                } else if (currentBlockType === 'redacted_thinking') {
-                  // Capture redacted thinking block immediately
-                  thinkingBlocks.push({
-                    type: 'redacted_thinking',
-                    data: parsed.content_block?.data,
-                  });
-                }
-              } else if (parsed.type === 'content_block_delta') {
-                if (parsed.delta?.type === 'thinking_delta') {
-                  // Thinking content delta — stream to client
-                  const thinkingText = parsed.delta.thinking ?? '';
-                  currentThinkingText += thinkingText;
-                  yield ok({
-                    id: '',
-                    content: thinkingText,
-                    metadata: { type: 'thinking' },
-                    done: false,
-                  });
-                } else if (parsed.delta?.type === 'signature_delta') {
-                  // Capture thinking signature
-                  currentThinkingSignature += parsed.delta.signature ?? '';
-                } else if (
-                  parsed.delta?.type === 'input_json_delta' &&
-                  parsed.delta.partial_json != null
-                ) {
-                  // Accumulate tool call arguments
-                  const blockIdx = parsed.index ?? currentToolBlockIndex;
-                  if (blockIdx >= 0 && toolCallBlocks[blockIdx]) {
-                    toolCallBlocks[blockIdx].arguments += parsed.delta.partial_json;
-                  }
-                } else if (parsed.delta?.type === 'text_delta') {
-                  // Text delta
-                  yield ok({
-                    id: '',
-                    content: parsed.delta?.text,
-                    done: false,
-                  });
-                }
-              } else if (parsed.type === 'content_block_stop') {
-                // Finalize thinking block if we were in one
-                if (currentBlockType === 'thinking' && currentThinkingText) {
-                  thinkingBlocks.push({
-                    type: 'thinking',
-                    thinking: currentThinkingText,
-                    signature: currentThinkingSignature || undefined,
-                  });
-                }
-                currentBlockType = undefined;
-              } else if (parsed.type === 'message_stop') {
-                // Emit accumulated tool calls if any, then signal done
-                // Filter out sparse array holes (indices may skip non-tool content blocks)
-                const completedToolCalls = toolCallBlocks.filter(Boolean);
-                yield ok({
-                  id: '',
-                  toolCalls: completedToolCalls.length > 0 ? completedToolCalls : undefined,
-                  done: true,
-                  // Pass thinking blocks in metadata for tool use preservation
-                  ...(thinkingBlocks.length > 0 && {
-                    metadata: { thinkingBlocks },
-                  }),
-                });
-                return;
-              } else if (parsed.type === 'message_delta') {
-                const outputTokens = parsed.usage?.output_tokens ?? 0;
-                yield ok({
-                  id: '',
-                  done: false,
-                  finishReason: this.mapAnthropicStopReason(
-                    parsed.delta?.stop_reason ?? 'end_turn'
-                  ),
-                  usage: {
-                    promptTokens: inputTokens,
-                    completionTokens: outputTokens,
-                    totalTokens: inputTokens + outputTokens,
-                  },
-                });
-              }
-            } catch {
-              // Skip malformed chunks
-            }
-          }
-        }
-      } finally {
+      for await (const data of readSseData(response.body)) {
         try {
-          await reader.cancel();
+          const parsed = JSON.parse(data) as AnthropicStreamEvent;
+
+          if (parsed.type === 'message_start') {
+            // Capture input token count from the initial message
+            inputTokens = parsed.message?.usage?.input_tokens ?? 0;
+          } else if (parsed.type === 'content_block_start') {
+            currentBlockType = parsed.content_block?.type;
+
+            if (currentBlockType === 'tool_use') {
+              // Track tool_use blocks as they start
+              currentToolBlockIndex = parsed.index ?? toolCallBlocks.length;
+              toolCallBlocks[currentToolBlockIndex] = {
+                id: parsed.content_block?.id ?? '',
+                name: parsed.content_block?.name
+                  ? desanitizeToolName(parsed.content_block.name)
+                  : '',
+                arguments: '',
+              };
+            } else if (currentBlockType === 'thinking') {
+              // Reset current thinking accumulator
+              currentThinkingText = '';
+              currentThinkingSignature = '';
+            } else if (currentBlockType === 'redacted_thinking') {
+              // Capture redacted thinking block immediately
+              thinkingBlocks.push({
+                type: 'redacted_thinking',
+                data: parsed.content_block?.data,
+              });
+            }
+          } else if (parsed.type === 'content_block_delta') {
+            if (parsed.delta?.type === 'thinking_delta') {
+              // Thinking content delta — stream to client
+              const thinkingText = parsed.delta.thinking ?? '';
+              currentThinkingText += thinkingText;
+              yield ok({
+                id: '',
+                content: thinkingText,
+                metadata: { type: 'thinking' },
+                done: false,
+              });
+            } else if (parsed.delta?.type === 'signature_delta') {
+              // Capture thinking signature
+              currentThinkingSignature += parsed.delta.signature ?? '';
+            } else if (
+              parsed.delta?.type === 'input_json_delta' &&
+              parsed.delta.partial_json != null
+            ) {
+              // Accumulate tool call arguments
+              const blockIdx = parsed.index ?? currentToolBlockIndex;
+              if (blockIdx >= 0 && toolCallBlocks[blockIdx]) {
+                toolCallBlocks[blockIdx].arguments += parsed.delta.partial_json;
+              }
+            } else if (parsed.delta?.type === 'text_delta') {
+              // Text delta
+              yield ok({
+                id: '',
+                content: parsed.delta?.text,
+                done: false,
+              });
+            }
+          } else if (parsed.type === 'content_block_stop') {
+            // Finalize thinking block if we were in one
+            if (currentBlockType === 'thinking' && currentThinkingText) {
+              thinkingBlocks.push({
+                type: 'thinking',
+                thinking: currentThinkingText,
+                signature: currentThinkingSignature || undefined,
+              });
+            }
+            currentBlockType = undefined;
+          } else if (parsed.type === 'message_stop') {
+            // Emit accumulated tool calls if any, then signal done
+            // Filter out sparse array holes (indices may skip non-tool content blocks)
+            const completedToolCalls = toolCallBlocks.filter(Boolean);
+            yield ok({
+              id: '',
+              toolCalls: completedToolCalls.length > 0 ? completedToolCalls : undefined,
+              done: true,
+              // Pass thinking blocks in metadata for tool use preservation
+              ...(thinkingBlocks.length > 0 && {
+                metadata: { thinkingBlocks },
+              }),
+            });
+            return;
+          } else if (parsed.type === 'message_delta') {
+            const outputTokens = parsed.usage?.output_tokens ?? 0;
+            yield ok({
+              id: '',
+              done: false,
+              finishReason: this.mapAnthropicStopReason(parsed.delta?.stop_reason ?? 'end_turn'),
+              usage: {
+                promptTokens: inputTokens,
+                completionTokens: outputTokens,
+                totalTokens: inputTokens + outputTokens,
+              },
+            });
+          }
         } catch {
-          /* already released */
+          // Skip malformed chunks
         }
       }
     } catch (error) {

--- a/packages/core/src/agent/providers/google.ts
+++ b/packages/core/src/agent/providers/google.ts
@@ -38,6 +38,7 @@ import {
   buildResponseDebugInfo,
   calculatePayloadBreakdown,
 } from '../debug.js';
+import { readSseData, runProviderHealthCheck, approximateTokenCount } from './shared.js';
 
 /**
  * Retry configuration
@@ -224,56 +225,17 @@ export class GoogleProvider {
   }
 
   async healthCheck(): Promise<Result<ProviderHealthResult, InternalError>> {
-    const start = Date.now();
-    const timeoutMs = 5000;
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
-    try {
-      if (!this.isReady()) {
-        clearTimeout(timeoutId);
-        return ok({
-          providerId: this.providerId,
-          status: 'unavailable',
-          error: 'API key not configured',
-          checkedAt: new Date(),
-        });
-      }
-
+    return runProviderHealthCheck({
+      providerId: this.providerId,
+      ready: this.isReady(),
+      notConfiguredError: 'API key not configured',
       // Gemini uses a different endpoint structure
-      const response = await fetch(
-        `https://generativelanguage.googleapis.com/v1beta/models?key=${this.config.apiKey}`,
-        {
+      request: (signal) =>
+        fetch(`https://generativelanguage.googleapis.com/v1beta/models?key=${this.config.apiKey}`, {
           method: 'GET',
-          signal: controller.signal,
-        }
-      );
-      clearTimeout(timeoutId);
-
-      if (response.ok) {
-        return ok({
-          providerId: this.providerId,
-          status: 'ok',
-          latencyMs: Date.now() - start,
-          checkedAt: new Date(),
-        });
-      }
-
-      return ok({
-        providerId: this.providerId,
-        status: 'unavailable',
-        error: `HTTP ${response.status}: ${response.statusText}`,
-        checkedAt: new Date(),
-      });
-    } catch (err) {
-      clearTimeout(timeoutId);
-      return ok({
-        providerId: this.providerId,
-        status: 'unavailable',
-        error: err instanceof Error ? err.message : String(err),
-        checkedAt: new Date(),
-      });
-    }
+          signal,
+        }),
+    });
   }
 
   async complete(
@@ -562,84 +524,59 @@ export class GoogleProvider {
         return;
       }
 
-      const reader = response.body.getReader();
-      try {
-        const decoder = new TextDecoder();
-        let buffer = '';
+      for await (const data of readSseData(response.body)) {
+        try {
+          const parsed = JSON.parse(data) as GeminiResponse;
+          const candidate = parsed.candidates?.[0];
 
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split('\n');
-          buffer = lines.pop() ?? '';
-
-          for (const line of lines) {
-            if (!line.startsWith('data: ')) continue;
-            const data = line.slice(6).trim();
-            if (!data) continue;
-
-            try {
-              const parsed = JSON.parse(data) as GeminiResponse;
-              const candidate = parsed.candidates?.[0];
-
-              if (candidate?.content?.parts) {
-                for (const part of candidate.content.parts) {
-                  if (part.text) {
-                    yield ok({
-                      id: `gemini_${Date.now()}`,
-                      content: part.text,
-                      metadata: part.thought ? { type: 'thinking' } : undefined,
-                      done: false,
-                    });
-                  }
-                  if (part.functionCall) {
-                    yield ok({
-                      id: `call_${Date.now()}`,
-                      toolCalls: [
-                        {
-                          id: `call_${Date.now()}`,
-                          name: desanitizeToolName(part.functionCall.name),
-                          arguments: JSON.stringify(part.functionCall.args ?? {}),
-                          // Capture thoughtSignature for Gemini 3+ thinking models
-                          metadata: part.thoughtSignature
-                            ? { thoughtSignature: part.thoughtSignature }
-                            : undefined,
-                        },
-                      ],
-                      done: false,
-                    });
-                  }
-                }
-              }
-
-              if (candidate?.finishReason) {
+          if (candidate?.content?.parts) {
+            for (const part of candidate.content.parts) {
+              if (part.text) {
                 yield ok({
                   id: `gemini_${Date.now()}`,
-                  done: true,
-                  finishReason: this.mapFinishReason(candidate.finishReason),
-                  usage: parsed.usageMetadata
-                    ? {
-                        promptTokens: parsed.usageMetadata.promptTokenCount ?? 0,
-                        completionTokens:
-                          (parsed.usageMetadata.candidatesTokenCount ?? 0) +
-                          (parsed.usageMetadata.thoughtsTokenCount ?? 0),
-                        totalTokens: parsed.usageMetadata.totalTokenCount ?? 0,
-                      }
-                    : undefined,
+                  content: part.text,
+                  metadata: part.thought ? { type: 'thinking' } : undefined,
+                  done: false,
                 });
               }
-            } catch {
-              // Skip malformed chunks
+              if (part.functionCall) {
+                yield ok({
+                  id: `call_${Date.now()}`,
+                  toolCalls: [
+                    {
+                      id: `call_${Date.now()}`,
+                      name: desanitizeToolName(part.functionCall.name),
+                      arguments: JSON.stringify(part.functionCall.args ?? {}),
+                      // Capture thoughtSignature for Gemini 3+ thinking models
+                      metadata: part.thoughtSignature
+                        ? { thoughtSignature: part.thoughtSignature }
+                        : undefined,
+                    },
+                  ],
+                  done: false,
+                });
+              }
             }
           }
-        }
-      } finally {
-        try {
-          await reader.cancel();
+
+          if (candidate?.finishReason) {
+            yield ok({
+              id: `gemini_${Date.now()}`,
+              done: true,
+              finishReason: this.mapFinishReason(candidate.finishReason),
+              usage: parsed.usageMetadata
+                ? {
+                    promptTokens: parsed.usageMetadata.promptTokenCount ?? 0,
+                    completionTokens:
+                      (parsed.usageMetadata.candidatesTokenCount ?? 0) +
+                      (parsed.usageMetadata.thoughtsTokenCount ?? 0),
+                    totalTokens: parsed.usageMetadata.totalTokenCount ?? 0,
+                  }
+                : undefined,
+            });
+          }
         } catch {
-          /* already released */
+          // Skip malformed chunks
         }
       }
     } catch (error) {
@@ -660,19 +597,7 @@ export class GoogleProvider {
    * Approximate token count
    */
   countTokens(messages: readonly Message[]): number {
-    let totalChars = 0;
-    for (const msg of messages) {
-      if (typeof msg.content === 'string') {
-        totalChars += msg.content.length;
-      } else {
-        for (const part of msg.content) {
-          if (part.type === 'text') {
-            totalChars += part.text.length;
-          }
-        }
-      }
-    }
-    return Math.ceil(totalChars / 4);
+    return approximateTokenCount(messages);
   }
 
   /**

--- a/packages/core/src/agent/providers/openai-compatible.ts
+++ b/packages/core/src/agent/providers/openai-compatible.ts
@@ -36,6 +36,7 @@ import {
   type ResolvedProviderConfig,
 } from './configs/index.js';
 import { getAuthHeader, type ResolvedAuth } from './configs/types.js';
+import { readSseData, runProviderHealthCheck, approximateTokenCount } from './shared.js';
 
 /**
  * Build the Authorization header from either the new `resolvedAuth`
@@ -154,56 +155,20 @@ export class OpenAICompatibleProvider {
   }
 
   async healthCheck(): Promise<Result<ProviderHealthResult, InternalError>> {
-    const start = Date.now();
-    const timeoutMs = 5000;
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
-    try {
-      if (!this.isReady()) {
-        clearTimeout(timeoutId);
-        return ok({
-          providerId: this.providerId,
-          status: 'unavailable',
-          error: 'API key or base URL not configured',
-          checkedAt: new Date(),
-        });
-      }
-
-      const response = await fetch(`${this.config.baseUrl}/models`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: authHeader(this.config),
-        },
-        signal: controller.signal,
-      });
-      clearTimeout(timeoutId);
-
-      if (response.ok) {
-        return ok({
-          providerId: this.providerId,
-          status: 'ok',
-          latencyMs: Date.now() - start,
-          checkedAt: new Date(),
-        });
-      }
-
-      return ok({
-        providerId: this.providerId,
-        status: 'unavailable',
-        error: `HTTP ${response.status}: ${response.statusText}`,
-        checkedAt: new Date(),
-      });
-    } catch (err) {
-      clearTimeout(timeoutId);
-      return ok({
-        providerId: this.providerId,
-        status: 'unavailable',
-        error: err instanceof Error ? err.message : String(err),
-        checkedAt: new Date(),
-      });
-    }
+    return runProviderHealthCheck({
+      providerId: this.providerId,
+      ready: this.isReady(),
+      notConfiguredError: 'API key or base URL not configured',
+      request: (signal) =>
+        fetch(`${this.config.baseUrl}/models`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: authHeader(this.config),
+          },
+          signal,
+        }),
+    });
   }
 
   async complete(
@@ -339,103 +304,81 @@ export class OpenAICompatibleProvider {
       const bridgeConvId = response.headers.get('x-conversation-id') ?? undefined;
       const bridgeSessionId = response.headers.get('x-session-id') ?? undefined;
 
-      const reader = response.body.getReader();
-      try {
-        const decoder = new TextDecoder();
-        let buffer = '';
-        let reasoningBuffer = '';
-        let reasoningDone = false;
+      let reasoningBuffer = '';
+      let reasoningDone = false;
 
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split('\n');
-          buffer = lines.pop() ?? '';
-
-          for (const line of lines) {
-            if (!line.startsWith('data: ')) continue;
-            const data = line.slice(6).trim();
-            if (process.env.OWNPILOT_DEBUG_STREAM) {
-              console.log(`[stream:${this.providerId}] ${data.slice(0, 500)}`);
-            }
-            if (data === '[DONE]') {
-              yield ok({
-                id: '',
-                done: true,
-                ...(bridgeConvId || bridgeSessionId
-                  ? {
-                      responseMetadata: { bridgeConversationId: bridgeConvId, bridgeSessionId },
-                    }
-                  : {}),
-              });
-              return;
-            }
-
-            try {
-              const parsed = JSON.parse(data) as OpenAIResponse;
-              const choice = parsed.choices?.[0];
-              const delta = choice?.delta ?? {};
-
-              // Handle reasoning content streaming (DeepSeek R1, QwQ, MiniMax-M2)
-              if (delta.reasoning_content) {
-                reasoningBuffer += delta.reasoning_content;
-                yield ok({
-                  id: parsed.id ?? '',
-                  content: delta.reasoning_content,
-                  metadata: { type: 'reasoning' },
-                  done: false,
-                });
-                // Skip the rest of this iteration only when the chunk is
-                // reasoning-only. Some providers (notably MiniMax) bundle
-                // reasoning_content together with delta.content / tool_calls
-                // / finish_reason in the SAME chunk — `continue` here would
-                // silently drop the final answer or stop signal.
-                if (!delta.content && !delta.tool_calls && choice?.finish_reason == null) {
-                  continue;
+      for await (const data of readSseData(response.body)) {
+        if (process.env.OWNPILOT_DEBUG_STREAM) {
+          console.log(`[stream:${this.providerId}] ${data.slice(0, 500)}`);
+        }
+        if (data === '[DONE]') {
+          yield ok({
+            id: '',
+            done: true,
+            ...(bridgeConvId || bridgeSessionId
+              ? {
+                  responseMetadata: { bridgeConversationId: bridgeConvId, bridgeSessionId },
                 }
-              }
+              : {}),
+          });
+          return;
+        }
 
-              // When switching from reasoning to content
-              if (reasoningBuffer && !reasoningDone && delta.content) {
-                reasoningDone = true;
-                yield ok({
-                  id: parsed.id ?? '',
-                  content: '\n\n',
-                  done: false,
-                });
-              }
+        try {
+          const parsed = JSON.parse(data) as OpenAIResponse;
+          const choice = parsed.choices?.[0];
+          const delta = choice?.delta ?? {};
 
-              yield ok({
-                id: parsed.id ?? '',
-                content: delta.content,
-                toolCalls: delta.tool_calls?.map((tc) => ({
-                  id: tc.id,
-                  name: tc.function?.name ? desanitizeToolName(tc.function.name) : undefined,
-                  arguments: tc.function?.arguments,
-                })),
-                done: choice?.finish_reason != null,
-                finishReason: choice?.finish_reason
-                  ? this.mapFinishReason(choice.finish_reason)
-                  : undefined,
-                usage: parsed.usage ? this.mapUsage(parsed.usage) : undefined,
-                ...(choice?.finish_reason != null && (bridgeConvId || bridgeSessionId)
-                  ? {
-                      responseMetadata: { bridgeConversationId: bridgeConvId, bridgeSessionId },
-                    }
-                  : {}),
-              });
-            } catch {
-              // Skip malformed chunks
+          // Handle reasoning content streaming (DeepSeek R1, QwQ, MiniMax-M2)
+          if (delta.reasoning_content) {
+            reasoningBuffer += delta.reasoning_content;
+            yield ok({
+              id: parsed.id ?? '',
+              content: delta.reasoning_content,
+              metadata: { type: 'reasoning' },
+              done: false,
+            });
+            // Skip the rest of this iteration only when the chunk is
+            // reasoning-only. Some providers (notably MiniMax) bundle
+            // reasoning_content together with delta.content / tool_calls
+            // / finish_reason in the SAME chunk — `continue` here would
+            // silently drop the final answer or stop signal.
+            if (!delta.content && !delta.tool_calls && choice?.finish_reason == null) {
+              continue;
             }
           }
-        }
-      } finally {
-        try {
-          await reader.cancel();
+
+          // When switching from reasoning to content
+          if (reasoningBuffer && !reasoningDone && delta.content) {
+            reasoningDone = true;
+            yield ok({
+              id: parsed.id ?? '',
+              content: '\n\n',
+              done: false,
+            });
+          }
+
+          yield ok({
+            id: parsed.id ?? '',
+            content: delta.content,
+            toolCalls: delta.tool_calls?.map((tc) => ({
+              id: tc.id,
+              name: tc.function?.name ? desanitizeToolName(tc.function.name) : undefined,
+              arguments: tc.function?.arguments,
+            })),
+            done: choice?.finish_reason != null,
+            finishReason: choice?.finish_reason
+              ? this.mapFinishReason(choice.finish_reason)
+              : undefined,
+            usage: parsed.usage ? this.mapUsage(parsed.usage) : undefined,
+            ...(choice?.finish_reason != null && (bridgeConvId || bridgeSessionId)
+              ? {
+                  responseMetadata: { bridgeConversationId: bridgeConvId, bridgeSessionId },
+                }
+              : {}),
+          });
         } catch {
-          /* already released */
+          // Skip malformed chunks
         }
       }
     } catch (error) {
@@ -489,19 +432,7 @@ export class OpenAICompatibleProvider {
    * Approximate token count
    */
   countTokens(messages: readonly Message[]): number {
-    let totalChars = 0;
-    for (const msg of messages) {
-      if (typeof msg.content === 'string') {
-        totalChars += msg.content.length;
-      } else {
-        for (const part of msg.content) {
-          if (part.type === 'text') {
-            totalChars += part.text.length;
-          }
-        }
-      }
-    }
-    return Math.ceil(totalChars / 4);
+    return approximateTokenCount(messages);
   }
 
   /**

--- a/packages/core/src/agent/providers/openai-provider.ts
+++ b/packages/core/src/agent/providers/openai-provider.ts
@@ -29,6 +29,7 @@ import {
 import { getErrorMessage } from '../../services/error-utils.js';
 import { desanitizeToolName } from '../tool-namespace.js';
 import { getAuthHeader, type ResolvedAuth } from './configs/types.js';
+import { readSseData, runProviderHealthCheck } from './shared.js';
 
 /**
  * Build the Authorization header from either the new `resolvedAuth`
@@ -105,56 +106,20 @@ export class OpenAIProvider extends BaseProvider {
   }
 
   async healthCheck(): Promise<Result<ProviderHealthResult, InternalError>> {
-    const start = Date.now();
-    const timeoutMs = 5000;
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-
-    try {
-      if (!this.isReady()) {
-        clearTimeout(timeoutId);
-        return ok({
-          providerId: 'openai',
-          status: 'unavailable',
-          error: 'API key not configured',
-          checkedAt: new Date(),
-        });
-      }
-
-      const response = await fetch(`${this.config.baseUrl}/models`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: authHeader(this.config),
-        },
-        signal: controller.signal,
-      });
-      clearTimeout(timeoutId);
-
-      if (response.ok) {
-        return ok({
-          providerId: 'openai',
-          status: 'ok',
-          latencyMs: Date.now() - start,
-          checkedAt: new Date(),
-        });
-      }
-
-      return ok({
-        providerId: 'openai',
-        status: 'unavailable',
-        error: `HTTP ${response.status}: ${response.statusText}`,
-        checkedAt: new Date(),
-      });
-    } catch (err) {
-      clearTimeout(timeoutId);
-      return ok({
-        providerId: 'openai',
-        status: 'unavailable',
-        error: err instanceof Error ? err.message : String(err),
-        checkedAt: new Date(),
-      });
-    }
+    return runProviderHealthCheck({
+      providerId: 'openai',
+      ready: this.isReady(),
+      notConfiguredError: 'API key not configured',
+      request: (signal) =>
+        fetch(`${this.config.baseUrl}/models`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: authHeader(this.config),
+          },
+          signal,
+        }),
+    });
   }
 
   async complete(
@@ -360,65 +325,42 @@ export class OpenAIProvider extends BaseProvider {
       const bridgeConvId = response.headers?.get?.('x-conversation-id') ?? undefined;
       const bridgeSessionId = response.headers?.get?.('x-session-id') ?? undefined;
 
-      const reader = response.body!.getReader();
-      try {
-        const decoder = new TextDecoder();
-        let buffer = '';
-
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split('\n');
-          buffer = lines.pop() ?? '';
-
-          for (const line of lines) {
-            if (!line.startsWith('data: ')) continue;
-            const data = line.slice(6).trim();
-            if (data === '[DONE]') {
-              yield ok({
-                id: '',
-                done: true,
-                ...(bridgeConvId || bridgeSessionId
-                  ? {
-                      responseMetadata: { bridgeConversationId: bridgeConvId, bridgeSessionId },
-                    }
-                  : {}),
-              });
-              return;
-            }
-
-            try {
-              const parsed = JSON.parse(data) as OpenAIResponse;
-              const choice = parsed.choices?.[0];
-              const delta = choice?.delta ?? {};
-
-              yield ok({
-                id: parsed.id ?? '',
-                content: delta.content,
-                toolCalls: delta.tool_calls?.map((tc) => ({
-                  id: tc.id,
-                  name: tc.function?.name ? desanitizeToolName(tc.function.name) : undefined,
-                  arguments: tc.function?.arguments,
-                  index: (tc as { index?: number }).index,
-                })),
-                done: choice?.finish_reason != null,
-                finishReason: choice?.finish_reason
-                  ? this.mapFinishReason(choice.finish_reason)
-                  : undefined,
-                usage: parsed.usage ? this.mapUsage(parsed.usage) : undefined,
-              });
-            } catch {
-              // Skip malformed chunks
-            }
-          }
+      for await (const data of readSseData(response.body!)) {
+        if (data === '[DONE]') {
+          yield ok({
+            id: '',
+            done: true,
+            ...(bridgeConvId || bridgeSessionId
+              ? {
+                  responseMetadata: { bridgeConversationId: bridgeConvId, bridgeSessionId },
+                }
+              : {}),
+          });
+          return;
         }
-      } finally {
+
         try {
-          await reader.cancel();
+          const parsed = JSON.parse(data) as OpenAIResponse;
+          const choice = parsed.choices?.[0];
+          const delta = choice?.delta ?? {};
+
+          yield ok({
+            id: parsed.id ?? '',
+            content: delta.content,
+            toolCalls: delta.tool_calls?.map((tc) => ({
+              id: tc.id,
+              name: tc.function?.name ? desanitizeToolName(tc.function.name) : undefined,
+              arguments: tc.function?.arguments,
+              index: (tc as { index?: number }).index,
+            })),
+            done: choice?.finish_reason != null,
+            finishReason: choice?.finish_reason
+              ? this.mapFinishReason(choice.finish_reason)
+              : undefined,
+            usage: parsed.usage ? this.mapUsage(parsed.usage) : undefined,
+          });
         } catch {
-          /* already released */
+          // Skip malformed chunks
         }
       }
     } catch (error) {

--- a/packages/core/src/agent/providers/shared.ts
+++ b/packages/core/src/agent/providers/shared.ts
@@ -1,0 +1,158 @@
+/**
+ * Shared provider plumbing.
+ *
+ * The four LLM providers (anthropic, google, openai, openai-compatible) each
+ * duplicated three pieces of infrastructure verbatim: the SSE stream reader
+ * loop, the boot-time health-check scaffold, and the approximate token
+ * counter. They live here once now — provider files keep only the genuinely
+ * provider-specific parts (request building, event dispatch, quirk handling).
+ */
+
+import { ok } from '../../types/result.js';
+import type { Result } from '../../types/result.js';
+import type { InternalError } from '../../types/errors.js';
+import type { Message } from '../types.js';
+import type { ProviderHealthResult } from '../provider-types.js';
+
+// ---------------------------------------------------------------------------
+// SSE reader
+// ---------------------------------------------------------------------------
+
+/**
+ * Read an SSE response body and yield the payload of each `data: ` line
+ * (trimmed, empty payloads skipped). Handles chunk buffering across reads and
+ * always cancels the reader on exit — including when the consumer `return`s
+ * out of its `for await` loop mid-stream (generator finalization runs the
+ * `finally`).
+ *
+ * Protocol markers like `[DONE]` are NOT interpreted here; consumers handle
+ * them in their own loop body.
+ */
+export async function* readSseData(body: ReadableStream<Uint8Array>): AsyncGenerator<string> {
+  const reader = body.getReader();
+  try {
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue;
+        const data = line.slice(6).trim();
+        if (!data) continue;
+        yield data;
+      }
+    }
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      /* already released */
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Health check
+// ---------------------------------------------------------------------------
+
+export interface ProviderHealthCheckTarget {
+  providerId: string;
+  /** Result of the provider's isReady() — false short-circuits to 'unavailable'. */
+  ready: boolean;
+  /** Error message when not ready, e.g. 'API key not configured'. */
+  notConfiguredError: string;
+  /** Issue the probe request. Must pass `signal` through to fetch. */
+  request: (signal: AbortSignal) => Promise<Response>;
+  /**
+   * Treat HTTP 401 as status 'ok' — the endpoint is reachable, the key is
+   * just wrong (used by providers whose probe hits an authenticated route).
+   */
+  authErrorIsOk?: boolean;
+}
+
+const HEALTH_CHECK_TIMEOUT_MS = 5000;
+
+/**
+ * Boot-time provider health check scaffold: 5s timeout, readiness gate,
+ * probe request, HTTP status mapping. Never rejects — failures are reported
+ * as `status: 'unavailable'` in the result value.
+ */
+export async function runProviderHealthCheck(
+  target: ProviderHealthCheckTarget
+): Promise<Result<ProviderHealthResult, InternalError>> {
+  const start = Date.now();
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), HEALTH_CHECK_TIMEOUT_MS);
+
+  try {
+    if (!target.ready) {
+      clearTimeout(timeoutId);
+      return ok({
+        providerId: target.providerId,
+        status: 'unavailable',
+        error: target.notConfiguredError,
+        checkedAt: new Date(),
+      });
+    }
+
+    const response = await target.request(controller.signal);
+    clearTimeout(timeoutId);
+
+    if (response.ok) {
+      return ok({
+        providerId: target.providerId,
+        status: 'ok',
+        latencyMs: Date.now() - start,
+        checkedAt: new Date(),
+      });
+    }
+
+    const isAuthOk = (target.authErrorIsOk ?? false) && response.status === 401;
+    return ok({
+      providerId: target.providerId,
+      status: isAuthOk ? 'ok' : 'unavailable',
+      error: isAuthOk ? undefined : `HTTP ${response.status}: ${response.statusText}`,
+      latencyMs: Date.now() - start,
+      checkedAt: new Date(),
+    });
+  } catch (error) {
+    clearTimeout(timeoutId);
+    return ok({
+      providerId: target.providerId,
+      status: 'unavailable',
+      error: error instanceof Error ? error.message : String(error),
+      checkedAt: new Date(),
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Token counting
+// ---------------------------------------------------------------------------
+
+/**
+ * Approximate token count for a message list (~4 chars per token). Shared by
+ * every provider's countTokens().
+ */
+export function approximateTokenCount(messages: readonly Message[]): number {
+  let totalChars = 0;
+  for (const msg of messages) {
+    if (typeof msg.content === 'string') {
+      totalChars += msg.content.length;
+    } else {
+      for (const part of msg.content) {
+        if (part.type === 'text') {
+          totalChars += part.text.length;
+        }
+      }
+    }
+  }
+  return Math.ceil(totalChars / 4);
+}


### PR DESCRIPTION
## Summary
The four LLM providers (anthropic, google, openai, openai-compatible) each carried verbatim copies of the SSE reader loop, the boot health-check scaffold, and the approximate token counter. They now live once in `providers/shared.ts`; the provider files keep only the genuinely provider-specific parts (request building, event dispatch, quirk handling).

- `readSseData(body)` — SSE reader with chunk buffering and guaranteed `reader.cancel()` (generator `finally` covers early `return` from the consumer loop)
- `runProviderHealthCheck({...})` — 5s timeout, readiness gate, status mapping; `authErrorIsOk` keeps anthropic's 401-means-reachable behavior
- `approximateTokenCount(messages)` — was duplicated in BaseProvider, GoogleProvider, OpenAICompatibleProvider

Composition over a template base class was deliberate: GoogleProvider/OpenAICompatibleProvider don't extend BaseProvider (different config types), and the message builders encode per-provider quirk handling that shouldn't be unified.

## Behavior notes
- Health checks now report `latencyMs` on non-OK responses for all providers (previously anthropic-only). Additive; nothing asserts the shape.

## Test plan
- [x] All provider suites: 588/588 (anthropic 59, google 48, openai-compatible 52, + router/fallback/aggregators/zhipu)
- [x] Full core suite: 9,428/9,428
- [x] `tsc --noEmit` + ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)