### PR TITLE
refactor(ui): split useChatStore into useAutoCompact + useChatSessions

### DIFF
--- a/packages/ui/src/hooks/useAutoCompact.ts
+++ b/packages/ui/src/hooks/useAutoCompact.ts
@@ -1,0 +1,241 @@
+/**
+ * Auto-compact concern of the chat store.
+ *
+ * Owns the threshold/hysteresis prompt state, the per-session decline set,
+ * the persistent opt-out, the compact-in-progress flag, and the manual/auto
+ * compactSession call. Extracted from useChatStore so the compaction logic
+ * is reviewable on its own; the ChatProvider wires it in and keeps the
+ * public ChatStore API unchanged.
+ *
+ * The provider still owns `sessionInfo` — this hook receives the setter and
+ * writes through it in applySessionInfo, so every code path (stream done,
+ * non-stream done, refresh, compact result) gets identical treatment.
+ */
+
+import { useState, useRef, useCallback } from 'react';
+import type { SessionInfo } from '../types';
+import { chatApi } from '../api';
+import { STORAGE_KEYS } from '../constants/storage-keys';
+
+/**
+ * Auto-compact threshold. Crossing this fill percent raises a one-time
+ * suggestion to compact older messages into a summary. Kept at module scope
+ * so tests can import and reason about it directly.
+ */
+export const AUTO_COMPACT_THRESHOLD = 85;
+
+/** Hysteresis below the threshold — clear the prompt once we drop this far. */
+export const AUTO_COMPACT_CLEAR_BELOW = AUTO_COMPACT_THRESHOLD - 5;
+
+/**
+ * Minimum messages required before the banner appears. The server requires
+ * `messages.length > keepRecentMessages + 2` (default keepRecent = 6, so >8)
+ * to actually compact — without this guard the user could accept the banner
+ * and silently get `compacted: false`.
+ */
+export const AUTO_COMPACT_MIN_MESSAGES = 9;
+
+export interface AutoCompactPromptState {
+  sessionId: string;
+  fillPercent: number;
+  estimatedTokens: number;
+  maxContextTokens: number;
+}
+
+/**
+ * Pure decision function: given the new sessionInfo, the previous prompt
+ * state, and whether the user has declined for this session, return the
+ * prompt that should be shown (or null).
+ *
+ * Extracted as a standalone export so the threshold + hysteresis logic can be
+ * tested without rendering the full ChatProvider tree.
+ */
+export function computeAutoCompactPrompt(input: {
+  next: SessionInfo;
+  prev: AutoCompactPromptState | null;
+  declined: boolean;
+  isCompacting: boolean;
+}): AutoCompactPromptState | null {
+  const { next, prev, declined, isCompacting } = input;
+  const fill = next.contextFillPercent ?? 0;
+  const overThreshold =
+    fill >= AUTO_COMPACT_THRESHOLD &&
+    next.messageCount >= AUTO_COMPACT_MIN_MESSAGES &&
+    !declined &&
+    !isCompacting;
+
+  if (overThreshold) {
+    // Reuse the existing prompt when the fill percent hasn't moved
+    // meaningfully — prevents spurious re-renders on every stream chunk.
+    if (prev && prev.sessionId === next.sessionId && Math.abs(prev.fillPercent - fill) < 1) {
+      return prev;
+    }
+    return {
+      sessionId: next.sessionId,
+      fillPercent: fill,
+      estimatedTokens: next.estimatedTokens,
+      maxContextTokens: next.maxContextTokens,
+    };
+  }
+  // Below the clear point — drop the prompt entirely. Between threshold and
+  // clear point (hysteresis band), keep whatever was there.
+  if (fill < AUTO_COMPACT_CLEAR_BELOW) return null;
+  return prev;
+}
+
+export interface CompactSessionResult {
+  compacted: boolean;
+  removedMessages: number;
+  savedTokens: number;
+  /** Server-provided reason when `compacted` is false (e.g. `too_few_messages`). */
+  reason?: string;
+  /** Structured summary text the server generated (only on success). */
+  summary?: string;
+}
+
+export interface UseAutoCompactResult {
+  isCompacting: boolean;
+  autoCompactPrompt: AutoCompactPromptState | null;
+  /** True when the user has opted out of the auto-compact banner. */
+  autoCompactDisabled: boolean;
+  /** Most recent compaction summary text (null until a compaction succeeds). */
+  lastCompactionSummary: string | null;
+  /**
+   * Apply a new sessionInfo (writes through the injected setter) and raise or
+   * clear the auto-compact prompt according to threshold + hysteresis.
+   */
+  applySessionInfo: (next: SessionInfo | null) => void;
+  /** Dismiss the suggestion until the next session change. */
+  dismissAutoCompactPrompt: () => void;
+  /** Permanently disable the banner (persisted to localStorage). */
+  disableAutoCompactPrompt: () => void;
+  clearLastCompactionSummary: () => void;
+  /** Drop the prompt without recording a decline (e.g. on loadConversation). */
+  resetAutoCompactPrompt: () => void;
+  /** Manually compact the current chat context. Updates sessionInfo from the server response. */
+  compactSession: (keepRecentMessages?: number) => Promise<CompactSessionResult>;
+}
+
+export function useAutoCompact(opts: {
+  provider: string;
+  model: string;
+  /** The ChatProvider's sessionInfo setter — applySessionInfo writes through it. */
+  setSessionInfo: (info: SessionInfo | null) => void;
+}): UseAutoCompactResult {
+  const { provider, model, setSessionInfo } = opts;
+
+  const [isCompacting, setIsCompacting] = useState(false);
+  const [autoCompactPrompt, setAutoCompactPrompt] = useState<AutoCompactPromptState | null>(null);
+  // Track which sessionIds the user has already declined an auto-compact for,
+  // so we don't re-prompt on every chunk after they say "not now".
+  const autoCompactSuppressedRef = useRef<Set<string>>(new Set());
+  // Persistent opt-out — survives page reloads. Read once at mount.
+  const [autoCompactDisabled, setAutoCompactDisabled] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEYS.AUTO_COMPACT_DISABLED) === '1';
+    } catch {
+      return false;
+    }
+  });
+  const [lastCompactionSummary, setLastCompactionSummary] = useState<string | null>(null);
+
+  const applySessionInfo = useCallback(
+    (next: SessionInfo | null) => {
+      setSessionInfo(next);
+      if (!next) {
+        setAutoCompactPrompt(null);
+        return;
+      }
+      if (autoCompactDisabled) {
+        setAutoCompactPrompt(null);
+        return;
+      }
+      setAutoCompactPrompt((prev) =>
+        computeAutoCompactPrompt({
+          next,
+          prev,
+          declined: autoCompactSuppressedRef.current.has(next.sessionId),
+          isCompacting,
+        })
+      );
+    },
+    [isCompacting, autoCompactDisabled, setSessionInfo]
+  );
+
+  const dismissAutoCompactPrompt = useCallback(() => {
+    setAutoCompactPrompt((prev) => {
+      if (prev) autoCompactSuppressedRef.current.add(prev.sessionId);
+      return null;
+    });
+  }, []);
+
+  const disableAutoCompactPrompt = useCallback(() => {
+    try {
+      localStorage.setItem(STORAGE_KEYS.AUTO_COMPACT_DISABLED, '1');
+    } catch {
+      /* localStorage might be blocked — in-memory toggle still applies */
+    }
+    setAutoCompactDisabled(true);
+    setAutoCompactPrompt(null);
+  }, []);
+
+  const clearLastCompactionSummary = useCallback(() => {
+    setLastCompactionSummary(null);
+  }, []);
+
+  const resetAutoCompactPrompt = useCallback(() => {
+    setAutoCompactPrompt(null);
+  }, []);
+
+  const compactSession = useCallback(
+    async (keepRecentMessages?: number): Promise<CompactSessionResult> => {
+      if (!provider || !model) {
+        return { compacted: false, removedMessages: 0, savedTokens: 0 };
+      }
+      setIsCompacting(true);
+      setAutoCompactPrompt(null);
+      try {
+        const d = await chatApi.compactContext(provider, model, keepRecentMessages);
+        if (d?.session) {
+          // Server returns post-compact SessionInfo — apply it directly so
+          // the bar reflects the new state without waiting for the next msg.
+          applySessionInfo(d.session);
+        }
+        if (d?.compacted && d.summary) {
+          setLastCompactionSummary(d.summary);
+        }
+        const saved = Math.max(0, (d?.previousTokenEstimate ?? 0) - (d?.newTokenEstimate ?? 0));
+        return {
+          compacted: !!d?.compacted,
+          removedMessages: d?.removedMessages ?? 0,
+          savedTokens: saved,
+          ...(d?.reason && { reason: d.reason }),
+          ...(d?.summary && { summary: d.summary }),
+        };
+      } catch {
+        return {
+          compacted: false,
+          removedMessages: 0,
+          savedTokens: 0,
+          reason: 'exception',
+        };
+      } finally {
+        setIsCompacting(false);
+      }
+    },
+    [provider, model, applySessionInfo]
+  );
+
+  return {
+    isCompacting,
+    autoCompactPrompt,
+    autoCompactDisabled,
+    lastCompactionSummary,
+    applySessionInfo,
+    dismissAutoCompactPrompt,
+    disableAutoCompactPrompt,
+    clearLastCompactionSummary,
+    resetAutoCompactPrompt,
+    compactSession,
+  };
+}

