### PR TITLE
feat(security): encrypt Config Center secrets at rest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,16 @@ POSTGRES_DB=ownpilot
 # Required in production for OAuth token encryption (32 bytes hex)
 # ENCRYPTION_KEY=
 
+# Data-at-rest encryption key for stored service configs (Config Center
+# API keys etc.). Any string works — the AES key is derived via SHA-256.
+# If unset, a key is auto-generated at <data>/credentials/data-encryption.key
+# on first run. Losing the key (or changing this value) makes existing
+# encrypted configs unreadable — they must be re-entered.
+# OWNPILOT_ENCRYPTION_KEY=
+
+# Escape hatch: write service configs as plaintext (reads still decrypt)
+# OWNPILOT_DISABLE_DATA_ENCRYPTION=0
+
 # Admin API key for debug endpoints (production only)
 # ADMIN_API_KEY=
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -1012,18 +1012,25 @@ Service definitions with typed configuration schemas.
 
 Actual configuration values for each service.
 
-| Column         | Type      | Constraints                | Description          |
-| -------------- | --------- | -------------------------- | -------------------- |
-| `id`           | TEXT      | PRIMARY KEY                | Entry UUID           |
-| `service_name` | TEXT      | NOT NULL                   | Parent service name  |
-| `label`        | TEXT      | NOT NULL DEFAULT 'Default' | Entry label          |
-| `data`         | JSONB     | NOT NULL DEFAULT '{}'      | Configuration values |
-| `is_default`   | BOOLEAN   | NOT NULL DEFAULT FALSE     | Default entry flag   |
-| `is_active`    | BOOLEAN   | NOT NULL DEFAULT TRUE      | Active flag          |
-| `created_at`   | TIMESTAMP | NOT NULL DEFAULT NOW()     | Creation time        |
-| `updated_at`   | TIMESTAMP | NOT NULL DEFAULT NOW()     | Last update          |
+| Column         | Type      | Constraints                | Description                      |
+| -------------- | --------- | -------------------------- | -------------------------------- |
+| `id`           | TEXT      | PRIMARY KEY                | Entry UUID                       |
+| `service_name` | TEXT      | NOT NULL                   | Parent service name              |
+| `label`        | TEXT      | NOT NULL DEFAULT 'Default' | Entry label                      |
+| `data`         | JSONB     | NOT NULL DEFAULT '{}'      | Configuration values (encrypted) |
+| `is_default`   | BOOLEAN   | NOT NULL DEFAULT FALSE     | Default entry flag               |
+| `is_active`    | BOOLEAN   | NOT NULL DEFAULT TRUE      | Active flag                      |
+| `created_at`   | TIMESTAMP | NOT NULL DEFAULT NOW()     | Creation time                    |
+| `updated_at`   | TIMESTAMP | NOT NULL DEFAULT NOW()     | Last update                      |
 
 Has a partial unique index: only one entry per `service_name` where `is_default = TRUE`.
+
+**Encryption at rest**: `data` is stored as an AES-256-GCM envelope
+(`{"__enc":"v1","iv":...,"tag":...,"ct":...}`) because it holds secrets such as
+provider API keys. The key comes from `OWNPILOT_ENCRYPTION_KEY` (SHA-256-derived)
+or an auto-generated key file at `<data>/credentials/data-encryption.key`.
+Legacy plaintext rows are re-encrypted automatically at gateway startup.
+See `packages/gateway/src/db/data-encryption.ts`.
 
 ---
 

