### PR TITLE
refactor(channels): close impl seams + extract inbound flood guard

### DIFF
--- a/packages/core/src/channels/service.ts
+++ b/packages/core/src/channels/service.ts
@@ -95,6 +95,35 @@ export interface IChannelService {
    * directly.
    */
   processIncomingMessage(message: ChannelIncomingMessage): Promise<void>;
+
+  /**
+   * Approve a pending DM sender by pairing code (owner dashboard action).
+   *
+   * DM-pairing management was previously only reachable via
+   * getChannelServiceImpl(); promoted to the contract (same rationale as
+   * processIncomingMessage) so the channel routes consume the capability
+   * accessor instead of the gateway impl module.
+   */
+  approvePendingSender(
+    platform: string,
+    code: string
+  ): Promise<{ success: boolean; error?: string }>;
+
+  /** Deny (and block) a pending DM sender by platform + platform user id. */
+  denyPendingSender(
+    platform: string,
+    platformUserId: string
+  ): Promise<{ success: boolean; error?: string }>;
+
+  /** List pending DM pairing requests for a platform. */
+  listPendingSenders(platform: string): Promise<
+    Array<{
+      platformUserId: string;
+      displayName?: string;
+      code: string;
+      expiresAt: Date;
+    }>
+  >;
 }
 
 // ============================================================================

