### PR TITLE
refactor(ui): add Modal primitive; compose MultiStepModal + migrate 2 dialogs

### DIFF
--- a/packages/ui/src/components/Modal.tsx
+++ b/packages/ui/src/components/Modal.tsx
@@ -1,0 +1,87 @@
+/**
+ * Modal — shared shell for centered dialogs.
+ *
+ * Owns the backdrop (with backdrop-click + Escape close via useModalClose),
+ * the panel, the bordered header, the scrollable body, and an optional
+ * footer. MultiStepModal composes this with step tabs + nav buttons; plain
+ * dialogs use it directly instead of copying the wrapper markup.
+ *
+ * Deliberately minimal: exotic dialogs (full-height viewers, forms that wrap
+ * body+footer in a <form>, animated popovers) should keep their own markup
+ * rather than grow this primitive.
+ */
+
+import type { ReactNode } from 'react';
+import { useModalClose } from '../hooks';
+
+const SIZE_CLASSES = {
+  sm: 'max-w-sm',
+  md: 'max-w-md',
+  lg: 'max-w-lg',
+  xl: 'max-w-xl',
+  '2xl': 'max-w-2xl',
+} as const;
+
+export interface ModalProps {
+  onClose: () => void;
+  /** Header title (h3). Omit together with headerContent for a headerless body. */
+  title?: ReactNode;
+  /** Extra header content below the title (e.g. filter chips, step tabs). */
+  headerContent?: ReactNode;
+  /** Panel width preset. Defaults to '2xl'. */
+  size?: keyof typeof SIZE_CLASSES;
+  /** Footer content. Rendered right-aligned by default (footerClassName overrides). */
+  footer?: ReactNode;
+  footerClassName?: string;
+  /** Override the body wrapper classes (default: scrollable with p-6). */
+  bodyClassName?: string;
+  children: ReactNode;
+}
+
+export function Modal({
+  onClose,
+  title,
+  headerContent,
+  size = '2xl',
+  footer,
+  footerClassName,
+  bodyClassName,
+  children,
+}: ModalProps) {
+  const { onBackdropClick } = useModalClose(onClose);
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onClick={onBackdropClick}
+    >
+      <div
+        className={`w-full ${SIZE_CLASSES[size]} bg-bg-primary dark:bg-dark-bg-primary border border-border dark:border-dark-border rounded-xl shadow-xl max-h-[90vh] overflow-hidden flex flex-col`}
+      >
+        {(title || headerContent) && (
+          <div className="p-4 border-b border-border dark:border-dark-border">
+            {title && (
+              <h3 className="text-lg font-semibold text-text-primary dark:text-dark-text-primary">
+                {title}
+              </h3>
+            )}
+            {headerContent}
+          </div>
+        )}
+
+        <div className={bodyClassName ?? 'flex-1 overflow-y-auto p-6'}>{children}</div>
+
+        {footer && (
+          <div
+            className={
+              footerClassName ??
+              'p-4 border-t border-border dark:border-dark-border flex justify-end gap-2'
+            }
+          >
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/MultiStepModal.tsx
+++ b/packages/ui/src/components/MultiStepModal.tsx
@@ -13,7 +13,7 @@
 
 import type { ReactNode } from 'react';
 import { LoadingSpinner } from './LoadingSpinner';
-import { useModalClose } from '../hooks';
+import { Modal } from './Modal';
 
 export interface MultiStepModalProps<S extends string> {
   title: string;
@@ -55,46 +55,33 @@ export function MultiStepModal<S extends string>({
   onSubmit,
   children,
 }: MultiStepModalProps<S>) {
-  const { onBackdropClick } = useModalClose(onClose);
   const stepIndex = steps.indexOf(step);
   const isLastStep = stepIndex === steps.length - 1;
 
   return (
-    <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
-      onClick={onBackdropClick}
-    >
-      <div className="w-full max-w-2xl bg-bg-primary dark:bg-dark-bg-primary border border-border dark:border-dark-border rounded-xl shadow-xl max-h-[90vh] overflow-hidden flex flex-col">
-        {/* Header */}
-        <div className="p-4 border-b border-border dark:border-dark-border">
-          <h3 className="text-lg font-semibold text-text-primary dark:text-dark-text-primary">
-            {title}
-          </h3>
-          <div className="flex gap-4 mt-3">
-            {steps.map((s, i) => (
-              <button
-                key={s}
-                onClick={() => onStepChange(s)}
-                className={`text-sm font-medium ${
-                  step === s
-                    ? 'text-primary border-b-2 border-primary pb-1'
-                    : 'text-text-muted dark:text-dark-text-muted'
-                }`}
-              >
-                {i + 1}. {s.charAt(0).toUpperCase() + s.slice(1)}
-              </button>
-            ))}
-          </div>
+    <Modal
+      onClose={onClose}
+      title={title}
+      headerContent={
+        <div className="flex gap-4 mt-3">
+          {steps.map((s, i) => (
+            <button
+              key={s}
+              onClick={() => onStepChange(s)}
+              className={`text-sm font-medium ${
+                step === s
+                  ? 'text-primary border-b-2 border-primary pb-1'
+                  : 'text-text-muted dark:text-dark-text-muted'
+              }`}
+            >
+              {i + 1}. {s.charAt(0).toUpperCase() + s.slice(1)}
+            </button>
+          ))}
         </div>
-
-        {/* Content */}
-        <div className="flex-1 overflow-y-auto p-6">
-          {isLoading ? <LoadingSpinner size="sm" message="Loading..." /> : children}
-          {error && <p className="text-sm text-error mt-4">{error}</p>}
-        </div>
-
-        {/* Footer */}
-        <div className="p-4 border-t border-border dark:border-dark-border flex justify-between">
+      }
+      footerClassName="p-4 border-t border-border dark:border-dark-border flex justify-between"
+      footer={
+        <>
           <button
             onClick={onClose}
             className="px-4 py-2 text-text-secondary dark:text-dark-text-secondary hover:bg-bg-tertiary dark:hover:bg-dark-bg-tertiary rounded-lg transition-colors"
@@ -128,8 +115,11 @@ export function MultiStepModal<S extends string>({
               </button>
             )}
           </div>
-        </div>
-      </div>
-    </div>
+        </>
+      }
+    >
+      {isLoading ? <LoadingSpinner size="sm" message="Loading..." /> : children}
+      {error && <p className="text-sm text-error mt-4">{error}</p>}
+    </Modal>
   );
 }

--- a/packages/ui/src/components/PlanHistoryModal.tsx
+++ b/packages/ui/src/components/PlanHistoryModal.tsx
@@ -1,5 +1,5 @@
 import type { PlanEventType, PlanHistoryEntry } from '../api';
-import { useModalClose } from '../hooks';
+import { Modal } from './Modal';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -43,60 +43,48 @@ interface PlanHistoryModalProps {
 }
 
 export function PlanHistoryModal({ history, onClose }: PlanHistoryModalProps) {
-  const { onBackdropClick } = useModalClose(onClose);
-
   return (
-    <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
-      onClick={onBackdropClick}
+    <Modal
+      onClose={onClose}
+      title="Plan History"
+      size="lg"
+      footer={
+        <button
+          onClick={onClose}
+          className="px-4 py-2 bg-primary hover:bg-primary-dark text-white rounded-lg transition-colors"
+        >
+          Close
+        </button>
+      }
     >
-      <div className="w-full max-w-lg bg-bg-primary dark:bg-dark-bg-primary border border-border dark:border-dark-border rounded-xl shadow-xl max-h-[90vh] overflow-hidden flex flex-col">
-        <div className="p-6 border-b border-border dark:border-dark-border">
-          <h3 className="text-lg font-semibold text-text-primary dark:text-dark-text-primary">
-            Plan History
-          </h3>
-        </div>
-
-        <div className="flex-1 overflow-y-auto p-6">
-          {history.length === 0 ? (
-            <p className="text-text-muted dark:text-dark-text-muted text-center">No history yet</p>
-          ) : (
-            <div className="space-y-2">
-              {history.map((entry) => (
-                <div
-                  key={entry.id}
-                  className="flex items-start gap-3 p-2 bg-bg-secondary dark:bg-dark-bg-secondary border border-border dark:border-dark-border rounded-lg"
-                >
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className={`text-sm font-medium ${eventTypeColors[entry.eventType]}`}>
-                        {eventTypeLabels[entry.eventType]}
-                      </span>
-                      <span className="text-xs text-text-muted dark:text-dark-text-muted">
-                        {new Date(entry.createdAt).toLocaleString()}
-                      </span>
-                    </div>
-                    {entry.details && Object.keys(entry.details).length > 0 && (
-                      <pre className="mt-1 text-xs text-text-muted dark:text-dark-text-muted overflow-x-auto">
-                        {JSON.stringify(entry.details, null, 2)}
-                      </pre>
-                    )}
-                  </div>
+      {history.length === 0 ? (
+        <p className="text-text-muted dark:text-dark-text-muted text-center">No history yet</p>
+      ) : (
+        <div className="space-y-2">
+          {history.map((entry) => (
+            <div
+              key={entry.id}
+              className="flex items-start gap-3 p-2 bg-bg-secondary dark:bg-dark-bg-secondary border border-border dark:border-dark-border rounded-lg"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className={`text-sm font-medium ${eventTypeColors[entry.eventType]}`}>
+                    {eventTypeLabels[entry.eventType]}
+                  </span>
+                  <span className="text-xs text-text-muted dark:text-dark-text-muted">
+                    {new Date(entry.createdAt).toLocaleString()}
+                  </span>
                 </div>
-              ))}
+                {entry.details && Object.keys(entry.details).length > 0 && (
+                  <pre className="mt-1 text-xs text-text-muted dark:text-dark-text-muted overflow-x-auto">
+                    {JSON.stringify(entry.details, null, 2)}
+                  </pre>
+                )}
+              </div>
             </div>
-          )}
+          ))}
         </div>
-
-        <div className="p-4 border-t border-border dark:border-dark-border flex justify-end">
-          <button
-            onClick={onClose}
-            className="px-4 py-2 bg-primary hover:bg-primary-dark text-white rounded-lg transition-colors"
-          >
-            Close
-          </button>
-        </div>
-      </div>
-    </div>
+      )}
+    </Modal>
   );
 }

--- a/packages/ui/src/components/TriggerHistoryModal.tsx
+++ b/packages/ui/src/components/TriggerHistoryModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import type { TriggerHistoryEntry, TriggerHistoryStatus, TriggerHistoryParams } from '../api';
 import { triggersApi } from '../api';
-import { useModalClose } from '../hooks';
+import { Modal } from './Modal';
 import { ChevronDown, ChevronRight, ChevronLeft } from './icons';
 import { LoadingSpinner } from './LoadingSpinner';
 
@@ -20,7 +20,6 @@ export function TriggerHistoryModal({
   history: initialHistory,
   onClose,
 }: TriggerHistoryModalProps) {
-  const { onBackdropClick } = useModalClose(onClose);
   const [history, setHistory] = useState<TriggerHistoryEntry[]>(initialHistory);
   const [total, setTotal] = useState(initialHistory.length);
   const [page, setPage] = useState(0);
@@ -58,142 +57,47 @@ export function TriggerHistoryModal({
   }, [fetchHistory, initialized]);
 
   return (
-    <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
-      onClick={onBackdropClick}
-    >
-      <div className="w-full max-w-2xl bg-bg-primary dark:bg-dark-bg-primary border border-border dark:border-dark-border rounded-xl shadow-xl max-h-[90vh] overflow-hidden flex flex-col">
-        <div className="p-6 border-b border-border dark:border-dark-border">
-          <h3 className="text-lg font-semibold text-text-primary dark:text-dark-text-primary">
-            History: {triggerName}
-          </h3>
-
-          {/* Status filter chips */}
-          <div className="flex items-center gap-2 mt-3">
-            {(['success', 'failure', 'skipped'] as const).map((s) => (
-              <button
-                key={s}
-                onClick={() => {
-                  setStatusFilter(statusFilter === s ? undefined : s);
-                  setPage(0);
-                }}
-                className={`px-2.5 py-1 text-xs rounded-full transition-colors ${
-                  statusFilter === s
-                    ? s === 'success'
-                      ? 'bg-success text-white'
-                      : s === 'failure'
-                        ? 'bg-error text-white'
-                        : 'bg-text-muted text-white'
-                    : 'bg-bg-tertiary dark:bg-dark-bg-tertiary text-text-secondary dark:text-dark-text-secondary hover:bg-bg-secondary dark:hover:bg-dark-bg-secondary'
-                }`}
-              >
-                {s.charAt(0).toUpperCase() + s.slice(1)}
-              </button>
-            ))}
-            {statusFilter && (
-              <button
-                onClick={() => {
-                  setStatusFilter(undefined);
-                  setPage(0);
-                }}
-                className="text-xs text-text-muted dark:text-dark-text-muted hover:text-error transition-colors"
-              >
-                Clear
-              </button>
-            )}
-          </div>
-        </div>
-
-        <div className="flex-1 overflow-y-auto p-6">
-          {isLoading && history.length === 0 ? (
-            <LoadingSpinner message="Loading history..." />
-          ) : history.length === 0 ? (
-            <p className="text-text-muted dark:text-dark-text-muted text-center">
-              {statusFilter ? 'No entries match this filter.' : 'No history yet'}
-            </p>
-          ) : (
-            <div className="space-y-2">
-              {history.map((entry) => {
-                const isExpanded = expandedId === entry.id;
-                return (
-                  <div
-                    key={entry.id}
-                    className="bg-bg-secondary dark:bg-dark-bg-secondary border border-border dark:border-dark-border rounded-lg"
-                  >
-                    <div
-                      className="flex items-center justify-between p-3 cursor-pointer hover:bg-bg-tertiary/50 dark:hover:bg-dark-bg-tertiary/50 transition-colors"
-                      onClick={() => setExpandedId(isExpanded ? null : entry.id)}
-                    >
-                      <div className="flex items-center gap-3">
-                        <span className="text-text-muted dark:text-dark-text-muted">
-                          {isExpanded ? (
-                            <ChevronDown className="w-4 h-4" />
-                          ) : (
-                            <ChevronRight className="w-4 h-4" />
-                          )}
-                        </span>
-                        <span className="text-sm text-text-primary dark:text-dark-text-primary">
-                          {new Date(entry.firedAt).toLocaleString()}
-                        </span>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        {entry.durationMs != null && (
-                          <span className="text-xs text-text-muted dark:text-dark-text-muted">
-                            {entry.durationMs}ms
-                          </span>
-                        )}
-                        <span
-                          className={`px-2 py-0.5 text-xs rounded-full ${
-                            entry.status === 'success'
-                              ? 'bg-success/10 text-success'
-                              : entry.status === 'failure'
-                                ? 'bg-error/10 text-error'
-                                : 'bg-text-muted/10 text-text-muted'
-                          }`}
-                        >
-                          {entry.status}
-                        </span>
-                      </div>
-                    </div>
-
-                    {isExpanded && (
-                      <div className="px-3 pb-3 border-t border-border dark:border-dark-border">
-                        {entry.error && (
-                          <div className="mt-2">
-                            <p className="text-xs font-medium text-error mb-1">Error</p>
-                            <pre className="text-xs text-error/80 bg-error/5 p-2 rounded overflow-x-auto whitespace-pre-wrap">
-                              {entry.error}
-                            </pre>
-                          </div>
-                        )}
-                        {entry.result != null && (
-                          <div className="mt-2">
-                            <p className="text-xs font-medium text-text-muted dark:text-dark-text-muted mb-1">
-                              Result
-                            </p>
-                            <pre className="text-xs text-text-secondary dark:text-dark-text-secondary bg-bg-tertiary dark:bg-dark-bg-tertiary p-2 rounded overflow-x-auto whitespace-pre-wrap max-h-48 overflow-y-auto">
-                              {typeof entry.result === 'string'
-                                ? entry.result
-                                : JSON.stringify(entry.result, null, 2)}
-                            </pre>
-                          </div>
-                        )}
-                        {!entry.error && entry.result == null && (
-                          <p className="mt-2 text-xs text-text-muted dark:text-dark-text-muted italic">
-                            No additional details.
-                          </p>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
+    <Modal
+      onClose={onClose}
+      title={`History: ${triggerName}`}
+      headerContent={
+        <div className="flex items-center gap-2 mt-3">
+          {(['success', 'failure', 'skipped'] as const).map((s) => (
+            <button
+              key={s}
+              onClick={() => {
+                setStatusFilter(statusFilter === s ? undefined : s);
+                setPage(0);
+              }}
+              className={`px-2.5 py-1 text-xs rounded-full transition-colors ${
+                statusFilter === s
+                  ? s === 'success'
+                    ? 'bg-success text-white'
+                    : s === 'failure'
+                      ? 'bg-error text-white'
+                      : 'bg-text-muted text-white'
+                  : 'bg-bg-tertiary dark:bg-dark-bg-tertiary text-text-secondary dark:text-dark-text-secondary hover:bg-bg-secondary dark:hover:bg-dark-bg-secondary'
+              }`}
+            >
+              {s.charAt(0).toUpperCase() + s.slice(1)}
+            </button>
+          ))}
+          {statusFilter && (
+            <button
+              onClick={() => {
+                setStatusFilter(undefined);
+                setPage(0);
+              }}
+              className="text-xs text-text-muted dark:text-dark-text-muted hover:text-error transition-colors"
+            >
+              Clear
+            </button>
           )}
         </div>
-
-        {/* Footer with pagination */}
-        <div className="p-4 border-t border-border dark:border-dark-border flex items-center justify-between">
+      }
+      footerClassName="p-4 border-t border-border dark:border-dark-border flex items-center justify-between"
+      footer={
+        <>
           <span className="text-xs text-text-muted dark:text-dark-text-muted">
             {total > 0 ? `${showFrom}–${showTo} of ${total}` : '0 entries'}
           </span>
@@ -226,8 +130,96 @@ export function TriggerHistoryModal({
               Close
             </button>
           </div>
-        </div>
-      </div>
-    </div>
+        </>
+      }
+    >
+      <>
+        {isLoading && history.length === 0 ? (
+          <LoadingSpinner message="Loading history..." />
+        ) : history.length === 0 ? (
+          <p className="text-text-muted dark:text-dark-text-muted text-center">
+            {statusFilter ? 'No entries match this filter.' : 'No history yet'}
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {history.map((entry) => {
+              const isExpanded = expandedId === entry.id;
+              return (
+                <div
+                  key={entry.id}
+                  className="bg-bg-secondary dark:bg-dark-bg-secondary border border-border dark:border-dark-border rounded-lg"
+                >
+                  <div
+                    className="flex items-center justify-between p-3 cursor-pointer hover:bg-bg-tertiary/50 dark:hover:bg-dark-bg-tertiary/50 transition-colors"
+                    onClick={() => setExpandedId(isExpanded ? null : entry.id)}
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="text-text-muted dark:text-dark-text-muted">
+                        {isExpanded ? (
+                          <ChevronDown className="w-4 h-4" />
+                        ) : (
+                          <ChevronRight className="w-4 h-4" />
+                        )}
+                      </span>
+                      <span className="text-sm text-text-primary dark:text-dark-text-primary">
+                        {new Date(entry.firedAt).toLocaleString()}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {entry.durationMs != null && (
+                        <span className="text-xs text-text-muted dark:text-dark-text-muted">
+                          {entry.durationMs}ms
+                        </span>
+                      )}
+                      <span
+                        className={`px-2 py-0.5 text-xs rounded-full ${
+                          entry.status === 'success'
+                            ? 'bg-success/10 text-success'
+                            : entry.status === 'failure'
+                              ? 'bg-error/10 text-error'
+                              : 'bg-text-muted/10 text-text-muted'
+                        }`}
+                      >
+                        {entry.status}
+                      </span>
+                    </div>
+                  </div>
+
+                  {isExpanded && (
+                    <div className="px-3 pb-3 border-t border-border dark:border-dark-border">
+                      {entry.error && (
+                        <div className="mt-2">
+                          <p className="text-xs font-medium text-error mb-1">Error</p>
+                          <pre className="text-xs text-error/80 bg-error/5 p-2 rounded overflow-x-auto whitespace-pre-wrap">
+                            {entry.error}
+                          </pre>
+                        </div>
+                      )}
+                      {entry.result != null && (
+                        <div className="mt-2">
+                          <p className="text-xs font-medium text-text-muted dark:text-dark-text-muted mb-1">
+                            Result
+                          </p>
+                          <pre className="text-xs text-text-secondary dark:text-dark-text-secondary bg-bg-tertiary dark:bg-dark-bg-tertiary p-2 rounded overflow-x-auto whitespace-pre-wrap max-h-48 overflow-y-auto">
+                            {typeof entry.result === 'string'
+                              ? entry.result
+                              : JSON.stringify(entry.result, null, 2)}
+                          </pre>
+                        </div>
+                      )}
+                      {!entry.error && entry.result == null && (
+                        <p className="mt-2 text-xs text-text-muted dark:text-dark-text-muted italic">
+                          No additional details.
+                        </p>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </>
+    </Modal>
   );
 }


### PR DESCRIPTION
## Summary
Adds the plain `Modal` primitive (backdrop + panel + bordered header + scrollable body + footer; size presets, `headerContent`, overridable footer layout) and recomposes `MultiStepModal` on top of it — the step shell markup is deleted from MultiStepModal.

**Scope correction vs the original report**: the "16 modals share 70%" finding overstated MultiStepModal applicability — TriggerModal's "steps" are cron fields, ConfigureServiceModal has no steps, ChannelSetupModal is an async wizard. What the dialogs actually share is the plain shell, hence this primitive. PlanHistoryModal and TriggerHistoryModal migrate as exemplars (the latter exercises `headerContent` chips + a `justify-between` pagination footer).

Deliberately NOT migrated (the primitive stays minimal): form-wrapped dialogs (RegisterDeviceModal), animated popovers (QuickAddModal), full-height viewers (ArtifactDetailModal).

## Behavior notes
- Migrated dialog headers standardize to `p-4` padding (was `p-6`) — matches the agent modals.

## Test plan
- [x] UI suite 378/378, typecheck, ESLint, production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)