--- a/packages/ui/src/hooks/useChatSessions.test.tsx
+++ b/packages/ui/src/hooks/useChatSessions.test.tsx
@@ -1,0 +1,220 @@
+// @vitest-environment happy-dom
+/**
+ * useChatSessions tests — tab lifecycle (create/switch/close), snapshot
+ * save/restore orchestration, and oldest-session eviction. The hook was
+ * extracted from useChatStore; these are its first direct tests (previously
+ * only reachable through the full ChatProvider).
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createElement, act, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useChatSessions, type ChatSessionController } from './useChatSessions';
+
+interface TestSnap {
+  messages: Array<{ role: string; content: string }>;
+}
+
+function renderHook<T>(useHook: () => T) {
+  const result = { current: null as unknown as T };
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  let root: Root;
+
+  function TestComponent() {
+    result.current = useHook();
+    return null as unknown as ReactNode;
+  }
+
+  act(() => {
+    root = createRoot(container);
+    root.render(createElement(TestComponent));
+  });
+
+  return {
+    result,
+    unmount: () =>
+      act(() => {
+        root.unmount();
+        if (container.parentNode) container.parentNode.removeChild(container);
+      }),
+  };
+}
+
+function makeController(overrides: Partial<ChatSessionController<TestSnap>> = {}) {
+  let current: TestSnap = { messages: [] };
+  const controller: ChatSessionController<TestSnap> = {
+    capture: vi.fn(() => current),
+    restore: vi.fn((snap: TestSnap) => {
+      current = snap;
+    }),
+    clear: vi.fn(() => {
+      current = { messages: [] };
+    }),
+    orphanStream: vi.fn(),
+    setSessionId: vi.fn(),
+    rejectPendingApproval: vi.fn(),
+    ...overrides,
+  };
+  return {
+    controller,
+    setCurrent: (snap: TestSnap) => {
+      current = snap;
+    },
+    getCurrent: () => current,
+  };
+}
+
+const flush = () => act(async () => {});
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('useChatSessions', () => {
+  it('createSession with no messages clears state without adding a tab', () => {
+    const { controller } = makeController();
+    const { result } = renderHook(() => useChatSessions<TestSnap>(controller));
+
+    let newId = '';
+    act(() => {
+      newId = result.current.createSession();
+    });
+
+    expect(result.current.sessionTabs).toHaveLength(0);
+    expect(result.current.activeSessionId).toBe(newId);
+    expect(controller.clear).toHaveBeenCalled();
+    expect(controller.setSessionId).toHaveBeenCalledWith(newId);
+    expect(controller.rejectPendingApproval).toHaveBeenCalled();
+  });
+
+  it('createSession with messages saves the old session as a tab titled by first user message', () => {
+    const { controller, setCurrent } = makeController();
+    const { result } = renderHook(() => useChatSessions<TestSnap>(controller));
+    const oldId = result.current.activeSessionId;
+
+    setCurrent({ messages: [{ role: 'user', content: 'hello world' }] });
+    act(() => {
+      result.current.createSession();
+    });
+
+    expect(result.current.sessionTabs).toHaveLength(1);
+    expect(result.current.sessionTabs[0]).toMatchObject({ id: oldId, title: 'hello world' });
+    expect(result.current.activeSessionId).not.toBe(oldId);
+  });
+
+  it('switchSession restores a cached snapshot and orphans the current stream', () => {
+    const { controller, setCurrent } = makeController();
+    const { result } = renderHook(() => useChatSessions<TestSnap>(controller));
+    const firstId = result.current.activeSessionId;
+
+    // Build up a first session, then create a new one (caches the first)
+    setCurrent({ messages: [{ role: 'user', content: 'first session' }] });
+    act(() => {
+      result.current.createSession();
+    });
+    setCurrent({ messages: [{ role: 'user', content: 'second session' }] });
+
+    act(() => {
+      result.current.switchSession(firstId);
+    });
+
+    expect(controller.orphanStream).toHaveBeenCalled();
+    expect(controller.restore).toHaveBeenCalledWith(
+      expect.objectContaining({ messages: [{ role: 'user', content: 'first session' }] })
+    );
+    expect(result.current.activeSessionId).toBe(firstId);
+    // The second session became a tab
+    expect(result.current.sessionTabs.map((t) => t.title)).toContain('second session');
+  });
+
+  it('switchSession to an uncached id clears state and sets the session id for DB load', () => {
+    const { controller } = makeController();
+    const { result } = renderHook(() => useChatSessions<TestSnap>(controller));
+
+    act(() => {
+      result.current.switchSession('db-session-id');
+    });
+
+    expect(controller.clear).toHaveBeenCalled();
+    expect(controller.setSessionId).toHaveBeenCalledWith('db-session-id');
+    expect(result.current.activeSessionId).toBe('db-session-id');
+  });
+
+  it('switchSession to the active session is a no-op', () => {
+    const { controller } = makeController();
+    const { result } = renderHook(() => useChatSessions<TestSnap>(controller));
+
+    act(() => {
+      result.current.switchSession(result.current.activeSessionId);
+    });
+
+    expect(controller.capture).not.toHaveBeenCalled();
+    expect(controller.orphanStream).not.toHaveBeenCalled();
+  });
+
+  it('closing the active tab switches to the nearest remaining tab', async () => {
+    const { controller, setCurrent } = makeController();
+    const { result } = renderHook(() => useChatSessions<TestSnap>(controller));
+
+    setCurrent({ messages: [{ role: 'user', content: 'tab one' }] });
+    act(() => {
+      result.current.createSession();
+    });
+    const secondId = result.current.activeSessionId;
+    setCurrent({ messages: [{ role: 'user', content: 'tab two' }] });
+    act(() => {
+      result.current.createSession();
+    });
+    // Tabs: [tab one, tab two]; active is a third (fresh) session.
+    expect(result.current.sessionTabs).toHaveLength(2);
+
+    act(() => {
+      result.current.switchSession(secondId);
+    });
+    act(() => {
+      result.current.closeSession(secondId);
+    });
+    await flush(); // queueMicrotask switch
+
+    // Closed the active tab — should have switched to the remaining one.
+    expect(result.current.sessionTabs.find((t) => t.id === secondId)).toBeUndefined();
+    expect(result.current.activeSessionId).not.toBe(secondId);
+  });
+
+  it('closing an inactive tab leaves the active session untouched', () => {
+    const { controller, setCurrent } = makeController();
+    const { result } = renderHook(() => useChatSessions<TestSnap>(controller));
+    const firstId = result.current.activeSessionId;
+
+    setCurrent({ messages: [{ role: 'user', content: 'background tab' }] });
+    act(() => {
+      result.current.createSession();
+    });
+    const activeId = result.current.activeSessionId;
+
+    act(() => {
+      result.current.closeSession(firstId);
+    });
+
+    expect(result.current.sessionTabs).toHaveLength(0);
+    expect(result.current.activeSessionId).toBe(activeId);
+  });
+
+  it('evicts the oldest cached session beyond the max', () => {
+    const { controller, setCurrent } = makeController();
+    const { result } = renderHook(() => useChatSessions<TestSnap>(controller));
+    const firstId = result.current.activeSessionId;
+
+    // Create 11 sessions with messages — the first should be evicted (max 10).
+    for (let i = 0; i < 11; i++) {
+      setCurrent({ messages: [{ role: 'user', content: `session ${i}` }] });
+      act(() => {
+        result.current.createSession();
+      });
+    }
+
+    expect(result.current.sessionTabs.length).toBe(10);
+    expect(result.current.sessionTabs.find((t) => t.id === firstId)).toBeUndefined();
+  });
+});

--- a/packages/ui/src/hooks/useChatSessions.ts
+++ b/packages/ui/src/hooks/useChatSessions.ts
@@ -1,0 +1,163 @@
+/**
+ * Multi-session (tab) concern of the chat store.
+ *
+ * Owns the snapshot map, active session id, and tab list; orchestrates
+ * create/switch/close. Extracted from useChatStore — the ChatProvider keeps
+ * owning the per-conversation state and hands this hook a small controller
+ * (capture/restore/clear/orphan/reject) so the tab lifecycle logic is
+ * separated from the streaming machinery.
+ *
+ * Generic over the snapshot type: this hook only needs `messages` (for tab
+ * titles); everything else in a snapshot is opaque to it, which also avoids
+ * a circular type dependency on useChatStore.
+ */
+
+import { useState, useRef, useCallback } from 'react';
+
+/** Tab entry for the session tab bar */
+export interface SessionTab {
+  id: string;
+  title: string;
+  createdAt: number;
+}
+
+const MAX_SESSIONS = 10;
+
+export interface ChatSessionController<TSnap> {
+  /** Capture the current per-conversation state. */
+  capture: () => TSnap;
+  /** Restore a previously captured snapshot. */
+  restore: (snap: TSnap) => void;
+  /** Clear all per-conversation state for a fresh session (also orphans streams). */
+  clear: () => void;
+  /**
+   * Orphan any running stream WITHOUT clearing state — the stream keeps
+   * draining in the background so the backend persists, but UI updates are
+   * suppressed (generation check in sendMessage).
+   */
+  orphanStream: () => void;
+  /** Set the backend conversation id (client-pre-generated UUID pattern). */
+  setSessionId: (id: string | null) => void;
+  /** Reject any pending execution approval so the backend doesn't hang. */
+  rejectPendingApproval: () => void;
+}
+
+export interface UseChatSessionsResult {
+  activeSessionId: string;
+  sessionTabs: SessionTab[];
+  createSession: () => string;
+  switchSession: (id: string) => void;
+  closeSession: (id: string) => void;
+}
+
+export function useChatSessions<
+  TSnap extends { messages: Array<{ role: string; content: string }> },
+>(controller: ChatSessionController<TSnap>): UseChatSessionsResult {
+  const { capture, restore, clear, orphanStream, setSessionId, rejectPendingApproval } = controller;
+
+  const sessionsRef = useRef(new Map<string, TSnap>());
+  const [activeSessionId, setActiveSessionId] = useState<string>(() => crypto.randomUUID());
+  const [sessionTabs, setSessionTabs] = useState<SessionTab[]>([]);
+  // Set when closeSession closes the ACTIVE tab: the queued switchSession must
+  // NOT re-save the departing (closed) session, or its tab reappears in the
+  // bar right after the user closed it.
+  const skipNextSaveRef = useRef(false);
+
+  /** Create a new session — saves current to map, clears UI */
+  const createSession = useCallback((): string => {
+    const currentId = activeSessionId;
+    const snap = capture();
+    // Only save if there are actual messages (sessionId is always set now via pre-generation)
+    if (snap.messages.length > 0) {
+      sessionsRef.current.set(currentId, snap);
+      const title =
+        snap.messages.find((m) => m.role === 'user')?.content.slice(0, 60) || 'New Chat';
+      setSessionTabs((prev) => {
+        if (prev.find((t) => t.id === currentId)) return prev;
+        return [...prev, { id: currentId, title, createdAt: Date.now() }];
+      });
+    }
+    // Reject pending approval before switching
+    rejectPendingApproval();
+    const newId = crypto.randomUUID();
+    setActiveSessionId(newId);
+    clear();
+    // Pre-set sessionId so the first message includes conversationId in the request.
+    // This follows the client-generated ID pattern (NextChat, LobeChat, big-AGI).
+    // The backend accepts unknown IDs and auto-creates the conversation (FIX-1).
+    setSessionId(newId);
+    // Enforce max sessions — evict oldest
+    if (sessionsRef.current.size > MAX_SESSIONS) {
+      const entries = [...sessionsRef.current.entries()];
+      const oldestKey = entries[0]?.[0];
+      if (oldestKey) {
+        sessionsRef.current.delete(oldestKey);
+        setSessionTabs((prev) => prev.filter((t) => t.id !== oldestKey));
+      }
+    }
+    return newId;
+  }, [activeSessionId, capture, clear, setSessionId, rejectPendingApproval]);
+
+  /** Switch to an existing session (from tab or sidebar) */
+  const switchSession = useCallback(
+    (targetId: string) => {
+      if (targetId === activeSessionId) return;
+      // Save current active session — unless it was just closed (closeSession
+      // sets the skip flag before queueing this switch).
+      const skipSave = skipNextSaveRef.current;
+      skipNextSaveRef.current = false;
+      if (!skipSave) {
+        const currentId = activeSessionId;
+        const snap = capture();
+        sessionsRef.current.set(currentId, snap);
+        setSessionTabs((prev) => {
+          if (prev.find((t) => t.id === currentId)) return prev;
+          const title =
+            snap.messages.find((m) => m.role === 'user')?.content.slice(0, 60) || 'New Chat';
+          return [...prev, { id: currentId, title, createdAt: Date.now() }];
+        });
+      }
+      // Orphan current stream
+      orphanStream();
+      // Restore target from map (if cached) or set sessionId for DB load
+      const target = sessionsRef.current.get(targetId);
+      if (target) {
+        restore(target);
+        sessionsRef.current.delete(targetId);
+      } else {
+        clear();
+        setSessionId(targetId);
+      }
+      setActiveSessionId(targetId);
+    },
+    [activeSessionId, capture, restore, clear, orphanStream, setSessionId]
+  );
+
+  /** Close a session tab */
+  const closeSession = useCallback(
+    (targetId: string) => {
+      sessionsRef.current.delete(targetId);
+      setSessionTabs((prev) => {
+        const remaining = prev.filter((t) => t.id !== targetId);
+        if (targetId === activeSessionId) {
+          if (remaining.length > 0) {
+            const nearest = remaining[remaining.length - 1]!;
+            // The departing session was closed — don't let the switch re-save
+            // it (that would put the closed tab right back in the bar).
+            skipNextSaveRef.current = true;
+            queueMicrotask(() => switchSession(nearest.id));
+          } else {
+            queueMicrotask(() => {
+              setActiveSessionId(crypto.randomUUID());
+              clear();
+            });
+          }
+        }
+        return remaining;
+      });
+    },
+    [activeSessionId, switchSession, clear]
+  );
+
+  return { activeSessionId, sessionTabs, createSession, switchSession, closeSession };
+}