--- a/packages/gateway/src/db/data-encryption.test.ts
+++ b/packages/gateway/src/db/data-encryption.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Data-at-Rest Encryption Tests
+ *
+ * Covers envelope round-trips, key resolution (env var vs auto-generated
+ * key file), tamper detection, the disable flag, and legacy plaintext
+ * pass-through.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Mocks — key file lives in a per-suite temp dir
+// ---------------------------------------------------------------------------
+
+const tempRoot = mkdtempSync(join(tmpdir(), 'ownpilot-data-enc-'));
+
+vi.mock('../paths/index.js', () => ({
+  getDataPaths: () => ({ credentials: tempRoot }),
+}));
+
+import {
+  encryptJsonData,
+  decryptJsonData,
+  isEncryptedEnvelope,
+  isDataEncryptionEnabled,
+  getDataEncryptionKey,
+  resetDataEncryptionKeyCache,
+  serializeEncryptedJson,
+  deserializeEncryptedJson,
+  type EncryptedJsonEnvelope,
+} from './data-encryption.js';
+
+const KEY_FILE = join(tempRoot, 'data-encryption.key');
+
+const ORIGINAL_ENV_KEY = process.env.OWNPILOT_ENCRYPTION_KEY;
+const ORIGINAL_DISABLE = process.env.OWNPILOT_DISABLE_DATA_ENCRYPTION;
+
+describe('data-encryption', () => {
+  beforeEach(() => {
+    delete process.env.OWNPILOT_ENCRYPTION_KEY;
+    delete process.env.OWNPILOT_DISABLE_DATA_ENCRYPTION;
+    resetDataEncryptionKeyCache();
+    if (existsSync(KEY_FILE)) rmSync(KEY_FILE);
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV_KEY === undefined) delete process.env.OWNPILOT_ENCRYPTION_KEY;
+    else process.env.OWNPILOT_ENCRYPTION_KEY = ORIGINAL_ENV_KEY;
+    if (ORIGINAL_DISABLE === undefined) delete process.env.OWNPILOT_DISABLE_DATA_ENCRYPTION;
+    else process.env.OWNPILOT_DISABLE_DATA_ENCRYPTION = ORIGINAL_DISABLE;
+    resetDataEncryptionKeyCache();
+  });
+
+  afterAll(() => {
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  // =========================================================================
+  // Envelope round-trip
+  // =========================================================================
+
+  describe('encryptJsonData / decryptJsonData', () => {
+    it('round-trips an object', () => {
+      const data = { api_key: 'sk-secret-123', region: 'eu', nested: { a: 1 } };
+      const envelope = encryptJsonData(data);
+
+      expect(envelope.__enc).toBe('v1');
+      expect(envelope.ct).not.toContain('sk-secret-123');
+      expect(decryptJsonData(envelope)).toEqual(data);
+    });
+
+    it('produces a different ciphertext per call (random IV)', () => {
+      const data = { api_key: 'same-input' };
+      const a = encryptJsonData(data);
+      const b = encryptJsonData(data);
+
+      expect(a.iv).not.toBe(b.iv);
+      expect(a.ct).not.toBe(b.ct);
+      expect(decryptJsonData(a)).toEqual(decryptJsonData(b));
+    });
+
+    it('throws on tampered ciphertext', () => {
+      const envelope = encryptJsonData({ api_key: 'sk-tamper-test' });
+      const tampered: EncryptedJsonEnvelope = {
+        ...envelope,
+        ct: Buffer.from('tampered-bytes').toString('base64'),
+      };
+
+      expect(() => decryptJsonData(tampered)).toThrow();
+    });
+
+    it('throws when the key changes between encrypt and decrypt', () => {
+      process.env.OWNPILOT_ENCRYPTION_KEY = 'first-key';
+      resetDataEncryptionKeyCache();
+      const envelope = encryptJsonData({ api_key: 'sk-rotate' });
+
+      process.env.OWNPILOT_ENCRYPTION_KEY = 'second-key';
+      resetDataEncryptionKeyCache();
+
+      expect(() => decryptJsonData(envelope)).toThrow();
+    });
+  });
+
+  // =========================================================================
+  // Envelope detection
+  // =========================================================================
+
+  describe('isEncryptedEnvelope', () => {
+    it('accepts a real envelope', () => {
+      expect(isEncryptedEnvelope(encryptJsonData({ a: 1 }))).toBe(true);
+    });
+
+    it.each([
+      ['null', null],
+      ['string', 'enc:v1:abc'],
+      ['plain object', { api_key: 'sk-plain' }],
+      ['wrong version', { __enc: 'v2', iv: 'a', tag: 'b', ct: 'c' }],
+      ['missing fields', { __enc: 'v1', iv: 'a' }],
+      ['non-string fields', { __enc: 'v1', iv: 1, tag: 2, ct: 3 }],
+    ])('rejects %s', (_label, value) => {
+      expect(isEncryptedEnvelope(value)).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // Key resolution
+  // =========================================================================
+
+  describe('getDataEncryptionKey', () => {
+    it('derives a deterministic key from OWNPILOT_ENCRYPTION_KEY', () => {
+      process.env.OWNPILOT_ENCRYPTION_KEY = 'my-passphrase';
+      resetDataEncryptionKeyCache();
+      const a = getDataEncryptionKey();
+
+      resetDataEncryptionKeyCache();
+      const b = getDataEncryptionKey();
+
+      expect(a.equals(b)).toBe(true);
+      expect(a.length).toBe(32);
+      // env-derived key never touches the key file
+      expect(existsSync(KEY_FILE)).toBe(false);
+    });
+
+    it('generates and persists a key file when no env key is set', () => {
+      const key = getDataEncryptionKey();
+
+      expect(key.length).toBe(32);
+      expect(existsSync(KEY_FILE)).toBe(true);
+      const stored = Buffer.from(readFileSync(KEY_FILE, 'utf-8').trim(), 'base64');
+      expect(stored.equals(key)).toBe(true);
+    });
+
+    it('reuses the existing key file on subsequent resolutions', () => {
+      const first = getDataEncryptionKey();
+      resetDataEncryptionKeyCache();
+      const second = getDataEncryptionKey();
+
+      expect(first.equals(second)).toBe(true);
+    });
+
+    it('throws on a corrupt key file instead of regenerating', () => {
+      writeFileSync(KEY_FILE, Buffer.from('too-short').toString('base64'), 'utf-8');
+
+      expect(() => getDataEncryptionKey()).toThrow(/Corrupt data-encryption key file/);
+    });
+  });
+
+  // =========================================================================
+  // Disable flag
+  // =========================================================================
+
+  describe('isDataEncryptionEnabled', () => {
+    it('is enabled by default', () => {
+      expect(isDataEncryptionEnabled()).toBe(true);
+    });
+
+    it.each(['1', 'true'])('is disabled when OWNPILOT_DISABLE_DATA_ENCRYPTION=%s', (flag) => {
+      process.env.OWNPILOT_DISABLE_DATA_ENCRYPTION = flag;
+      expect(isDataEncryptionEnabled()).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // Column helpers
+  // =========================================================================
+
+  describe('serializeEncryptedJson', () => {
+    it('returns an envelope JSON string when enabled', () => {
+      const raw = serializeEncryptedJson({ api_key: 'sk-serialize' });
+
+      expect(raw).not.toContain('sk-serialize');
+      const parsed = JSON.parse(raw) as unknown;
+      expect(isEncryptedEnvelope(parsed)).toBe(true);
+    });
+
+    it('returns plaintext JSON when disabled', () => {
+      process.env.OWNPILOT_DISABLE_DATA_ENCRYPTION = '1';
+      const raw = serializeEncryptedJson({ api_key: 'sk-plain-write' });
+
+      expect(JSON.parse(raw)).toEqual({ api_key: 'sk-plain-write' });
+    });
+  });
+
+  describe('deserializeEncryptedJson', () => {
+    it('decrypts an envelope', () => {
+      const envelope = encryptJsonData({ api_key: 'sk-read' });
+      expect(deserializeEncryptedJson(envelope)).toEqual({ api_key: 'sk-read' });
+    });
+
+    it('decrypts envelopes even when encrypt-on-write is disabled', () => {
+      const envelope = encryptJsonData({ api_key: 'sk-mixed' });
+      process.env.OWNPILOT_DISABLE_DATA_ENCRYPTION = '1';
+
+      expect(deserializeEncryptedJson(envelope)).toEqual({ api_key: 'sk-mixed' });
+    });
+
+    it('passes plaintext legacy objects through unchanged', () => {
+      expect(deserializeEncryptedJson({ api_key: 'sk-legacy' })).toEqual({
+        api_key: 'sk-legacy',
+      });
+    });
+
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+      ['string', 'not-json-object'],
+    ])('returns an empty object for %s', (_label, value) => {
+      expect(deserializeEncryptedJson(value)).toEqual({});
+    });
+  });
+});

--- a/packages/gateway/src/db/data-encryption.ts
+++ b/packages/gateway/src/db/data-encryption.ts
@@ -1,0 +1,190 @@
+/**
+ * Data-at-Rest Encryption
+ *
+ * AES-256-GCM envelope encryption for database columns that hold secrets
+ * (e.g. config_entries.data, which stores provider API keys). The envelope
+ * is a plain JSON object so it can live in JSONB columns unchanged.
+ *
+ * Key resolution order:
+ *  1. OWNPILOT_ENCRYPTION_KEY env var — any non-empty string; the actual
+ *     AES key is derived via SHA-256 so passphrases of any length work.
+ *  2. Auto-generated key file <data>/credentials/data-encryption.key
+ *     (32 random bytes, base64, mode 0600). Created on first use so
+ *     encryption is on by default with zero setup.
+ *
+ * Escape hatch: OWNPILOT_DISABLE_DATA_ENCRYPTION=1 writes plaintext.
+ * Reads always decrypt envelopes when possible, regardless of the flag.
+ *
+ * If the key is lost (key file deleted, env var changed), encrypted values
+ * cannot be recovered — callers should surface a clear "re-enter this
+ * configuration" error instead of crashing.
+ */
+
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { getDataPaths } from '../paths/index.js';
+import { getLog } from '../services/log.js';
+
+const log = getLog('DataEncryption');
+
+const ALGORITHM = 'aes-256-gcm';
+const KEY_LENGTH = 32; // 256 bits
+const IV_LENGTH = 12; // GCM standard nonce size
+const KEY_FILE_NAME = 'data-encryption.key';
+
+/** Marker value identifying an encrypted JSON envelope. */
+const ENVELOPE_VERSION = 'v1';
+
+/**
+ * Encrypted JSON envelope — stored verbatim in JSONB columns.
+ */
+export interface EncryptedJsonEnvelope {
+  __enc: typeof ENVELOPE_VERSION;
+  /** base64 IV (12 bytes) */
+  iv: string;
+  /** base64 GCM auth tag */
+  tag: string;
+  /** base64 ciphertext of the JSON-serialized payload */
+  ct: string;
+}
+
+// =============================================================================
+// Key management
+// =============================================================================
+
+let cachedKey: Buffer | null = null;
+
+/**
+ * Resolve the data-encryption key (cached after first call).
+ *
+ * Throws when the key file exists but is corrupt — regenerating it would
+ * silently orphan every encrypted row, so we fail loudly instead.
+ */
+export function getDataEncryptionKey(): Buffer {
+  if (cachedKey) return cachedKey;
+
+  const envKey = process.env.OWNPILOT_ENCRYPTION_KEY?.trim();
+  if (envKey) {
+    cachedKey = createHash('sha256').update(envKey).digest();
+    return cachedKey;
+  }
+
+  const keyPath = join(getDataPaths().credentials, KEY_FILE_NAME);
+  if (existsSync(keyPath)) {
+    const key = Buffer.from(readFileSync(keyPath, 'utf-8').trim(), 'base64');
+    if (key.length !== KEY_LENGTH) {
+      throw new Error(
+        `Corrupt data-encryption key file (expected ${KEY_LENGTH} bytes, got ${key.length}): ${keyPath}`
+      );
+    }
+    cachedKey = key;
+    return cachedKey;
+  }
+
+  // First run — generate and persist a new key
+  const key = randomBytes(KEY_LENGTH);
+  mkdirSync(dirname(keyPath), { recursive: true });
+  writeFileSync(keyPath, key.toString('base64'), { encoding: 'utf-8', mode: 0o600 });
+  log.info(`[DataEncryption] Generated new data-encryption key: ${keyPath}`);
+  cachedKey = key;
+  return cachedKey;
+}
+
+/**
+ * Clear the cached key (tests only — key resolution re-runs on next use).
+ */
+export function resetDataEncryptionKeyCache(): void {
+  cachedKey = null;
+}
+
+/**
+ * Whether encrypt-on-write is enabled (default: yes).
+ */
+export function isDataEncryptionEnabled(): boolean {
+  const flag = process.env.OWNPILOT_DISABLE_DATA_ENCRYPTION;
+  return flag !== '1' && flag !== 'true';
+}
+
+// =============================================================================
+// Envelope encrypt / decrypt
+// =============================================================================
+
+/**
+ * Type guard for the encrypted envelope shape.
+ */
+export function isEncryptedEnvelope(value: unknown): value is EncryptedJsonEnvelope {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    v.__enc === ENVELOPE_VERSION &&
+    typeof v.iv === 'string' &&
+    typeof v.tag === 'string' &&
+    typeof v.ct === 'string'
+  );
+}
+
+/**
+ * Encrypt a JSON-serializable object into an envelope.
+ */
+export function encryptJsonData(data: Record<string, unknown>): EncryptedJsonEnvelope {
+  const key = getDataEncryptionKey();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+
+  let ct = cipher.update(JSON.stringify(data), 'utf8', 'base64');
+  ct += cipher.final('base64');
+
+  return {
+    __enc: ENVELOPE_VERSION,
+    iv: iv.toString('base64'),
+    tag: cipher.getAuthTag().toString('base64'),
+    ct,
+  };
+}
+
+/**
+ * Decrypt an envelope back into the original object.
+ * Throws on wrong key, tampered ciphertext, or corrupt envelope.
+ */
+export function decryptJsonData(envelope: EncryptedJsonEnvelope): Record<string, unknown> {
+  const key = getDataEncryptionKey();
+  const decipher = createDecipheriv(ALGORITHM, key, Buffer.from(envelope.iv, 'base64'));
+  decipher.setAuthTag(Buffer.from(envelope.tag, 'base64'));
+
+  let plaintext = decipher.update(envelope.ct, 'base64', 'utf8');
+  plaintext += decipher.final('utf8');
+
+  return JSON.parse(plaintext) as Record<string, unknown>;
+}
+
+// =============================================================================
+// Column helpers
+// =============================================================================
+
+/**
+ * Serialize an object for storage in an encrypted JSONB column.
+ * Returns the JSON string of the envelope (or of the plaintext object when
+ * encryption is disabled).
+ */
+export function serializeEncryptedJson(data: Record<string, unknown>): string {
+  if (!isDataEncryptionEnabled()) {
+    return JSON.stringify(data);
+  }
+  return JSON.stringify(encryptJsonData(data));
+}
+
+/**
+ * Restore an object from a (possibly encrypted) parsed JSONB value.
+ * Plaintext legacy values pass through unchanged; envelopes are decrypted.
+ * Throws on decrypt failure — callers decide how to degrade.
+ */
+export function deserializeEncryptedJson(parsed: unknown): Record<string, unknown> {
+  if (isEncryptedEnvelope(parsed)) {
+    return decryptJsonData(parsed);
+  }
+  if (typeof parsed === 'object' && parsed !== null) {
+    return parsed as Record<string, unknown>;
+  }
+  return {};
+}

--- a/packages/gateway/src/db/repositories/config-services.test.ts
+++ b/packages/gateway/src/db/repositories/config-services.test.ts
@@ -5,7 +5,7 @@
  * caching, dependency tracking, config resolution, and statistics.
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
 import { createMockAdapter } from '../../test-helpers.js';
 
 // ---------------------------------------------------------------------------
@@ -20,6 +20,13 @@ vi.mock('../adapters/index.js', () => ({
 }));
 
 import { ConfigServicesRepository } from './config-services.js';
+import {
+  decryptJsonData,
+  encryptJsonData,
+  isEncryptedEnvelope,
+  resetDataEncryptionKeyCache,
+  type EncryptedJsonEnvelope,
+} from '../data-encryption.js';
 
 // ---------------------------------------------------------------------------
 // Sample data helpers
@@ -70,7 +77,15 @@ describe('ConfigServicesRepository', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Pin the at-rest encryption key so tests are hermetic (no key file IO)
+    process.env.OWNPILOT_ENCRYPTION_KEY = 'config-services-test-key';
+    resetDataEncryptionKeyCache();
     repo = new ConfigServicesRepository();
+  });
+
+  afterAll(() => {
+    delete process.env.OWNPILOT_ENCRYPTION_KEY;
+    resetDataEncryptionKeyCache();
   });
 
   // =========================================================================
@@ -126,6 +141,96 @@ describe('ConfigServicesRepository', () => {
       await repo.initialize();
 
       expect(repo.list()).toEqual([]);
+    });
+  });
+
+  // =========================================================================
+  // At-rest encryption
+  // =========================================================================
+
+  describe('at-rest encryption', () => {
+    it('decrypts encrypted entry rows on load', async () => {
+      const encryptedRow = makeEntryRow({
+        data: JSON.stringify(encryptJsonData({ api_key: 'sk-encrypted-at-rest' })),
+      });
+      mockAdapter.query
+        .mockResolvedValueOnce([makeServiceRow()])
+        .mockResolvedValueOnce([encryptedRow]);
+
+      await repo.initialize();
+
+      expect(repo.getApiKey('openai')).toBe('sk-encrypted-at-rest');
+    });
+
+    it('degrades to an empty entry when the encryption key is wrong', async () => {
+      // Encrypt under a different key, then load with the test key
+      process.env.OWNPILOT_ENCRYPTION_KEY = 'some-other-key';
+      resetDataEncryptionKeyCache();
+      const foreignRow = makeEntryRow({
+        data: JSON.stringify(encryptJsonData({ api_key: 'sk-unreachable' })),
+      });
+      process.env.OWNPILOT_ENCRYPTION_KEY = 'config-services-test-key';
+      resetDataEncryptionKeyCache();
+
+      mockAdapter.query
+        .mockResolvedValueOnce([makeServiceRow()])
+        .mockResolvedValueOnce([foreignRow]);
+
+      // Boot must not throw
+      await repo.initialize();
+
+      const entries = repo.getEntries('openai');
+      expect(entries).toHaveLength(1);
+      expect(entries[0]!.data).toEqual({});
+      expect(repo.getApiKey('openai')).toBeUndefined();
+    });
+
+    it('re-encrypts legacy plaintext rows during initialize', async () => {
+      mockAdapter.query
+        .mockResolvedValueOnce([makeServiceRow()]) // services
+        .mockResolvedValueOnce([makeEntryRow()]) // entries (cache)
+        .mockResolvedValueOnce([
+          { id: 'entry-1', data: JSON.stringify({ api_key: 'sk-test-123' }) },
+        ]); // legacy-encryption scan
+
+      await repo.initialize();
+
+      const updateCall = mockAdapter.execute.mock.calls.find(
+        (c) =>
+          typeof c[0] === 'string' && (c[0] as string).startsWith('UPDATE config_entries SET data')
+      );
+      expect(updateCall).toBeDefined();
+      const [serialized, id] = updateCall![1] as [string, string];
+      expect(id).toBe('entry-1');
+      const stored = JSON.parse(serialized) as EncryptedJsonEnvelope;
+      expect(isEncryptedEnvelope(stored)).toBe(true);
+      expect(decryptJsonData(stored)).toEqual({ api_key: 'sk-test-123' });
+    });
+
+    it('skips already-encrypted rows during the legacy scan', async () => {
+      const envelope = encryptJsonData({ api_key: 'sk-already-enc' });
+      mockAdapter.query
+        .mockResolvedValueOnce([makeServiceRow()])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ id: 'entry-1', data: JSON.stringify(envelope) }]);
+
+      await repo.initialize();
+
+      expect(mockAdapter.execute).not.toHaveBeenCalled();
+    });
+
+    it('skips the legacy scan entirely when encryption is disabled', async () => {
+      process.env.OWNPILOT_DISABLE_DATA_ENCRYPTION = '1';
+      try {
+        mockAdapter.query.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+        await repo.initialize();
+
+        // Only the two refreshCache queries — no legacy scan
+        expect(mockAdapter.query).toHaveBeenCalledTimes(2);
+      } finally {
+        delete process.env.OWNPILOT_DISABLE_DATA_ENCRYPTION;
+      }
     });
   });
 
