### PR TITLE
fix(core): bound long-lived in-memory stores + unref cleanup timer

### DIFF
--- a/packages/core/src/agent/code-generator.test.ts
+++ b/packages/core/src/agent/code-generator.test.ts
@@ -610,6 +610,29 @@ describe('CodeGenerator', () => {
       expect(stats.totalExecutions).toBe(0);
     });
 
+    it('should cap execution history at 1000 entries, rolling off the oldest', async () => {
+      const generator = new CodeGenerator();
+      const history = (generator as unknown as { executionHistory: Array<{ userId: string }> })
+        .executionHistory;
+
+      // Pre-fill to the cap, then execute once more
+      for (let i = 0; i < 1000; i++) {
+        history.push({
+          userId: `user-${i}`,
+          language: 'javascript',
+          success: true,
+          duration: 1,
+          timestamp: new Date().toISOString(),
+        } as never);
+      }
+      await generator.execute('1 + 1', 'javascript', { userId: 'newest-user' });
+
+      expect(history).toHaveLength(1000);
+      // Oldest rolled off; newest entry survives at the tail
+      expect(history[0]?.userId).toBe('user-1');
+      expect(history[999]?.userId).toBe('newest-user');
+    });
+
     it('should return memoryUsed from sandbox result', async () => {
       mockSandboxExecutor.execute.mockResolvedValue({
         ok: true,
@@ -888,6 +911,25 @@ describe('CodeGenerator', () => {
       });
 
       expect(snippet.createdAt).toBe(snippet.updatedAt);
+    });
+
+    it('should cap per-user snippets at 500, evicting the oldest', () => {
+      const generator = new CodeGenerator();
+      for (let i = 0; i < 501; i++) {
+        generator.saveSnippet('user-1', {
+          userId: 'user-1',
+          language: 'javascript',
+          code: `code-${i}`,
+          description: `desc-${i}`,
+          tags: [],
+        });
+      }
+
+      const snippets = generator.getSnippets('user-1');
+      expect(snippets).toHaveLength(500);
+      // Oldest snippet rolled off; newest survives
+      expect(snippets[0]?.code).toBe('code-1');
+      expect(snippets[499]?.code).toBe('code-500');
     });
   });
 