--- a/packages/ui/src/hooks/useChatStore.tsx
+++ b/packages/ui/src/hooks/useChatStore.tsx
@@ -22,6 +22,18 @@ import { STORAGE_KEYS } from '../constants/storage-keys';
 import { dispatchSessionChanged } from '../utils/session-events';
 import { stripChatInternalTags } from '../utils/chat-content';
 import { ignoreError } from '../utils/ignore-error';
+import { useAutoCompact, type AutoCompactPromptState } from './useAutoCompact';
+import { useChatSessions, type SessionTab } from './useChatSessions';
+
+// Auto-compact threshold logic + constants live in useAutoCompact.ts;
+// re-exported here so existing importers (tests) keep working.
+export {
+  AUTO_COMPACT_THRESHOLD,
+  AUTO_COMPACT_CLEAR_BELOW,
+  AUTO_COMPACT_MIN_MESSAGES,
+  computeAutoCompactPrompt,
+  type AutoCompactPromptState,
+} from './useAutoCompact';
 
 // Progress event types from the stream
 export interface ProgressEvent {
@@ -88,12 +100,7 @@ interface ChatState {
    * prompt to one conversation so dismissing here doesn't bleed into other
    * sessions.
    */
-  autoCompactPrompt: {
-    sessionId: string;
-    fillPercent: number;
-    estimatedTokens: number;
-    maxContextTokens: number;
-  } | null;
+  autoCompactPrompt: AutoCompactPromptState | null;
   /** Compact-in-progress flag (manual or auto). */
   isCompacting: boolean;
 }
@@ -116,85 +123,10 @@ interface ChatSessionSnapshot {
   pendingApproval: ApprovalRequest | null;
 }
 
-/** Tab entry for the session tab bar */
-interface SessionTab {
-  id: string;
-  title: string;
-  createdAt: number;
-}
-
 interface FailedChatRequest {
   content: string;
   directTools?: string[];
   imageAttachments?: MessageAttachment[];
-}
-
-const MAX_SESSIONS = 10;
-
-/**
- * Auto-compact threshold. Crossing this fill percent raises a one-time
- * suggestion to compact older messages into a summary. Kept at module scope
- * so tests can import and reason about it directly.
- */
-export const AUTO_COMPACT_THRESHOLD = 85;
-
-/** Hysteresis below the threshold — clear the prompt once we drop this far. */
-export const AUTO_COMPACT_CLEAR_BELOW = AUTO_COMPACT_THRESHOLD - 5;
-
-/**
- * Minimum messages required before the banner appears. The server requires
- * `messages.length > keepRecentMessages + 2` (default keepRecent = 6, so >8)
- * to actually compact — without this guard the user could accept the banner
- * and silently get `compacted: false`.
- */
-export const AUTO_COMPACT_MIN_MESSAGES = 9;
-
-export interface AutoCompactPromptState {
-  sessionId: string;
-  fillPercent: number;
-  estimatedTokens: number;
-  maxContextTokens: number;
-}
-
-/**
- * Pure decision function: given the new sessionInfo, the previous prompt
- * state, and whether the user has declined for this session, return the
- * prompt that should be shown (or null).
- *
- * Extracted as a standalone export so the threshold + hysteresis logic can be
- * tested without rendering the full ChatProvider tree.
- */
-export function computeAutoCompactPrompt(input: {
-  next: SessionInfo;
-  prev: AutoCompactPromptState | null;
-  declined: boolean;
-  isCompacting: boolean;
-}): AutoCompactPromptState | null {
-  const { next, prev, declined, isCompacting } = input;
-  const fill = next.contextFillPercent ?? 0;
-  const overThreshold =
-    fill >= AUTO_COMPACT_THRESHOLD &&
-    next.messageCount >= AUTO_COMPACT_MIN_MESSAGES &&
-    !declined &&
-    !isCompacting;
-
-  if (overThreshold) {
-    // Reuse the existing prompt when the fill percent hasn't moved
-    // meaningfully — prevents spurious re-renders on every stream chunk.
-    if (prev && prev.sessionId === next.sessionId && Math.abs(prev.fillPercent - fill) < 1) {
-      return prev;
-    }
-    return {
-      sessionId: next.sessionId,
-      fillPercent: fill,
-      estimatedTokens: next.estimatedTokens,
-      maxContextTokens: next.maxContextTokens,
-    };
-  }
-  // Below the clear point — drop the prompt entirely. Between threshold and
-  // clear point (hysteresis band), keep whatever was there.
-  if (fill < AUTO_COMPACT_CLEAR_BELOW) return null;
-  return prev;
 }
 
 interface ChatStore extends ChatState {
@@ -308,8 +240,9 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const sessionIdRef = useRef<string | null>(null);
   // Initialize ref from restored state
   sessionIdRef.current = sessionId;
-  // Wrapper: keep ref + localStorage in sync with state
-  const setSessionId = (id: string | null) => {
+  // Wrapper: keep ref + localStorage in sync with state. Stable identity —
+  // it sits in useChatSessions' dependency arrays.
+  const setSessionId = useCallback((id: string | null) => {
     sessionIdRef.current = id;
     setSessionIdState(id);
     try {
@@ -318,22 +251,25 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     } catch {
       /* */
     }
-  };
+  }, []);
   const [sessionInfo, setSessionInfo] = useState<SessionInfo | null>(null);
-  const [isCompacting, setIsCompacting] = useState(false);
-  const [autoCompactPrompt, setAutoCompactPrompt] = useState<ChatState['autoCompactPrompt']>(null);
-  // Track which sessionIds the user has already declined an auto-compact for,
-  // so we don't re-prompt on every chunk after they say "not now".
-  const autoCompactSuppressedRef = useRef<Set<string>>(new Set());
-  // Persistent opt-out — survives page reloads. Read once at mount.
-  const [autoCompactDisabled, setAutoCompactDisabled] = useState<boolean>(() => {
-    try {
-      return localStorage.getItem(STORAGE_KEYS.AUTO_COMPACT_DISABLED) === '1';
-    } catch {
-      return false;
-    }
-  });
-  const [lastCompactionSummary, setLastCompactionSummary] = useState<string | null>(null);
+
+  // Auto-compact concern (threshold prompt, decline tracking, opt-out,
+  // compactSession) — extracted to useAutoCompact; sessionInfo writes flow
+  // through its applySessionInfo so every code path gets the same treatment.
+  const {
+    isCompacting,
+    autoCompactPrompt,
+    autoCompactDisabled,
+    lastCompactionSummary,
+    applySessionInfo,
+    dismissAutoCompactPrompt,
+    disableAutoCompactPrompt,
+    clearLastCompactionSummary,
+    resetAutoCompactPrompt,
+    compactSession,
+  } = useAutoCompact({ provider, model, setSessionInfo });
+
   const [isThinking, setIsThinking] = useState(false);
   const [thinkingContent, setThinkingContent] = useState('');
   const [thinkingConfig, setThinkingConfig] = useState<ChatState['thinkingConfig']>(null);
@@ -344,11 +280,6 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   // Stream generation counter — orphaned streams (from New Chat) keep reading
   // so the backend can finish + persist, but their UI updates are suppressed.
   const streamGenRef = useRef(0);
-
-  // --- Multi-session management ---
-  const sessionsRef = useRef(new Map<string, ChatSessionSnapshot>());
-  const [activeSessionId, setActiveSessionId] = useState<string>(() => crypto.randomUUID());
-  const [sessionTabs, setSessionTabs] = useState<SessionTab[]>([]);
 
   // Refs for capturing current state without stale closures
   const messagesRef = useRef(messages);
@@ -403,56 +334,6 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   }, [pendingApproval]);
 
   const clearSuggestions = useCallback(() => setSuggestions([]), []);