@@ -806,7 +911,11 @@ describe('ConfigServicesRepository', () => {
       await repo.createEntry('openai', { data: { api_key: 'key', url: 'http://example.com' } });
 
       const params = mockAdapter.execute.mock.calls[0]![1] as unknown[];
-      expect(params[3]).toBe('{"api_key":"key","url":"http://example.com"}');
+      // Data is stored as an encrypted envelope, never as plaintext JSON
+      const stored = JSON.parse(params[3] as string) as EncryptedJsonEnvelope;
+      expect(params[3]).not.toContain('key');
+      expect(isEncryptedEnvelope(stored)).toBe(true);
+      expect(decryptJsonData(stored)).toEqual({ api_key: 'key', url: 'http://example.com' });
     });
   });
 
@@ -897,7 +1006,10 @@ describe('ConfigServicesRepository', () => {
       await repo.updateEntry('entry-1', { data: { new_field: 'value' } });
 
       const params = mockAdapter.execute.mock.calls[0]![1] as unknown[];
-      expect(params[0]).toBe('{"new_field":"value"}');
+      // Data is stored as an encrypted envelope, never as plaintext JSON
+      const stored = JSON.parse(params[0] as string) as EncryptedJsonEnvelope;
+      expect(isEncryptedEnvelope(stored)).toBe(true);
+      expect(decryptJsonData(stored)).toEqual({ new_field: 'value' });
     });
 
     it('should include is_active in SET clause when isActive provided (lines 502-503)', async () => {
@@ -1690,8 +1802,8 @@ describe('ConfigServicesRepository', () => {
 
       await initializeConfigServicesRepo();
 
-      // initialize() triggers two DB queries (services + entries)
-      expect(mockAdapter.query).toHaveBeenCalledTimes(2);
+      // initialize() triggers three DB queries (services + entries + legacy-encryption scan)
+      expect(mockAdapter.query).toHaveBeenCalledTimes(3);
     });
   });
 });

