### PR TITLE
refactor(ui): migrate three pages to usePageData; add onError option

### DIFF
--- a/packages/ui/src/hooks/usePageData.test.tsx
+++ b/packages/ui/src/hooks/usePageData.test.tsx
@@ -96,6 +96,19 @@ describe('usePageData', () => {
     expect(result.current.data).toBeNull();
   });
 
+  it('invokes onError with the raw error (error state still set)', async () => {
+    const onError = vi.fn();
+    const boom = new Error('boom');
+    const { result } = renderHook(
+      () => usePageData<string>(() => Promise.reject(boom), [], { onError }),
+      undefined
+    );
+    await flush();
+
+    expect(onError).toHaveBeenCalledWith(boom);
+    expect(result.current.error).toBe('boom');
+  });
+
   it('prefers the fixed errorMessage option over the thrown message', async () => {
     const { result } = renderHook(
       () =>

--- a/packages/ui/src/hooks/usePageData.ts
+++ b/packages/ui/src/hooks/usePageData.ts
@@ -31,6 +31,11 @@ export interface UsePageDataOptions {
    * is still unknown). Defaults to true.
    */
   enabled?: boolean;
+  /**
+   * Called with the raw thrown error (e.g. to toast). The `error` state is
+   * still set; pages that toast simply don't render it.
+   */
+  onError?: (error: unknown) => void;
 }
 
 export interface UsePageDataResult<T> {
@@ -51,18 +56,20 @@ export function usePageData<T>(
   deps: DependencyList = [],
   options: UsePageDataOptions = {}
 ): UsePageDataResult<T> {
-  const { errorMessage, enabled = true } = options;
+  const { errorMessage, enabled = true, onError } = options;
 
   const [data, setData] = useState<T | null>(null);
   const [isLoading, setIsLoading] = useState(enabled);
   const [error, setError] = useState<string | null>(null);
 
-  // Keep the latest fetcher/errorMessage in refs so the load function stays
-  // stable and only `deps` (plus refetch calls) trigger new requests.
+  // Keep the latest fetcher/errorMessage/onError in refs so the load function
+  // stays stable and only `deps` (plus refetch calls) trigger new requests.
   const fetcherRef = useRef(fetcher);
   fetcherRef.current = fetcher;
   const errorMessageRef = useRef(errorMessage);
   errorMessageRef.current = errorMessage;
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
 
   // Generation counter: each load bumps it; a response only lands if it is
   // still the newest request. Covers both unmount and dep-change races.
@@ -80,6 +87,7 @@ export function usePageData<T>(
       if (generationRef.current !== generation) return;
       const message = errorMessageRef.current ?? (err instanceof Error ? err.message : String(err));
       setError(message);
+      onErrorRef.current?.(err);
     } finally {
       if (generationRef.current === generation && !silent) setIsLoading(false);
     }

--- a/packages/ui/src/pages/ArtifactsPage.tsx
+++ b/packages/ui/src/pages/ArtifactsPage.tsx
@@ -12,6 +12,7 @@ import { ArtifactDetailModal } from '../components/ArtifactDetailModal';
 import { EmptyState } from '../components/EmptyState';
 import { SkeletonCard } from '../components/Skeleton';
 import { useSkipHome } from '../hooks/useSkipHome';
+import { usePageData } from '../hooks/usePageData';
 import {
   LayoutTemplate,
   Code2,
@@ -86,43 +87,31 @@ export function ArtifactsPage() {
   const [activeTab, setActiveTab] = useState('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [searchInput, setSearchInput] = useState('');
-  const [artifacts, setArtifacts] = useState<Artifact[]>([]);
-  const [total, setTotal] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
 
-  const fetchArtifacts = useCallback(async () => {
+  const {
+    data: listData,
+    isLoading,
+    refetch,
+    setData: setListData,
+  } = usePageData(() => {
     const filter = FILTER_TABS.find((t) => t.key === activeTab)?.filter ?? {};
-    try {
-      const data = await artifactsApi.list({
-        ...filter,
-        search: searchQuery || undefined,
-        limit: 50,
-      });
-      setArtifacts(data?.artifacts ?? []);
-      setTotal(data?.total ?? 0);
-    } catch {
-      // API client handles error reporting
-    } finally {
-      setIsLoading(false);
-    }
+    return artifactsApi.list({ ...filter, search: searchQuery || undefined, limit: 50 });
   }, [activeTab, searchQuery]);
+  const artifacts = listData?.artifacts ?? [];
+  const total = listData?.total ?? 0;
 
-  useEffect(() => {
-    setIsLoading(true);
-    fetchArtifacts();
-  }, [fetchArtifacts]);
-
-  // WS-driven refresh
+  // WS-driven refresh (silent — no spinner flash on background updates,
+  // matching the previous fetchArtifacts behavior outside dep changes)
   useEffect(() => {
     const unsub = subscribe<{ entity: string }>('data:changed', (payload) => {
       if (payload.entity === 'artifact') {
-        fetchArtifacts();
+        void refetch({ silent: true });
       }
     });
     return () => {
       unsub();
     };
-  }, [subscribe, fetchArtifacts]);
+  }, [subscribe, refetch]);
 
   // Debounced search
   useEffect(() => {
@@ -130,14 +119,31 @@ export function ArtifactsPage() {
     return () => clearTimeout(t);
   }, [searchInput]);
 
-  const handleDelete = useCallback((id: string) => {
-    setArtifacts((prev) => prev.filter((a) => a.id !== id));
-    setTotal((prev) => Math.max(0, prev - 1));
-  }, []);
+  const handleDelete = useCallback(
+    (id: string) => {
+      setListData((prev) =>
+        prev
+          ? {
+              ...prev,
+              artifacts: prev.artifacts.filter((a) => a.id !== id),
+              total: Math.max(0, prev.total - 1),
+            }
+          : prev
+      );
+    },
+    [setListData]
+  );
 
-  const handleUpdate = useCallback((updated: Artifact) => {
-    setArtifacts((prev) => prev.map((a) => (a.id === updated.id ? updated : a)));
-  }, []);
+  const handleUpdate = useCallback(
+    (updated: Artifact) => {
+      setListData((prev) =>
+        prev
+          ? { ...prev, artifacts: prev.artifacts.map((a) => (a.id === updated.id ? updated : a)) }
+          : prev
+      );
+    },
+    [setListData]
+  );
 
   // Single artifact detail view
   const [selectedArtifact, setSelectedArtifact] = useState<Artifact | null>(null);
@@ -155,10 +161,7 @@ export function ArtifactsPage() {
           </p>
         </div>
         <button
-          onClick={() => {
-            setIsLoading(true);
-            fetchArtifacts();
-          }}
+          onClick={() => void refetch()}
           className="p-2 rounded-lg hover:bg-bg-tertiary dark:hover:bg-dark-bg-tertiary transition-colors"
           title="Refresh"
         >

--- a/packages/ui/src/pages/CodingAgentSettingsPage.tsx
+++ b/packages/ui/src/pages/CodingAgentSettingsPage.tsx
@@ -6,10 +6,11 @@
  * Accessible at /settings/coding-agents.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useToast } from '../components/ToastProvider';
 import { useSkipHome } from '../hooks/useSkipHome';
+import { usePageData } from '../hooks/usePageData';
 import {
   RefreshCw,
   Terminal,
@@ -43,26 +44,18 @@ export function CodingAgentSettingsPage() {
     pageName: 'codingagentsettings',
     defaultTab: 'providers',
   });
-  const [statuses, setStatuses] = useState<CodingAgentStatus[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
   const [testingProvider, setTestingProvider] = useState<string | null>(null);
   const [testResults, setTestResults] = useState<Record<string, CodingAgentTestResult>>({});
 
-  const fetchStatuses = useCallback(async () => {
-    try {
-      setIsLoading(true);
-      const statusData = await codingAgentsApi.status();
-      setStatuses(statusData);
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to load provider status');
-    } finally {
-      setIsLoading(false);
-    }
-  }, [toast]);
-
-  useEffect(() => {
-    fetchStatuses();
-  }, [fetchStatuses]);
+  const {
+    data: statusesData,
+    isLoading,
+    refetch: fetchStatuses,
+  } = usePageData<CodingAgentStatus[]>(() => codingAgentsApi.status(), [], {
+    onError: (err) =>
+      toast.error(err instanceof Error ? err.message : 'Failed to load provider status'),
+  });
+  const statuses = statusesData ?? [];
 
   const handleTest = useCallback(
     async (provider: string) => {
@@ -114,7 +107,7 @@ export function CodingAgentSettingsPage() {
         </div>
         <div className="flex items-center gap-2">
           <button
-            onClick={fetchStatuses}
+            onClick={() => void fetchStatuses()}
             disabled={isLoading}
             className="p-2 rounded-lg text-text-muted dark:text-dark-text-muted hover:bg-bg-tertiary dark:hover:bg-dark-bg-tertiary transition-colors disabled:opacity-50"
             title="Refresh"

--- a/packages/ui/src/pages/EdgeDevicesPage.tsx
+++ b/packages/ui/src/pages/EdgeDevicesPage.tsx
@@ -30,6 +30,7 @@ import { edgeApi } from '../api/endpoints/edge';
 import type { EdgeDevice, EdgeDeviceType, EdgeDeviceStatus } from '../api/endpoints/edge';
 import { useGateway } from '../hooks/useWebSocket';
 import { useSkipHome } from '../hooks/useSkipHome';
+import { usePageData } from '../hooks/usePageData';
 
 type PageTabId = 'home' | 'devices';
 
@@ -75,29 +76,21 @@ export function EdgeDevicesPage() {
   const [filterTab, setFilterTab] = useState('all');
   const [searchQuery, setSearchQuery] = useState('');
   const [searchInput, setSearchInput] = useState('');
-  const [devices, setDevices] = useState<EdgeDevice[]>([]);
-  const [total, setTotal] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
   const [mqttConnected, setMqttConnected] = useState(false);
   const [showRegister, setShowRegister] = useState(false);
   const [selectedDevice, setSelectedDevice] = useState<EdgeDevice | null>(null);
 
-  const fetchDevices = useCallback(async () => {
+  const {
+    data: listData,
+    isLoading,
+    refetch,
+    setData: setListData,
+  } = usePageData(() => {
     const filter = FILTER_TABS.find((t) => t.key === filterTab)?.filter ?? {};
-    try {
-      const data = await edgeApi.list({
-        ...filter,
-        search: searchQuery || undefined,
-        limit: 50,
-      });
-      setDevices(data?.devices ?? []);
-      setTotal(data?.total ?? 0);
-    } catch {
-      // API client handles error reporting
-    } finally {
-      setIsLoading(false);
-    }
+    return edgeApi.list({ ...filter, search: searchQuery || undefined, limit: 50 });
   }, [filterTab, searchQuery]);
+  const devices = listData?.devices ?? [];
+  const total = listData?.total ?? 0;
 
   const fetchMqttStatus = useCallback(async () => {
     try {
@@ -109,25 +102,20 @@ export function EdgeDevicesPage() {
   }, []);
 
   useEffect(() => {
-    setIsLoading(true);
-    fetchDevices();
-  }, [fetchDevices]);
-
-  useEffect(() => {
     fetchMqttStatus();
   }, [fetchMqttStatus]);
 
-  // WS-driven refresh
+  // WS-driven refresh (silent — background update, no spinner flash)
   useEffect(() => {
     const unsub = subscribe<{ entity: string }>('data:changed', (payload) => {
       if (payload.entity === 'edge-device') {
-        fetchDevices();
+        void refetch({ silent: true });
       }
     });
     return () => {
       unsub();
     };
-  }, [subscribe, fetchDevices]);
+  }, [subscribe, refetch]);
 
   // Debounced search
   useEffect(() => {
@@ -137,26 +125,41 @@ export function EdgeDevicesPage() {
 
   const handleDelete = useCallback(
     (id: string) => {
-      setDevices((prev) => prev.filter((d) => d.id !== id));
-      setTotal((prev) => Math.max(0, prev - 1));
+      setListData((prev) =>
+        prev
+          ? {
+              ...prev,
+              devices: prev.devices.filter((d) => d.id !== id),
+              total: Math.max(0, prev.total - 1),
+            }
+          : prev
+      );
       if (selectedDevice?.id === id) setSelectedDevice(null);
     },
-    [selectedDevice]
+    [selectedDevice, setListData]
   );
 
   const handleUpdate = useCallback(
     (updated: EdgeDevice) => {
-      setDevices((prev) => prev.map((d) => (d.id === updated.id ? updated : d)));
+      setListData((prev) =>
+        prev
+          ? { ...prev, devices: prev.devices.map((d) => (d.id === updated.id ? updated : d)) }
+          : prev
+      );
       if (selectedDevice?.id === updated.id) setSelectedDevice(updated);
     },
-    [selectedDevice]
+    [selectedDevice, setListData]
   );
 
-  const handleCreated = useCallback((device: EdgeDevice) => {
-    setDevices((prev) => [device, ...prev]);
-    setTotal((prev) => prev + 1);
-    setShowRegister(false);
-  }, []);
+  const handleCreated = useCallback(
+    (device: EdgeDevice) => {
+      setListData((prev) =>
+        prev ? { ...prev, devices: [device, ...prev.devices], total: prev.total + 1 } : prev
+      );
+      setShowRegister(false);
+    },
+    [setListData]
+  );
 
   return (
     <div className="flex flex-col h-full">
@@ -191,9 +194,8 @@ export function EdgeDevicesPage() {
           </div>
           <button
             onClick={() => {
-              setIsLoading(true);
-              fetchDevices();
-              fetchMqttStatus();
+              void refetch();
+              void fetchMqttStatus();
             }}
             className="p-2 rounded-lg hover:bg-bg-tertiary dark:hover:bg-dark-bg-tertiary transition-colors"
             title="Refresh"


### PR DESCRIPTION
## Summary
- `usePageData` gains an optional `onError(rawError)` callback for the common toast-on-error page pattern (+1 hook test, 12 total).
- First migration batch: **CodingAgentSettingsPage**, **ArtifactsPage**, **EdgeDevicesPage** drop their hand-rolled `isLoading`/`useEffect` fetch blocks. WS-driven refreshes use `refetch({silent: true})` so background updates don't flash the spinner (matches previous behavior — the old code only set loading on dep changes). Local list mutations (delete/update/create) go through `setData` patches.

~57 pages remain on the as-touched migration path.

## Test plan
- [x] UI suite 370/370, typecheck, ESLint, production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)