### PR TITLE
refactor(core): extract file-system path security into file-security.ts

### DIFF
--- a/packages/core/src/agent/tools/file-security.test.ts
+++ b/packages/core/src/agent/tools/file-security.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Direct unit tests for the extracted path-security module.
+ *
+ * The allow/deny behavior of isPathAllowedAsync is covered end-to-end through
+ * the executors in file-system.test.ts; these tests pin the building blocks —
+ * especially realpathNearestExistingAncestor, whose docstring always claimed
+ * "exported for unit testing" but only became exported with the extraction.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  realpathNearestExistingAncestor,
+  isPathAllowedAsync,
+  resolveFilePath,
+  getWorkspaceDir,
+} from './file-security.js';
+
+let tmpDir: string;
+
+beforeAll(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'file-security-'));
+});
+
+afterAll(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('realpathNearestExistingAncestor', () => {
+  it('returns the realpath itself for an existing path', async () => {
+    const real = await realpathNearestExistingAncestor(tmpDir);
+    expect(real).toBe(await fs.realpath(tmpDir));
+  });
+
+  it('re-attaches non-existent trailing segments to the existing ancestor', async () => {
+    const target = path.join(tmpDir, 'does-not-exist', 'leaf.txt');
+    const real = await realpathNearestExistingAncestor(target);
+    expect(real).toBe(path.join(await fs.realpath(tmpDir), 'does-not-exist', 'leaf.txt'));
+  });
+
+  it('resolves a symlinked ancestor for a non-existent leaf', async () => {
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'file-security-outside-'));
+    const link = path.join(tmpDir, 'link-dir');
+    try {
+      await fs.symlink(outside, link, 'junction');
+    } catch {
+      // Symlink creation can require privileges on Windows — skip silently.
+      await fs.rm(outside, { recursive: true, force: true });
+      return;
+    }
+    try {
+      const real = await realpathNearestExistingAncestor(path.join(link, 'new-file.txt'));
+      // The symlink must be resolved to the OUTSIDE dir — this is exactly the
+      // escape isPathAllowedAsync range-checks against.
+      expect(real).toBe(path.join(await fs.realpath(outside), 'new-file.txt'));
+    } finally {
+      await fs.rm(link, { force: true });
+      await fs.rm(outside, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('isPathAllowedAsync', () => {
+  it('allows paths inside the workspace dir', async () => {
+    expect(await isPathAllowedAsync(path.join(tmpDir, 'file.txt'), tmpDir)).toBe(true);
+  });
+
+  it('blocks paths outside workspace and tmp', async () => {
+    // A path that exists but is in neither the workspace nor os.tmpdir().
+    // tmpDir IS under os.tmpdir(), so pick a root-level path instead.
+    const outside = path.parse(process.cwd()).root; // e.g. C:\ or /
+    expect(await isPathAllowedAsync(path.join(outside, 'no-such-dir', 'f.txt'), tmpDir)).toBe(
+      false
+    );
+  });
+
+  it('blocks null bytes', async () => {
+    expect(await isPathAllowedAsync(`${tmpDir}\0evil`, tmpDir)).toBe(false);
+  });
+});
+
+describe('resolveFilePath / getWorkspaceDir', () => {
+  it('resolves relative paths against the workspace', () => {
+    expect(resolveFilePath('a/b.txt', tmpDir)).toBe(path.resolve(tmpDir, 'a/b.txt'));
+  });
+
+  it('keeps absolute paths as-is (resolved)', () => {
+    const abs = path.join(tmpDir, 'x.txt');
+    expect(resolveFilePath(abs, tmpDir)).toBe(path.resolve(abs));
+  });
+
+  it('getWorkspaceDir prefers the explicit override', () => {
+    expect(getWorkspaceDir(tmpDir)).toBe(tmpDir);
+  });
+});

--- a/packages/core/src/agent/tools/file-security.ts
+++ b/packages/core/src/agent/tools/file-security.ts
@@ -1,0 +1,152 @@
+/**
+ * File-system path security.
+ *
+ * The allow-list + symlink-resolution logic that every file tool (read,
+ * write, list, search, image, pdf, ...) gates on before touching disk.
+ * Extracted from file-system.ts so the security layer is reviewable and
+ * testable on its own, separate from the tool definitions.
+ *
+ * Threat model addressed here:
+ * - path traversal out of the workspace (`../../etc/passwd`)
+ * - symlink escapes, including symlinked PARENT directories of files that
+ *   do not exist yet (create/write/move targets)
+ * - null-byte injection
+ * - access to OwnPilot's own installation (self-protection)
+ */
+
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { isOwnPilotPath } from '../../security/self-protection.js';
+
+/**
+ * Get allowed base directories for file operations (security)
+ * For self-hosted single-user setups, workspace and temp dirs are allowed
+ * @param workspaceDir Optional workspace directory override from context
+ */
+function getAllowedPaths(workspaceDir?: string): string[] {
+  const paths = [workspaceDir ?? process.env.WORKSPACE_DIR ?? process.cwd(), os.tmpdir()];
+
+  // Only add home dir if explicitly enabled (security consideration)
+  if (process.env.ALLOW_HOME_DIR_ACCESS === 'true') {
+    const home = process.env.HOME ?? process.env.USERPROFILE;
+    if (home) paths.push(home);
+  }
+
+  return paths.filter(Boolean);
+}
+
+/**
+ * Get the primary workspace directory
+ * @param workspaceDir Optional workspace directory override from context
+ */
+export function getWorkspaceDir(workspaceDir?: string): string {
+  return workspaceDir ?? process.env.WORKSPACE_DIR ?? process.cwd();
+}
+
+/**
+ * Resolve the real path of `target` when `target` itself does not exist yet
+ * (e.g. creating a new file). `fs.realpath` only resolves symlinks for paths
+ * that EXIST, so a missing leaf would skip symlink resolution entirely — and
+ * `path.normalize` does NOT follow symlinks. That gap lets a symlinked PARENT
+ * directory inside the workspace be used to escape it on create/write/delete/
+ * move (e.g. writing through a `cache -> /outside` symlink). This walks up to
+ * the nearest existing ancestor, resolves ITS symlinks, then re-attaches the
+ * non-existent trailing segments so the caller range-checks the real location.
+ * Exported for unit testing.
+ */
+export async function realpathNearestExistingAncestor(target: string): Promise<string> {
+  let current = path.resolve(target);
+  const trailing: string[] = [];
+  for (;;) {
+    try {
+      const real = await fs.realpath(current);
+      return trailing.length ? path.join(real, ...trailing) : real;
+    } catch {
+      const parent = path.dirname(current);
+      if (parent === current) {
+        // Reached the filesystem root without an existing ancestor — fall back
+        // to the normalized (symlink-free) path.
+        return path.normalize(path.resolve(target));
+      }
+      trailing.unshift(path.basename(current));
+      current = parent;
+    }
+  }
+}
+
+/**
+ * Check if path is within allowed directories (secure implementation)
+ * - Resolves symlinks to prevent escape attacks
+ * - Uses proper path comparison with separator check
+ * @param filePath Path to check
+ * @param workspaceDir Optional workspace directory override from context
+ */
+export async function isPathAllowedAsync(
+  filePath: string,
+  workspaceDir?: string
+): Promise<boolean> {
+  try {
+    // Resolve relative paths against workspace directory
+    const targetPath = path.isAbsolute(filePath)
+      ? path.resolve(filePath)
+      : path.resolve(getWorkspaceDir(workspaceDir), filePath);
+
+    // Try to resolve symlinks (if file exists)
+    let resolvedPath: string;
+    try {
+      resolvedPath = await fs.realpath(targetPath);
+    } catch {
+      // The target doesn't exist yet (e.g. creating a new file). realpath only
+      // resolves symlinks for paths that exist and path.normalize does NOT
+      // follow symlinks, so resolve the nearest existing ancestor's real path
+      // and re-attach the missing remainder — otherwise a symlinked parent
+      // directory could be used to escape the workspace on write/create.
+      resolvedPath = await realpathNearestExistingAncestor(targetPath);
+    }
+
+    // Reject null bytes and other injection attempts
+    if (resolvedPath.includes('\0')) {
+      return false;
+    }
+
+    // Self-protection: NEVER allow access to OwnPilot's own files
+    if (isOwnPilotPath(resolvedPath)) {
+      return false;
+    }
+
+    const allowedPaths = getAllowedPaths(workspaceDir);
+
+    for (const allowed of allowedPaths) {
+      const resolvedAllowed = path.resolve(allowed);
+
+      // Normalize separators for cross-platform comparison (Windows backslash → forward slash)
+      const normalizedPath = resolvedPath.replace(/\\/g, '/');
+      const normalizedAllowed = resolvedAllowed.replace(/\\/g, '/');
+
+      // Check exact match or proper subdirectory (with forward slash separator)
+      if (
+        normalizedPath === normalizedAllowed ||
+        normalizedPath.startsWith(normalizedAllowed + '/')
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve a file path, making relative paths relative to workspace
+ * @param filePath Path to resolve
+ * @param workspaceDir Optional workspace directory override from context
+ */
+export function resolveFilePath(filePath: string, workspaceDir?: string): string {
+  if (path.isAbsolute(filePath)) {
+    return path.resolve(filePath);
+  }
+  return path.resolve(getWorkspaceDir(workspaceDir), filePath);
+}

--- a/packages/core/src/agent/tools/file-system.ts
+++ b/packages/core/src/agent/tools/file-system.ts
@@ -5,13 +5,16 @@
  */
 
 import * as fs from 'node:fs/promises';
-import * as os from 'node:os';
 import * as path from 'node:path';
 import type { ToolDefinition, ToolExecutor, ToolExecutionResult } from '../types.js';
 import { getErrorMessage } from '../../services/error-utils.js';
 import { isBlockedUrl } from './web-fetch.js';
 import { isPrivateUrlAsync } from './dynamic-tool-permissions.js';
-import { isOwnPilotPath } from '../../security/self-protection.js';
+import { isPathAllowedAsync, resolveFilePath } from './file-security.js';
+
+// Path security (allow-list, symlink resolution, self-protection) lives in
+// file-security.ts; re-exported here so existing import paths keep working.
+export { isPathAllowedAsync, resolveFilePath } from './file-security.js';
 
 /** Maximum file size for read/write operations (10 MB) */
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
@@ -31,138 +34,6 @@ function safeGlobToRegex(glob: string): RegExp {
   const escaped = glob.replace(/[.+^${}()|[\]\\]/g, '\\$&');
   const pattern = escaped.replace(/\*/g, '.*').replace(/\?/g, '.');
   return new RegExp(`^${pattern}$`, 'i');
-}
-
-/**
- * Get allowed base directories for file operations (security)
- * For self-hosted single-user setups, workspace and temp dirs are allowed
- * @param workspaceDir Optional workspace directory override from context
- */
-function getAllowedPaths(workspaceDir?: string): string[] {
-  const paths = [workspaceDir ?? process.env.WORKSPACE_DIR ?? process.cwd(), os.tmpdir()];
-
-  // Only add home dir if explicitly enabled (security consideration)
-  if (process.env.ALLOW_HOME_DIR_ACCESS === 'true') {
-    const home = process.env.HOME ?? process.env.USERPROFILE;
-    if (home) paths.push(home);
-  }
-
-  return paths.filter(Boolean);
-}
-
-/**
- * Get the primary workspace directory
- * @param workspaceDir Optional workspace directory override from context
- */
-function getWorkspaceDir(workspaceDir?: string): string {
-  return workspaceDir ?? process.env.WORKSPACE_DIR ?? process.cwd();
-}
-
-/**
- * Resolve the real path of `target` when `target` itself does not exist yet
- * (e.g. creating a new file). `fs.realpath` only resolves symlinks for paths
- * that EXIST, so a missing leaf would skip symlink resolution entirely — and
- * `path.normalize` does NOT follow symlinks. That gap lets a symlinked PARENT
- * directory inside the workspace be used to escape it on create/write/delete/
- * move (e.g. writing through a `cache -> /outside` symlink). This walks up to
- * the nearest existing ancestor, resolves ITS symlinks, then re-attaches the
- * non-existent trailing segments so the caller range-checks the real location.
- * Exported for unit testing.
- */
-async function realpathNearestExistingAncestor(target: string): Promise<string> {
-  let current = path.resolve(target);
-  const trailing: string[] = [];
-  for (;;) {
-    try {
-      const real = await fs.realpath(current);
-      return trailing.length ? path.join(real, ...trailing) : real;
-    } catch {
-      const parent = path.dirname(current);
-      if (parent === current) {
-        // Reached the filesystem root without an existing ancestor — fall back
-        // to the normalized (symlink-free) path.
-        return path.normalize(path.resolve(target));
-      }
-      trailing.unshift(path.basename(current));
-      current = parent;
-    }
-  }
-}
-
-/**
- * Check if path is within allowed directories (secure implementation)
- * - Resolves symlinks to prevent escape attacks
- * - Uses proper path comparison with separator check
- * @param filePath Path to check
- * @param workspaceDir Optional workspace directory override from context
- */
-export async function isPathAllowedAsync(
-  filePath: string,
-  workspaceDir?: string
-): Promise<boolean> {
-  try {
-    // Resolve relative paths against workspace directory
-    const targetPath = path.isAbsolute(filePath)
-      ? path.resolve(filePath)
-      : path.resolve(getWorkspaceDir(workspaceDir), filePath);
-
-    // Try to resolve symlinks (if file exists)
-    let resolvedPath: string;
-    try {
-      resolvedPath = await fs.realpath(targetPath);
-    } catch {
-      // The target doesn't exist yet (e.g. creating a new file). realpath only
-      // resolves symlinks for paths that exist and path.normalize does NOT
-      // follow symlinks, so resolve the nearest existing ancestor's real path
-      // and re-attach the missing remainder — otherwise a symlinked parent
-      // directory could be used to escape the workspace on write/create.
-      resolvedPath = await realpathNearestExistingAncestor(targetPath);
-    }
-
-    // Reject null bytes and other injection attempts
-    if (resolvedPath.includes('\0')) {
-      return false;
-    }
-
-    // Self-protection: NEVER allow access to OwnPilot's own files
-    if (isOwnPilotPath(resolvedPath)) {
-      return false;
-    }
-
-    const allowedPaths = getAllowedPaths(workspaceDir);
-
-    for (const allowed of allowedPaths) {
-      const resolvedAllowed = path.resolve(allowed);
-
-      // Normalize separators for cross-platform comparison (Windows backslash → forward slash)
-      const normalizedPath = resolvedPath.replace(/\\/g, '/');
-      const normalizedAllowed = resolvedAllowed.replace(/\\/g, '/');
-
-      // Check exact match or proper subdirectory (with forward slash separator)
-      if (
-        normalizedPath === normalizedAllowed ||
-        normalizedPath.startsWith(normalizedAllowed + '/')
-      ) {
-        return true;
-      }
-    }
-
-    return false;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Resolve a file path, making relative paths relative to workspace
- * @param filePath Path to resolve
- * @param workspaceDir Optional workspace directory override from context
- */
-export function resolveFilePath(filePath: string, workspaceDir?: string): string {
-  if (path.isAbsolute(filePath)) {
-    return path.resolve(filePath);
-  }
-  return path.resolve(getWorkspaceDir(workspaceDir), filePath);
 }
 
 /**


### PR DESCRIPTION
## Summary
The path-security layer (allow-list, symlink resolution including the symlinked-parent-of-nonexistent-leaf escape case, null-byte rejection, self-protection) moves out of the 1,358-line `file-system.ts` into `file-security.ts`. Tool definitions stay where they were; `file-system.ts` re-exports `isPathAllowedAsync`/`resolveFilePath` so every existing import path — and the test mocks in image/pdf tool tests that mock `./file-system.js` — keep working unchanged.

`realpathNearestExistingAncestor` is now actually exported (its docstring claimed "exported for unit testing" but it wasn't), with direct tests pinning the symlinked-ancestor resolution it exists for.

## Test plan
- [x] 9 new direct unit tests (`file-security.test.ts`), incl. symlink-escape resolution (skips gracefully where symlinks need privileges on Windows)
- [x] Full core suite 9,437/9,437
- [x] tsc + ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)