--- a/packages/gateway/src/channels/flood-guard.test.ts
+++ b/packages/gateway/src/channels/flood-guard.test.ts
@@ -1,0 +1,69 @@
+/**
+ * InboundFloodGuard unit tests — sliding window, per-sender isolation,
+ * tracked-sender eviction, and warn-once behavior.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { InboundFloodGuard } from './flood-guard.js';
+
+describe('InboundFloodGuard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('allows messages under the limit', () => {
+    const guard = new InboundFloodGuard({ maxPerWindow: 3, windowMs: 1000 });
+    expect(guard.shouldDrop('telegram.main', 'u1')).toBe(false);
+    expect(guard.shouldDrop('telegram.main', 'u1')).toBe(false);
+    expect(guard.shouldDrop('telegram.main', 'u1')).toBe(false);
+  });
+
+  it('drops messages once the limit is reached', () => {
+    const guard = new InboundFloodGuard({ maxPerWindow: 2, windowMs: 1000 });
+    expect(guard.shouldDrop('telegram.main', 'u1')).toBe(false);
+    expect(guard.shouldDrop('telegram.main', 'u1')).toBe(false);
+    expect(guard.shouldDrop('telegram.main', 'u1')).toBe(true);
+    expect(guard.shouldDrop('telegram.main', 'u1')).toBe(true);
+  });
+
+  it('tracks senders independently (per channel + user)', () => {
+    const guard = new InboundFloodGuard({ maxPerWindow: 1, windowMs: 1000 });
+    expect(guard.shouldDrop('telegram.main', 'u1')).toBe(false);
+    expect(guard.shouldDrop('telegram.main', 'u2')).toBe(false);
+    expect(guard.shouldDrop('discord.main', 'u1')).toBe(false);
+    expect(guard.shouldDrop('telegram.main', 'u1')).toBe(true);
+  });
+
+  it('allows again after the window slides past old timestamps', () => {
+    const guard = new InboundFloodGuard({ maxPerWindow: 2, windowMs: 1000 });
+    expect(guard.shouldDrop('telegram.main', 'u1')).toBe(false);
+    expect(guard.shouldDrop('telegram.main', 'u1')).toBe(false);
+    expect(guard.shouldDrop('telegram.main', 'u1')).toBe(true);
+
+    vi.advanceTimersByTime(1001);
+    expect(guard.shouldDrop('telegram.main', 'u1')).toBe(false);
+  });
+
+  it('never drops messages with an empty platformUserId', () => {
+    const guard = new InboundFloodGuard({ maxPerWindow: 1, windowMs: 1000 });
+    expect(guard.shouldDrop('telegram.main', '')).toBe(false);
+    expect(guard.shouldDrop('telegram.main', '')).toBe(false);
+    expect(guard.shouldDrop('telegram.main', '')).toBe(false);
+  });
+
+  it('evicts the oldest tracked sender beyond maxTracked', () => {
+    const guard = new InboundFloodGuard({ maxPerWindow: 1, windowMs: 60_000, maxTracked: 2 });
+    expect(guard.shouldDrop('ch', 'u1')).toBe(false);
+    expect(guard.shouldDrop('ch', 'u2')).toBe(false);
+    // u3 pushes the map over maxTracked → u1 (oldest) evicted
+    expect(guard.shouldDrop('ch', 'u3')).toBe(false);
+    // u1 was evicted, so its window restarted — allowed again despite limit 1
+    // (this insert in turn evicts u2, the new oldest)
+    expect(guard.shouldDrop('ch', 'u1')).toBe(false);
+    // u3 stayed tracked throughout — at its limit, dropped
+    expect(guard.shouldDrop('ch', 'u3')).toBe(true);
+  });
+});

--- a/packages/gateway/src/channels/flood-guard.ts
+++ b/packages/gateway/src/channels/flood-guard.ts
@@ -1,0 +1,86 @@
+/**
+ * Inbound channel flood guard.
+ *
+ * Tracks (channelPluginId, platformUserId) -> sliding window of recent
+ * message timestamps. Over-limit messages are dropped BEFORE user lookup /
+ * AI routing, so a flood cannot exhaust DB or LLM resources.
+ *
+ * Extracted from ChannelServiceImpl so the rate-limit policy is testable on
+ * its own and reusable by other inbound surfaces (e.g. webhook handlers).
+ */
+
+import { getLog } from '../services/log.js';
+
+const log = getLog('ChannelFloodGuard');
+
+export interface FloodGuardOptions {
+  /** Max messages per sender per window. */
+  maxPerWindow?: number;
+  /** Sliding window size in ms. */
+  windowMs?: number;
+  /** Cap on distinct senders tracked (oldest evicted beyond this). */
+  maxTracked?: number;
+}
+
+const DEFAULT_MAX = parseInt(process.env.CHANNEL_INBOUND_RATE_LIMIT_MAX ?? '20', 10);
+const DEFAULT_WINDOW_MS = parseInt(process.env.CHANNEL_INBOUND_RATE_LIMIT_WINDOW_MS ?? '60000', 10);
+const DEFAULT_MAX_TRACKED = 10_000;
+
+export class InboundFloodGuard {
+  private readonly windows = new Map<string, number[]>();
+  private readonly recentlyWarned = new Set<string>();
+  private readonly maxPerWindow: number;
+  private readonly windowMs: number;
+  private readonly maxTracked: number;
+
+  constructor(options: FloodGuardOptions = {}) {
+    this.maxPerWindow = options.maxPerWindow ?? DEFAULT_MAX;
+    this.windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
+    this.maxTracked = options.maxTracked ?? DEFAULT_MAX_TRACKED;
+  }
+
+  /**
+   * Returns true if the message should be dropped due to sender flood.
+   * Records the timestamp on the allowed path so consecutive messages count
+   * toward the window. Logs one warning per sender per window.
+   */
+  shouldDrop(channelPluginId: string, platformUserId: string): boolean {
+    if (!platformUserId) return false;
+    const key = `${channelPluginId}::${platformUserId}`;
+    const now = Date.now();
+
+    let stamps = this.windows.get(key);
+    if (!stamps) {
+      stamps = [];
+      this.windows.set(key, stamps);
+      if (this.windows.size > this.maxTracked) {
+        const oldest = this.windows.keys().next().value;
+        if (oldest !== undefined && oldest !== key) this.windows.delete(oldest);
+      }
+    }
+
+    const cutoff = now - this.windowMs;
+    const filtered: number[] = [];
+    for (const t of stamps) if (t >= cutoff) filtered.push(t);
+    stamps = filtered;
+    this.windows.set(key, stamps);
+
+    if (stamps.length >= this.maxPerWindow) {
+      if (!this.recentlyWarned.has(key)) {
+        log.warn('Inbound message dropped: sender exceeded rate limit', {
+          channelPluginId,
+          platformUserId,
+          limit: this.maxPerWindow,
+          windowMs: this.windowMs,
+        });
+        this.recentlyWarned.add(key);
+        const timer = setTimeout(() => this.recentlyWarned.delete(key), this.windowMs);
+        timer.unref?.();
+      }
+      return true;
+    }
+
+    stamps.push(now);
+    return false;
+  }
+}