-
-  /**
-   * Apply a new sessionInfo and, if the fill % is past the threshold AND the
-   * user hasn't already declined for this session, raise an auto-compact
-   * prompt. Centralizes the behavior so every code path (stream done,
-   * non-stream done, refresh, compact result) gets the same treatment.
-   */
-  const applySessionInfo = useCallback(
-    (next: SessionInfo | null) => {
-      setSessionInfo(next);
-      if (!next) {
-        setAutoCompactPrompt(null);
-        return;
-      }
-      if (autoCompactDisabled) {
-        setAutoCompactPrompt(null);
-        return;
-      }
-      setAutoCompactPrompt((prev) =>
-        computeAutoCompactPrompt({
-          next,
-          prev,
-          declined: autoCompactSuppressedRef.current.has(next.sessionId),
-          isCompacting,
-        })
-      );
-    },
-    [isCompacting, autoCompactDisabled]
-  );
-
-  const dismissAutoCompactPrompt = useCallback(() => {
-    setAutoCompactPrompt((prev) => {
-      if (prev) autoCompactSuppressedRef.current.add(prev.sessionId);
-      return null;
-    });
-  }, []);
-
-  const disableAutoCompactPrompt = useCallback(() => {
-    try {
-      localStorage.setItem(STORAGE_KEYS.AUTO_COMPACT_DISABLED, '1');
-    } catch {
-      /* localStorage might be blocked — in-memory toggle still applies */
-    }
-    setAutoCompactDisabled(true);
-    setAutoCompactPrompt(null);
-  }, []);
-
-  const clearLastCompactionSummary = useCallback(() => {
-    setLastCompactionSummary(null);
-  }, []);
 
   // Ref for auto-accept logic — keeps fresh reference without re-renders
   const extractedMemoriesRef = useRef(extractedMemories);