--- a/packages/gateway/src/db/repositories/config-services.ts
+++ b/packages/gateway/src/db/repositories/config-services.ts
@@ -17,6 +17,12 @@ import type {
   ConfigServiceDefinition,
   ConfigEntry,
 } from '@ownpilot/core';
+import {
+  deserializeEncryptedJson,
+  isDataEncryptionEnabled,
+  isEncryptedEnvelope,
+  serializeEncryptedJson,
+} from '../data-encryption.js';
 import { getLog } from '../../services/log.js';
 
 const log = getLog('ConfigServicesRepo');
@@ -125,11 +131,24 @@ function rowToService(row: ConfigServiceRow): ConfigServiceDefinition {
 }
 
 function rowToEntry(row: ConfigEntryRow): ConfigEntry {
+  let data: Record<string, unknown>;
+  try {
+    data = deserializeEncryptedJson(parseJsonField<unknown>(row.data, {}));
+  } catch {
+    // Wrong or missing encryption key — degrade to an empty entry so the
+    // gateway still boots; the service shows as unconfigured until the
+    // user re-enters its values.
+    log.error(
+      `[ConfigServices] Cannot decrypt config entry ${row.id} (${row.service_name}/${row.label}) — ` +
+        'encryption key changed or missing. Re-enter this configuration.'
+    );
+    data = {};
+  }
   return {
     id: row.id,
     serviceName: row.service_name,
     label: row.label,
-    data: parseJsonField<Record<string, unknown>>(row.data, {}),
+    data,
     isDefault: parseBool(row.is_default),
     isActive: parseBool(row.is_active),
   };
@@ -150,6 +169,41 @@ export class ConfigServicesRepository extends BaseRepository {
    */
   async initialize(): Promise<void> {
     await this.refreshCache();
+    await this.encryptLegacyPlaintextEntries();
+  }
+
+  /**
+   * One-time at-rest migration: re-write any plaintext config_entries rows
+   * as encrypted envelopes. Idempotent — already-encrypted rows are skipped.
+   * The in-memory cache is unaffected (it always holds decrypted values).
+   */
+  private async encryptLegacyPlaintextEntries(): Promise<void> {
+    if (!isDataEncryptionEnabled()) return;
+
+    const rows = await this.query<Pick<ConfigEntryRow, 'id' | 'data'>>(
+      'SELECT id, data FROM config_entries'
+    );
+
+    let migrated = 0;
+    for (const row of rows) {
+      const parsed = parseJsonField<unknown>(row.data, {});
+      if (isEncryptedEnvelope(parsed)) continue;
+      if (typeof parsed !== 'object' || parsed === null) continue;
+
+      try {
+        await this.execute('UPDATE config_entries SET data = $1 WHERE id = $2', [
+          serializeEncryptedJson(parsed as Record<string, unknown>),
+          row.id,
+        ]);
+        migrated++;
+      } catch (error) {
+        log.error(`[ConfigServices] Failed to encrypt legacy entry ${row.id}: ${String(error)}`);
+      }
+    }
+
+    if (migrated > 0) {
+      log.info(`[ConfigServices] Encrypted ${migrated} legacy plaintext config entries at rest`);
+    }
   }
 
   /**
@@ -459,7 +513,7 @@ export class ConfigServicesRepository extends BaseRepository {
         id,
         serviceName,
         input.label ?? 'Default',
-        JSON.stringify(input.data ?? {}),
+        serializeEncryptedJson(input.data ?? {}),
         isDefault,
         input.isActive !== false,
         now,
@@ -517,7 +571,7 @@ export class ConfigServicesRepository extends BaseRepository {
     }
     if (input.data !== undefined) {
       updates.push(`data = $${paramIndex++}`);
-      values.push(JSON.stringify(input.data));
+      values.push(serializeEncryptedJson(input.data));
     }
     if (input.isDefault !== undefined) {
       updates.push(`is_default = $${paramIndex++}`);

--- a/packages/gateway/src/test-setup.ts
+++ b/packages/gateway/src/test-setup.ts
@@ -20,3 +20,9 @@ vi.mock('./services/log.js', () => ({
     debug: vi.fn(),
   }),
 }));
+
+// Pin the at-rest encryption key so any test that touches encrypted columns
+// stays hermetic — without this, the first encrypt would auto-generate a
+// real key file under the user's data directory.
+// (data-encryption.test.ts manages this env var itself for key-resolution tests.)
+process.env.OWNPILOT_ENCRYPTION_KEY ??= 'gateway-test-suite-encryption-key';


### PR DESCRIPTION
## Summary

Second tier of the June 2026 security audit (after #99). `config_entries.data` stored provider API keys and other service secrets as **plaintext JSONB** — a DB dump or backup leak exposed every configured key. It is now encrypted at rest with AES-256-GCM, on by default with zero setup.

### Design

**New module `db/data-encryption.ts`** — envelope encryption for JSONB columns:
- Envelope is plain JSON (`{"__enc":"v1","iv":...,"tag":...,"ct":...}`) so it lives in JSONB columns unchanged — no schema migration needed.
- Key resolution: `OWNPILOT_ENCRYPTION_KEY` env var (any string, AES key derived via SHA-256) → auto-generated 32-byte key file at `<data>/credentials/data-encryption.key` (base64, mode 0600). The credentials dir already gets 0700 on Unix.
- Corrupt key file **throws** instead of regenerating (silent regeneration would orphan every encrypted row).
- `OWNPILOT_DISABLE_DATA_ENCRYPTION=1` opts out of encrypt-on-write; reads always decrypt envelopes regardless.

**Repository wiring (`config-services.ts`)**:
- `createEntry` / `updateEntry` encrypt on write.
- `rowToEntry` decrypts on load; legacy plaintext passes through. Wrong/missing key degrades that entry to `{}` with an actionable log line ("re-enter this configuration") — the gateway still boots.
- `initialize()` runs an idempotent boot-time migration that re-encrypts existing plaintext rows (already-encrypted rows are skipped via envelope detection).
- The in-memory cache keeps decrypted values, so every consumer (ConfigCenter, channel plugins, `getApiKey`/`getFieldValue`, UI routes) is unchanged.

**Hermeticity**: `test-setup.ts` pins `OWNPILOT_ENCRYPTION_KEY` for the whole gateway suite so no test ever writes a key file to the real data dir.

### Trade-offs

- Older builds reading an encrypted DB see envelope objects instead of values → services appear unconfigured until this build runs again (data is not lost). Standard downgrade cost of at-rest encryption.
- Same-host attacker who can read both the DB *and* the key file still wins — this protects DB dumps, backups, and remote-DB access, which is the realistic leak surface for a self-hosted deployment.
- Scope is `config_entries` only (the audit finding). The module is reusable for other secret-bearing columns in follow-ups.

### Docs
- `.env.example`: `OWNPILOT_ENCRYPTION_KEY` + `OWNPILOT_DISABLE_DATA_ENCRYPTION` documented with the key-loss warning.
- `docs/DATABASE.md`: `config_entries.data` marked encrypted + envelope/key explanation.

## Test plan
- [x] New `data-encryption.test.ts`: 26 tests — round-trip, random IV, tamper detection, key rotation failure, envelope detection matrix, env-key vs key-file resolution, corrupt-key-file throw, disable flag, column helpers
- [x] `config-services.test.ts`: 109 tests (5 new — decrypt-on-load, wrong-key degradation without boot crash, legacy re-encryption migration, already-encrypted skip, disabled-scan skip; 3 updated for envelope writes)
- [x] Full gateway suite: 17,291/17,291, no type errors
- [x] No new SQL shapes — writes reuse the existing `JSON.stringify` → JSONB param pattern already proven in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)