--- a/packages/gateway/src/channels/service-impl.ts
+++ b/packages/gateway/src/channels/service-impl.ts
@@ -7,6 +7,7 @@
  */
 
 import { timingSafeEqual, randomInt } from 'node:crypto';
+import { InboundFloodGuard } from './flood-guard.js';
 import {
   type IChannelService,
   type ChannelOutgoingMessage,
@@ -117,68 +118,10 @@ export class ChannelServiceImpl implements IChannelService {
   private static readonly MAX_APPROVAL_ATTEMPTS = 3;
 
   /**
-   * Inbound flood guard. Tracks (channelPluginId, platformUserId) -> sliding
-   * window of recent message timestamps. Over-limit messages are dropped
-   * BEFORE user lookup / AI routing, so a flood cannot exhaust DB or LLM.
+   * Inbound flood guard — drops over-limit senders BEFORE user lookup / AI
+   * routing. Policy + sliding-window state live in channels/flood-guard.ts.
    */
-  private readonly inboundWindows = new Map<string, number[]>();
-  private readonly recentlyWarnedFlooders = new Set<string>();
-  private static readonly INBOUND_RATE_LIMIT_MAX = parseInt(
-    process.env.CHANNEL_INBOUND_RATE_LIMIT_MAX ?? '20',
-    10
-  );
-  private static readonly INBOUND_RATE_LIMIT_WINDOW_MS = parseInt(
-    process.env.CHANNEL_INBOUND_RATE_LIMIT_WINDOW_MS ?? '60000',
-    10
-  );
-  private static readonly INBOUND_RATE_LIMIT_MAX_TRACKED = 10_000;
-
-  /**
-   * Returns true if the message should be dropped due to sender flood.
-   * Records the timestamp on the allowed path so consecutive messages count
-   * toward the window.
-   */
-  private isFlooding(channelPluginId: string, platformUserId: string): boolean {
-    if (!platformUserId) return false;
-    const key = `${channelPluginId}::${platformUserId}`;
-    const now = Date.now();
-    const windowMs = ChannelServiceImpl.INBOUND_RATE_LIMIT_WINDOW_MS;
-    const limit = ChannelServiceImpl.INBOUND_RATE_LIMIT_MAX;
-
-    let stamps = this.inboundWindows.get(key);
-    if (!stamps) {
-      stamps = [];
-      this.inboundWindows.set(key, stamps);
-      if (this.inboundWindows.size > ChannelServiceImpl.INBOUND_RATE_LIMIT_MAX_TRACKED) {
-        const oldest = this.inboundWindows.keys().next().value;
-        if (oldest !== undefined && oldest !== key) this.inboundWindows.delete(oldest);
-      }
-    }
-
-    const cutoff = now - windowMs;
-    const filtered: number[] = [];
-    for (const t of stamps) if (t >= cutoff) filtered.push(t);
-    stamps = filtered;
-    this.inboundWindows.set(key, stamps);
-
-    if (stamps.length >= limit) {
-      if (!this.recentlyWarnedFlooders.has(key)) {
-        log.warn('Inbound message dropped: sender exceeded rate limit', {
-          channelPluginId,
-          platformUserId,
-          limit,
-          windowMs,
-        });
-        this.recentlyWarnedFlooders.add(key);
-        const timer = setTimeout(() => this.recentlyWarnedFlooders.delete(key), windowMs);
-        timer.unref?.();
-      }
-      return true;
-    }
-
-    stamps.push(now);
-    return false;
-  }
+  private readonly floodGuard = new InboundFloodGuard();
 
   constructor(
     pluginRegistry: PluginRegistry,
@@ -541,8 +484,8 @@ export class ChannelServiceImpl implements IChannelService {
     let progress: ChannelProgressManager | null = null;
     try {
       // 0. Drop floods before any DB/LLM work. A single sender cannot exhaust
-      //    resources by spamming — see isFlooding() for the sliding window.
-      if (this.isFlooding(message.channelPluginId, message.sender.platformUserId)) {
+      //    resources by spamming — see InboundFloodGuard for the sliding window.
+      if (this.floodGuard.shouldDrop(message.channelPluginId, message.sender.platformUserId)) {
         return;
       }
 

--- a/packages/gateway/src/routes/channels/index.ts
+++ b/packages/gateway/src/routes/channels/index.ts
@@ -12,7 +12,7 @@
  */
 
 import { Hono } from 'hono';
-import { getChannelService, getDefaultPluginRegistry } from '@ownpilot/core';
+import { getChannelService, hasChannelService, getDefaultPluginRegistry } from '@ownpilot/core';
 import { ChannelMessagesRepository } from '../../db/repositories/channels/messages.js';
 import { channelUsersRepo } from '../../db/repositories/channels/users.js';
 import { configServicesRepo } from '../../db/repositories/config-services.js';
@@ -144,17 +144,16 @@ channelRoutes.post('/dm-pairing/approve', async (c) => {
     );
   }
 
-  const impl = await import('../../channels/service-impl.js');
-  const instance = impl.getChannelServiceImpl();
-  if (!instance) {
+  if (!hasChannelService()) {
     return apiError(
       c,
       { code: ERROR_CODES.SERVICE_UNAVAILABLE, message: 'Channel service not initialized' },
       503
     );
   }
+  const service = getChannelService();
 
-  const result = await instance.approvePendingSender(body.platform, body.code);
+  const result = await service.approvePendingSender(body.platform, body.code);
   if (!result.success) {
     return apiError(
       c,
@@ -192,17 +191,16 @@ channelRoutes.post('/dm-pairing/deny', async (c) => {
     );
   }
 
-  const impl = await import('../../channels/service-impl.js');
-  const instance = impl.getChannelServiceImpl();
-  if (!instance) {
+  if (!hasChannelService()) {
     return apiError(
       c,
       { code: ERROR_CODES.SERVICE_UNAVAILABLE, message: 'Channel service not initialized' },
       503
     );
   }
+  const service = getChannelService();
 
-  const result = await instance.denyPendingSender(body.platform, body.platformUserId);
+  const result = await service.denyPendingSender(body.platform, body.platformUserId);
   if (!result.success) {
     return apiError(
       c,
@@ -222,17 +220,16 @@ channelRoutes.post('/dm-pairing/deny', async (c) => {
 channelRoutes.get('/dm-pairing/pending/:platform', async (c) => {
   const platform = c.req.param('platform');
 
-  const impl = await import('../../channels/service-impl.js');
-  const instance = impl.getChannelServiceImpl();
-  if (!instance) {
+  if (!hasChannelService()) {
     return apiError(
       c,
       { code: ERROR_CODES.SERVICE_UNAVAILABLE, message: 'Channel service not initialized' },
       503
     );
   }
+  const service = getChannelService();
 
-  const pending = await instance.listPendingSenders(platform);
+  const pending = await service.listPendingSenders(platform);
 
   return apiResponse(c, { pending, count: pending.length });
 });
@@ -564,10 +561,8 @@ channelRoutes.get('/:id/users', async (c) => {
     const pendingMap = new Map<string, { code: string; expiresAt: Date }>();
     if (channelUsers.length > 0) {
       try {
-        const impl = await import('../../channels/service-impl.js');
-        const instance = impl.getChannelServiceImpl();
-        if (instance) {
-          const pendingSenders = await instance.listPendingSenders(platform);
+        if (hasChannelService()) {
+          const pendingSenders = await getChannelService().listPendingSenders(platform);
           for (const sender of pendingSenders) {
             pendingMap.set(sender.platformUserId, {
               code: sender.code,


### PR DESCRIPTION
## Summary
- **DM-pairing methods promoted to the contract**: `approvePendingSender` / `denyPendingSender` / `listPendingSenders` join `IChannelService` (same precedent as the `processIncomingMessage` promotion). The four route callsites in `routes/channels/index.ts` migrate from `getChannelServiceImpl()` to `getChannelService()`/`hasChannelService()` — these were the last production imports of the impl module outside boot.
- **Flood guard extracted**: the per-sender sliding-window rate limit moves from `ChannelServiceImpl` private state to `channels/flood-guard.ts` (`InboundFloodGuard`), behavior-identical (same env vars, same warn-once, same maxTracked eviction), now with its first dedicated unit tests. `ChannelServiceImpl` sheds one of its mixed responsibilities.

## Test plan
- [x] Gateway suite 17,246/17,246 (incl. 6 new flood-guard tests)
- [x] Core suite 9,428/9,428
- [x] tsc + ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)