@@ -978,7 +859,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       setPendingApproval(null);
       setSessionId(id);
       setSessionInfo(null);
-      setAutoCompactPrompt(null);
+      resetAutoCompactPrompt();
       // Fetch fresh context breakdown so the chip shows real fill, not an
       // empty bar, when the user opens an existing chat from the sidebar.
       ignoreError(
@@ -998,7 +879,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         'chatApi.getContextDetail:loadConversation'
       );
     },
-    [pendingApproval, provider, model, applySessionInfo]
+    [pendingApproval, provider, model, applySessionInfo, resetAutoCompactPrompt]
   );
 
   const refreshSessionInfo = useCallback(async () => {
@@ -1020,45 +901,6 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       /* ignore — bar will reconcile on next message */
     }
   }, [provider, model, applySessionInfo]);
-
-  const compactSession = useCallback(
-    async (keepRecentMessages?: number) => {
-      if (!provider || !model) {
-        return { compacted: false, removedMessages: 0, savedTokens: 0 };
-      }
-      setIsCompacting(true);
-      setAutoCompactPrompt(null);
-      try {
-        const d = await chatApi.compactContext(provider, model, keepRecentMessages);
-        if (d?.session) {
-          // Server returns post-compact SessionInfo — apply it directly so
-          // the bar reflects the new state without waiting for the next msg.
-          applySessionInfo(d.session);
-        }
-        if (d?.compacted && d.summary) {
-          setLastCompactionSummary(d.summary);
-        }
-        const saved = Math.max(0, (d?.previousTokenEstimate ?? 0) - (d?.newTokenEstimate ?? 0));
-        return {
-          compacted: !!d?.compacted,
-          removedMessages: d?.removedMessages ?? 0,
-          savedTokens: saved,
-          ...(d?.reason && { reason: d.reason }),
-          ...(d?.summary && { summary: d.summary }),
-        };
-      } catch {
-        return {
-          compacted: false,
-          removedMessages: 0,
-          savedTokens: 0,
-          reason: 'exception',
-        };
-      } finally {
-        setIsCompacting(false);
-      }
-    },
-    [provider, model, applySessionInfo]
-  );
 
   // --- Multi-session methods ---
 