--- a/packages/core/src/agent/code-generator.ts
+++ b/packages/core/src/agent/code-generator.ts
@@ -199,6 +199,13 @@ const DEFAULT_CONFIG: CodeGeneratorConfig = {
 };
 
 /**
+ * In-memory retention bounds — both stores live for the process lifetime,
+ * so without caps they grow without limit on long-running gateways.
+ */
+const MAX_EXECUTION_HISTORY = 1000;
+const MAX_SNIPPETS_PER_USER = 500;
+
+/**
  * Code Generator with Sandbox Execution
  */
 export class CodeGenerator {
@@ -355,7 +362,7 @@ export class CodeGenerator {
       const result = await sandbox.execute<unknown>(wrappedCode, options.inputData);
       const duration = Date.now() - startTime;
 
-      // Track execution
+      // Track execution (bounded: oldest entries roll off)
       if (options.userId) {
         this.executionHistory.push({
           userId: options.userId,
@@ -364,6 +371,9 @@ export class CodeGenerator {
           duration,
           timestamp: new Date().toISOString(),
         });
+        if (this.executionHistory.length > MAX_EXECUTION_HISTORY) {
+          this.executionHistory.splice(0, this.executionHistory.length - MAX_EXECUTION_HISTORY);
+        }
       }
 
       if (result.ok) {
@@ -546,6 +556,10 @@ export class CodeGenerator {
 
     const userSnippets = this.snippetStorage.get(userId) ?? [];
     userSnippets.push(newSnippet);
+    // Bounded per user: oldest snippets roll off (in-memory store only)
+    if (userSnippets.length > MAX_SNIPPETS_PER_USER) {
+      userSnippets.splice(0, userSnippets.length - MAX_SNIPPETS_PER_USER);
+    }
     this.snippetStorage.set(userId, userSnippets);
 
     return newSnippet;

--- a/packages/core/src/agent/permissions.test.ts
+++ b/packages/core/src/agent/permissions.test.ts
@@ -731,6 +731,33 @@ describe('PermissionChecker', () => {
       expect(result.reason).toContain('Rate limit exceeded');
     });
 
+    it('prunes expired counters once the map grows past the threshold', () => {
+      const policy = makePolicy({
+        defaultLevel: 'admin',
+        defaultCategories: ['code_execute'],
+      });
+      const c = new PermissionChecker(policy);
+      const counters = (
+        c as unknown as { rateLimitCounters: Map<string, { count: number; resetAt: number }> }
+      ).rateLimitCounters;
+
+      vi.useFakeTimers();
+
+      // Grow the map past the 1000-entry prune threshold with distinct users
+      for (let i = 0; i < 1001; i++) {
+        c.check('execute_javascript', makeContext({ userId: `user-${i}` }));
+      }
+      expect(counters.size).toBe(1001);
+
+      // Expire every window, then trigger one more check — the sweep
+      // should drop all stale entries instead of accumulating forever
+      vi.advanceTimersByTime(61000);
+      c.check('execute_javascript', makeContext({ userId: 'fresh-user' }));
+      expect(counters.size).toBe(1);
+
+      vi.useRealTimers();
+    });
+
     it('includes rate limit context in denial', () => {
       const policy = makePolicy({
         defaultLevel: 'admin',

--- a/packages/core/src/agent/permissions.ts
+++ b/packages/core/src/agent/permissions.ts
@@ -294,6 +294,13 @@ export function getHighestPermissionLevel(levels: readonly PermissionLevel[]): P
 // =============================================================================
 
 /**
+ * Once the counter map grows past this size, expired entries are swept
+ * on the next rate-limit check. Keeps the map bounded on long-running
+ * processes (keys are `userId:toolName`, so stale pairs accumulate).
+ */
+const RATE_LIMIT_PRUNE_THRESHOLD = 1000;
+
+/**
  * Permission checker class
  */
 export class PermissionChecker {
@@ -475,6 +482,17 @@ export class PermissionChecker {
    */
   private checkRateLimit(key: string, limit: number): PermissionCheckResult {
     const now = Date.now();
+
+    // Opportunistic sweep: drop expired counters once the map gets large,
+    // so the map stays bounded without a background timer.
+    if (this.rateLimitCounters.size > RATE_LIMIT_PRUNE_THRESHOLD) {
+      for (const [k, v] of this.rateLimitCounters) {
+        if (v.resetAt < now) {
+          this.rateLimitCounters.delete(k);
+        }
+      }
+    }
+
     const counter = this.rateLimitCounters.get(key);
 
     if (!counter || counter.resetAt < now) {

--- a/packages/core/src/assistant/memory-oversight.ts
+++ b/packages/core/src/assistant/memory-oversight.ts
@@ -850,6 +850,9 @@ export class MemoryCleaner {
     this.cleanupInterval = setInterval(() => {
       this.runCleanup().catch((e) => log.error('Cleanup failed:', e));
     }, intervalMs);
+    // Don't hold the process open just for this cleanup — matches the other
+    // background timers (scheduler, secure-store, communication-bus).
+    this.cleanupInterval.unref?.();
   }
 
   /**


### PR DESCRIPTION
## Summary

Reliability hardening for long-running gateways — the remaining "reliability" tier from the project-wide audit.

### Fixed
- **`PermissionChecker.rateLimitCounters`**: expired rate-limit counters were never evicted (keys are `userId:toolName`, so stale pairs accumulate forever). Now an opportunistic sweep drops expired entries once the map exceeds 1000 entries — bounded without needing a background timer.
- **`CodeGenerator.executionHistory`**: pushed on every tracked execution, never trimmed. Capped at 1000 entries; oldest roll off.
- **`CodeGenerator.snippetStorage`**: per-user snippet arrays grew without limit. Capped at 500 per user; oldest roll off (in-memory store only).
- **`MemoryOversight.startAutoCleanup`**: the cleanup interval was the only background timer in core/gateway without `unref()` — it could hold the process open if a consumer forgot `stopAutoCleanup()`. Now unref'd, matching scheduler / secure-store / communication-bus / claw manager.

### Verified stale (no change needed)
- **WS broadcast try/catch**: `ws/session.ts` broadcast loops already have per-socket try/catch, backpressure (`bufferedAmount`) drops, and stale-session cleanup; EventBus `safeCall` isolates handler errors.
- **Timer shutdown wiring**: every `setInterval` in gateway + core is unref'd and/or cleared in stop paths; `server.ts` shutdown stops each service with guarded calls.

## Tests
- 3 new regression tests: rate-limit counter prune past threshold, execution-history cap, per-user snippet cap.
- Full core suite: **9,440/9,440 passed, no type errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)