@@ -1099,10 +941,15 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     setPendingApproval(snap.pendingApproval);
   }, []);
 
-  /** Helper: clear all per-conversation state for a fresh session */
-  const clearAllState = useCallback(() => {
+  /** Orphan any running stream without clearing state (see useChatSessions). */
+  const orphanStream = useCallback(() => {
     streamGenRef.current++;
     abortControllerRef.current = null;
+  }, []);
+
+  /** Helper: clear all per-conversation state for a fresh session */
+  const clearAllState = useCallback(() => {
+    orphanStream();
     setMessages([]);
     setIsLoading(false);
     setError(null);
@@ -1117,104 +964,31 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     setPendingApproval(null);
     setSessionId(null);
     setSessionInfo(null);
-  }, []);
+  }, [orphanStream]);
 
-  /** Create a new session — saves current to map, clears UI */
-  const createSession = useCallback((): string => {
-    const currentId = activeSessionId;
-    const snap = captureSnapshot();
-    // Only save if there are actual messages (sessionId is always set now via pre-generation)
-    if (snap.messages.length > 0) {
-      sessionsRef.current.set(currentId, snap);
-      const title =
-        snap.messages.find((m) => m.role === 'user')?.content.slice(0, 60) || 'New Chat';
-      setSessionTabs((prev) => {
-        if (prev.find((t) => t.id === currentId)) return prev;
-        return [...prev, { id: currentId, title, createdAt: Date.now() }];
-      });
-    }
-    // Reject pending approval before switching
-    if (stateRefsForCapture.current.pendingApproval) {
+  /** Reject any pending execution approval so the backend doesn't hang. */
+  const rejectPendingApproval = useCallback(() => {
+    const approval = stateRefsForCapture.current.pendingApproval;
+    if (approval) {
       ignoreError(
-        executionPermissionsApi.resolveApproval(
-          stateRefsForCapture.current.pendingApproval.approvalId,
-          false
-        ),
+        executionPermissionsApi.resolveApproval(approval.approvalId, false),
         'resolveApproval:cleanup'
       );
     }
-    const newId = crypto.randomUUID();
-    setActiveSessionId(newId);
-    clearAllState();
-    // Pre-set sessionId so the first message includes conversationId in the request.
-    // This follows the client-generated ID pattern (NextChat, LobeChat, big-AGI).
-    // The backend accepts unknown IDs and auto-creates the conversation (FIX-1).
-    setSessionId(newId);
-    // Enforce max sessions — evict oldest
-    if (sessionsRef.current.size > MAX_SESSIONS) {
-      const entries = [...sessionsRef.current.entries()];
-      const oldestKey = entries[0]?.[0];
-      if (oldestKey) {
-        sessionsRef.current.delete(oldestKey);
-        setSessionTabs((prev) => prev.filter((t) => t.id !== oldestKey));
-      }
-    }
-    return newId;
-  }, [activeSessionId, captureSnapshot, clearAllState]);
+  }, []);
 
-  /** Switch to an existing session (from tab or sidebar) */
-  const switchSession = useCallback(
-    (targetId: string) => {
-      if (targetId === activeSessionId) return;
-      // Save current active session
-      const currentId = activeSessionId;
-      const snap = captureSnapshot();
-      sessionsRef.current.set(currentId, snap);
-      setSessionTabs((prev) => {
-        if (prev.find((t) => t.id === currentId)) return prev;
-        const title =
-          snap.messages.find((m) => m.role === 'user')?.content.slice(0, 60) || 'New Chat';
-        return [...prev, { id: currentId, title, createdAt: Date.now() }];
-      });
-      // Orphan current stream
-      streamGenRef.current++;
-      abortControllerRef.current = null;
-      // Restore target from map (if cached) or set sessionId for DB load
-      const target = sessionsRef.current.get(targetId);
-      if (target) {
-        restoreSnapshot(target);
-        sessionsRef.current.delete(targetId);
-      } else {
-        clearAllState();
-        setSessionId(targetId);
-      }
-      setActiveSessionId(targetId);
-    },
-    [activeSessionId, captureSnapshot, restoreSnapshot, clearAllState]
-  );
-
-  /** Close a session tab */
-  const closeSession = useCallback(
-    (targetId: string) => {
-      sessionsRef.current.delete(targetId);
-      setSessionTabs((prev) => {
-        const remaining = prev.filter((t) => t.id !== targetId);
-        if (targetId === activeSessionId) {
-          if (remaining.length > 0) {
-            const nearest = remaining[remaining.length - 1]!;
-            queueMicrotask(() => switchSession(nearest.id));
-          } else {
-            queueMicrotask(() => {
-              setActiveSessionId(crypto.randomUUID());
-              clearAllState();
-            });
-          }
-        }
-        return remaining;
-      });
-    },
-    [activeSessionId, switchSession, clearAllState]
-  );
+  // Multi-session (tab) lifecycle — snapshot map + tabs live in
+  // useChatSessions; this provider supplies the per-conversation state
+  // operations it orchestrates.
+  const { activeSessionId, sessionTabs, createSession, switchSession, closeSession } =
+    useChatSessions<ChatSessionSnapshot>({
+      capture: captureSnapshot,
+      restore: restoreSnapshot,
+      clear: clearAllState,
+      orphanStream,
+      setSessionId,
+      rejectPendingApproval,
+    });
 
   const value: ChatStore = {
     messages,


### PR DESCRIPTION
## Summary
The 1,278-line chat store mixed streaming, auto-compact, and multi-session concerns. The two separable ones are now dedicated hooks (`useChatStore` drops to 1,052 lines), with the **public ChatStore API unchanged** — ChatPage and every other consumer is untouched.

- **`useAutoCompact`** — threshold/hysteresis prompt, per-session decline set, persistent opt-out, `compactSession`. The provider injects its `sessionInfo` setter so `applySessionInfo` keeps centralizing all code paths (stream done, non-stream, refresh, compact result). `computeAutoCompactPrompt` + constants moved along and are re-exported from `useChatStore` so the existing tests/imports keep working.
- **`useChatSessions`** — snapshot map, tab list, create/switch/close orchestration. Generic over the snapshot type (avoids circular imports); receives a small controller (`capture/restore/clear/orphanStream/setSessionId/rejectPendingApproval`) from the provider. **First direct tests for the tab lifecycle (8)** — previously only reachable through the full ChatProvider.
- `setSessionId` stabilized with `useCallback` (it now sits in dependency arrays).

## Behavior fix (found by the new tests)
Closing the **active** session tab queued a `switchSession` that re-saved the departing session — the just-closed tab reappeared in the tab bar. The queued switch now skips re-saving the closed session (`skipNextSaveRef`). This is the only intentional behavior change.

## Test plan
- [x] 8 new useChatSessions tests (create/switch/close, no-op switch, snapshot restore, eviction at max, active-tab close)
- [x] Full UI suite 378/378 (incl. existing useChatStore tests via re-exports), typecheck, ESLint, production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)