### PR TITLE
fix(security): authenticate /api/v2/* and apply security-check hardening

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,11 @@ on:
     tags:
       - 'v*'
 
+# Least privilege: the default token is read-only. The write scopes are granted
+# at the job level (below) so they apply only to the release job, not to any
+# job added to this workflow later.
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 concurrency:
   group: release-${{ github.ref }}
@@ -16,6 +18,9 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Create GitHub Release (softprops/action-gh-release)
+      packages: write # Push image to GHCR
 
     steps:
       - name: Checkout

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,6 +48,23 @@ OwnPilot implements multiple layers of security:
 
 - Tamper-evident hash chain logging for audit trail verification
 
+## Deployment Hardening (exposed gateways)
+
+The defaults target a localhost, single-tenant deployment. When exposing the
+gateway beyond localhost (e.g. via a tunnel or `0.0.0.0` bind), also set:
+
+- **`TRUSTED_PROXY=true` + `TRUSTED_PROXY_IPS`** — required for the rate limiter
+  and TLS detection to trust `X-Forwarded-*`. Without it, external clients can
+  collapse into the local-exempt bucket and the global limiter becomes
+  ineffective.
+- **`UI_SESSION_COOKIE_SECURE=true`** (or **`HTTPS_ONLY=true`**) — ensures the UI
+  session cookie carries the `Secure` flag when TLS is terminated upstream.
+- **MQTT (edge)** — the bundled Mosquitto broker allows anonymous connections and
+  is bound to loopback behind the optional `mqtt` compose profile. Configure
+  broker credentials before binding it to any non-loopback interface.
+- **API auth** — set `auth.type` to `api-key` or `jwt` (with a strong key/secret);
+  authentication covers the entire `/api/*` surface (all versions).
+
 ## Dependency Management
 
 - Dependencies are pinned and audited regularly.

--- a/packages/core/src/agent/tools/file-system.ts
+++ b/packages/core/src/agent/tools/file-system.ts
@@ -8,7 +8,7 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import type { ToolDefinition, ToolExecutor, ToolExecutionResult, ToolContext } from '../types.js';
 import { getErrorMessage } from '../../services/error-utils.js';
-import { isBlockedUrl } from './web-fetch.js';
+import { isBlockedUrl, safeFetch } from './web-fetch.js';
 import { isPrivateUrlAsync } from './dynamic-tool-permissions.js';
 import { isPathAllowedAsync, resolveFilePath } from './file-security.js';
 
@@ -630,9 +630,11 @@ export const downloadFileExecutor: ToolExecutor = async (
       };
     }
 
-    // Download file with size limit (100 MB)
+    // Download file with size limit (100 MB). safeFetch re-validates every
+    // redirect hop against the SSRF block-list (plain fetch would follow a 3xx
+    // to an internal address before any check could run).
     const MAX_DOWNLOAD_SIZE = 100 * 1024 * 1024;
-    const response = await fetch(url);
+    const response = await safeFetch(url);
     if (!response.ok) {
       return {
         content: `Error: Failed to download: ${response.status} ${response.statusText}`,

--- a/packages/core/src/agent/tools/web-fetch.test.ts
+++ b/packages/core/src/agent/tools/web-fetch.test.ts
@@ -346,6 +346,48 @@ describe('SSRF redirect protection', () => {
     const result = await httpRequestExecutor({ url: 'https://example.com' }, ctx);
     expect(result.isError).toBe(false);
   });
+
+  it('blocks an intermediate 3xx hop to a private IP before following it', async () => {
+    // First (and only) hop returns a 302 whose Location points at an internal
+    // address. With manual redirect following, the next hop must be rejected
+    // BEFORE the second fetch is issued — the platform fetch would have
+    // connected to 169.254.169.254 transparently.
+    fetchMock.mockResolvedValueOnce(
+      mockResponse({
+        ok: false,
+        status: 302,
+        statusText: 'Found',
+        url: 'https://example.com/redirect',
+        headers: { location: 'http://169.254.169.254/latest/meta-data/' },
+      })
+    );
+    const result = await httpRequestExecutor({ url: 'https://example.com/redirect' }, ctx);
+    expect(result.isError).toBe(true);
+    expect((result.content as any).error).toContain('blocked internal address');
+    // The redirect target was never fetched.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://example.com/redirect');
+  });
+
+  it('follows an intermediate 3xx hop to a public URL and returns the final body', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        mockResponse({
+          ok: false,
+          status: 302,
+          statusText: 'Found',
+          url: 'https://example.com/start',
+          headers: { location: 'https://cdn.example.com/final' },
+        })
+      )
+      .mockResolvedValueOnce(
+        mockResponse({ url: 'https://cdn.example.com/final', body: 'final-body' })
+      );
+    const result = await httpRequestExecutor({ url: 'https://example.com/start' }, ctx);
+    expect(result.isError).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('https://cdn.example.com/final');
+  });
 });
 
 // =============================================================================

--- a/packages/core/src/agent/tools/web-fetch.ts
+++ b/packages/core/src/agent/tools/web-fetch.ts
@@ -210,6 +210,61 @@ async function checkRedirectTarget(finalUrl: string, originalUrl: string): Promi
   return null;
 }
 
+/** Maximum redirect hops followed by `safeFetch` before giving up. */
+const MAX_REDIRECTS = 5;
+
+/**
+ * SSRF-safe `fetch` that follows redirects MANUALLY, re-validating every
+ * intermediate hop against the block-list — not just the final URL.
+ *
+ * The platform `fetch` follows 3xx transparently and exposes only the final
+ * `response.url`, so a URL that 302-redirects to 169.254.169.254 or an RFC1918
+ * host is connected to before any post-fetch check can run (CWE-918). Here each
+ * `Location` is resolved relative to the current hop, checked with
+ * `isBlockedUrl` + DNS-rebinding-aware `isPrivateUrlAsync`, and only then
+ * followed. A blocked hop (or exceeding MAX_REDIRECTS) throws a plain Error
+ * whose message is surfaced by the caller's existing catch as a tool error.
+ *
+ * Redirect method/body rewriting mirrors the Fetch spec: 303 (and 301/302 for
+ * non-GET/HEAD) downgrade to GET with the body dropped; 307/308 preserve both.
+ */
+export async function safeFetch(initialUrl: string, init: RequestInit = {}): Promise<Response> {
+  let currentUrl = initialUrl;
+  let method = (init.method ?? 'GET').toUpperCase();
+  let body = init.body;
+
+  for (let hops = 0; ; hops++) {
+    const response = await fetch(currentUrl, { ...init, method, body, redirect: 'manual' });
+
+    // Not a redirect (or a 3xx with no Location) → terminal response.
+    if (response.status < 300 || response.status >= 400) return response;
+    const location = response.headers.get('location');
+    if (!location) return response;
+
+    if (hops >= MAX_REDIRECTS) {
+      throw new Error(`Too many redirects (>${MAX_REDIRECTS}) starting from ${initialUrl}`);
+    }
+
+    const nextUrl = new URL(location, currentUrl).href;
+    if (isBlockedUrl(nextUrl) || (await isPrivateUrlAsync(nextUrl))) {
+      throw new Error(
+        `Request was redirected to a blocked internal address (${nextUrl}). Original URL: ${initialUrl}`
+      );
+    }
+
+    if (
+      response.status === 303 ||
+      ((response.status === 301 || response.status === 302) &&
+        method !== 'GET' &&
+        method !== 'HEAD')
+    ) {
+      method = 'GET';
+      body = undefined;
+    }
+    currentUrl = nextUrl;
+  }
+}
+
 /**
  * Parse HTML and extract text content
  */
@@ -372,7 +427,7 @@ export const httpRequestExecutor: ToolExecutor = async (
 
     let response: Response;
     try {
-      response = await fetch(url, {
+      response = await safeFetch(url, {
         method,
         headers: requestHeaders,
         body: requestBody,
@@ -515,7 +570,7 @@ export const fetchWebPageExecutor: ToolExecutor = async (
 
     let response: Response;
     try {
-      response = await fetch(url, {
+      response = await safeFetch(url, {
         headers: {
           'User-Agent': 'Mozilla/5.0 (compatible; OwnPilot/1.0; +https://github.com/ownpilot)',
           Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
@@ -783,7 +838,7 @@ export const jsonApiExecutor: ToolExecutor = async (
 
     let response: Response;
     try {
-      response = await fetch(url, {
+      response = await safeFetch(url, {
         method,
         headers: requestHeaders,
         body: data ? JSON.stringify(data) : undefined,

--- a/packages/gateway/src/app.test.ts
+++ b/packages/gateway/src/app.test.ts
@@ -10,7 +10,14 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 // Mock middleware modules
 const mockRequestId = vi.fn().mockImplementation((c, next) => next());
 const mockTiming = vi.fn().mockImplementation((c, next) => next());
-const mockCreateAuthMiddleware = vi.fn().mockImplementation(() => (c, next) => next());
+// Records every request path the auth middleware actually runs on, so tests can
+// assert which routes are covered by authentication (regression guard for the
+// /api/v2/* auth-bypass fix — auth must cover all /api/* versions, not just v1).
+const authSeenPaths: string[] = [];
+const mockCreateAuthMiddleware = vi.fn().mockImplementation(() => (c, next) => {
+  authSeenPaths.push(c.req.path);
+  return next();
+});
 const mockCreateRateLimitMiddleware = vi.fn().mockImplementation(() => (c, next) => next());
 const mockErrorHandler = vi.fn().mockImplementation((err, c) => c.json({ error: 'test' }, 500));
 const mockNotFoundHandler = vi.fn().mockImplementation((c) => c.json({ error: 'Not found' }, 404));
@@ -126,6 +133,7 @@ const { createApp } = await import('./app.js');
 describe('createApp', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    authSeenPaths.length = 0;
     delete process.env.NODE_ENV;
     delete process.env.UI_PORT;
     delete process.env.CORS_ORIGINS;
@@ -154,6 +162,37 @@ describe('createApp', () => {
       const app = createApp(customConfig);
       const res = await app.request('/api/v1/agents');
       expect(res.status).toBe(200);
+    });
+  });
+
+  // Regression guard: the auth + UI-session middleware must cover the entire
+  // /api/* surface. Previously they were scoped to /api/v1/* only, leaving the
+  // identical handlers mirrored at /api/v2/* (registerV2Routes) completely
+  // unauthenticated (CWE-306). The unprefixed /health route must stay public.
+  describe('API authentication coverage (v2 bypass regression)', () => {
+    it('applies authentication to /api/v2/* routes', async () => {
+      const app = createApp();
+      const res = await app.request('/api/v2/agents');
+      expect(res.status).toBe(200);
+      expect(authSeenPaths).toContain('/api/v2/agents');
+    });
+
+    it('still applies authentication to /api/v1/* routes', async () => {
+      const app = createApp();
+      await app.request('/api/v1/agents');
+      expect(authSeenPaths).toContain('/api/v1/agents');
+    });
+
+    it('does not apply authentication to the public /health route', async () => {
+      const app = createApp();
+      await app.request('/health');
+      expect(authSeenPaths).not.toContain('/health');
+    });
+
+    it('does not mount authentication when auth.type is none', async () => {
+      const app = createApp({ auth: { type: 'none' } });
+      await app.request('/api/v2/agents');
+      expect(authSeenPaths).toHaveLength(0);
     });
   });
 

--- a/packages/gateway/src/app.ts
+++ b/packages/gateway/src/app.ts
@@ -194,8 +194,8 @@ export function createApp(config: Partial<GatewayConfig> = {}): Hono {
     c.header('Server', '');
   });
 
-  // Prevent caching of sensitive API responses
-  app.use('/api/v1/*', async (c, next) => {
+  // Prevent caching of sensitive API responses (all API versions)
+  app.use('/api/*', async (c, next) => {
     await next();
     // Only add cache control if not already set
     if (!c.res.headers.get('Cache-Control')) {
@@ -272,11 +272,14 @@ export function createApp(config: Partial<GatewayConfig> = {}): Hono {
   // Do not reorder - session auth must come before API auth to enable bypass
 
   // UI session authentication (before API auth — valid session bypasses api-key/jwt)
-  app.use('/api/v1/*', uiSessionMiddleware);
+  // Scoped to ALL versioned API paths (/api/*), not just /api/v1/*, so the v2
+  // mirror (registerV2Routes) is covered too. The unprefixed /health route is
+  // not under /api/* and stays public for container health checks.
+  app.use('/api/*', uiSessionMiddleware);
 
   // Authentication (skip health routes)
   if (fullConfig.auth && fullConfig.auth.type !== 'none') {
-    app.use('/api/v1/*', createAuthMiddleware(fullConfig.auth));
+    app.use('/api/*', createAuthMiddleware(fullConfig.auth));
   }
 
   // Audit logging (fire-and-forget, logs method/path/status/duration)

--- a/packages/gateway/src/routes/database/index.ts
+++ b/packages/gateway/src/routes/database/index.ts
@@ -19,13 +19,16 @@ export const databaseRoutes = new Hono();
 // All routes under /database require X-Admin-Key header.
 // GET routes are read-only but still sensitive (expose schema, size, config).
 databaseRoutes.use('*', async (c, next) => {
-  const adminKey = process.env.ADMIN_KEY;
+  // Canonical name is ADMIN_API_KEY (shared with the debug routes); the legacy
+  // ADMIN_KEY is still honored as a deprecated fallback so existing deployments
+  // keep working.
+  const adminKey = process.env.ADMIN_API_KEY ?? process.env.ADMIN_KEY;
   if (!adminKey) {
     return apiError(
       c,
       {
         code: ERROR_CODES.UNAUTHORIZED,
-        message: 'ADMIN_KEY environment variable must be set.',
+        message: 'ADMIN_API_KEY environment variable must be set.',
       },
       403
     );

--- a/packages/gateway/src/routes/database/schema.ts
+++ b/packages/gateway/src/routes/database/schema.ts
@@ -155,12 +155,14 @@ schemaRoutes.post('/migrate', async (c) => {
   if (body.truncate) args.push('--truncate');
   if (body.skipSchema) args.push('--skip-schema');
 
-  // Run migration script in background
+  // Run migration script in background. Spawn npx.cmd directly on Windows
+  // instead of going through `shell: true` — the args are all static literals
+  // today, but a shell-less spawn removes the latent injection footgun entirely
+  // if a future arg ever becomes dynamic.
   const cwd = join(process.cwd(), 'packages', 'gateway');
-  // shell: true needed on Windows for npx.cmd resolution
-  const migration = spawn('npx', args, {
+  const npxBin = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+  const migration = spawn(npxBin, args, {
     cwd,
-    shell: process.platform === 'win32',
     env: {
       ...process.env,
       SQLITE_PATH: sqlitePath,

--- a/packages/gateway/src/routes/expenses.test.ts
+++ b/packages/gateway/src/routes/expenses.test.ts
@@ -197,6 +197,28 @@ describe('Expenses Routes', () => {
       });
       expect(res.status).toBe(400);
     });
+
+    it('returns 400 for a non-numeric amount', async () => {
+      const app = createApp();
+      const res = await app.request('/expenses', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amount: 'abc', description: 'Bad amount' }),
+      });
+      expect(res.status).toBe(400);
+      expect(mockRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for a negative amount', async () => {
+      const app = createApp();
+      const res = await app.request('/expenses', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amount: -5, description: 'Negative' }),
+      });
+      expect(res.status).toBe(400);
+      expect(mockRepo.create).not.toHaveBeenCalled();
+    });
   });
 
   describe('PUT /expenses/:id', () => {
@@ -212,6 +234,17 @@ describe('Expenses Routes', () => {
         'exp-1',
         expect.objectContaining({ amount: 99 })
       );
+    });
+
+    it('returns 400 for a negative amount on update', async () => {
+      const app = createApp();
+      const res = await app.request('/expenses/exp-1', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amount: -1 }),
+      });
+      expect(res.status).toBe(400);
+      expect(mockRepo.update).not.toHaveBeenCalled();
     });
 
     it('returns 404 for missing', async () => {

--- a/packages/gateway/src/routes/expenses.ts
+++ b/packages/gateway/src/routes/expenses.ts
@@ -282,9 +282,23 @@ expensesRoutes.post('/', async (c) => {
       );
     }
 
+    // Reject NaN / Infinity / negative amounts — `Number('abc')` is NaN and a
+    // negative spend corrupts budget/aggregation math downstream.
+    const amountNum = Number(amount);
+    if (!Number.isFinite(amountNum) || amountNum < 0) {
+      return apiError(
+        c,
+        {
+          code: ERROR_CODES.VALIDATION_ERROR,
+          message: 'amount must be a finite, non-negative number',
+        },
+        400
+      );
+    }
+
     const expense = await repo.create({
       date: (date as string) ?? new Date().toISOString().split('T')[0]!,
-      amount: Number(amount),
+      amount: amountNum,
       currency: (currency as string) ?? 'TRY',
       category: (category as string) ?? 'other',
       description: description as string,
@@ -315,7 +329,24 @@ expensesRoutes.put('/:id', async (c) => {
     if (!body)
       return apiError(c, { code: ERROR_CODES.VALIDATION_ERROR, message: 'Invalid JSON body' }, 400);
 
-    const updated = await repo.update(c.req.param('id'), body as Record<string, unknown>);
+    // Validate amount on update too (when present) — same rule as create.
+    const updateFields = body as Record<string, unknown>;
+    if (updateFields.amount !== undefined) {
+      const amountNum = Number(updateFields.amount);
+      if (!Number.isFinite(amountNum) || amountNum < 0) {
+        return apiError(
+          c,
+          {
+            code: ERROR_CODES.VALIDATION_ERROR,
+            message: 'amount must be a finite, non-negative number',
+          },
+          400
+        );
+      }
+      updateFields.amount = amountNum;
+    }
+
+    const updated = await repo.update(c.req.param('id'), updateFields);
     if (!updated) return notFoundError(c, 'Expense', c.req.param('id'));
 
     wsGateway.broadcast(

--- a/packages/gateway/src/services/claw/skill-distiller.test.ts
+++ b/packages/gateway/src/services/claw/skill-distiller.test.ts
@@ -129,17 +129,15 @@ describe('findLearnedSkills', () => {
 
   it('filters out skills without the LEARNED_SKILL_TAG', () => {
     const svc = {
-      getEnabledMetadata: vi
-        .fn()
-        .mockReturnValue([
-          {
-            id: 's1',
-            name: 'Deploy webapp',
-            description: 'How to deploy',
-            keywords: [],
-            instructions: '',
-          },
-        ]),
+      getEnabledMetadata: vi.fn().mockReturnValue([
+        {
+          id: 's1',
+          name: 'Deploy webapp',
+          description: 'How to deploy',
+          keywords: [],
+          instructions: '',
+        },
+      ]),
       getById: vi.fn(),
     };
     const result = findLearnedSkills(svc, 'deploy webapp');
@@ -171,16 +169,14 @@ describe('findLearnedSkills', () => {
           instructions: 'Step 1',
         },
       ]),
-      getById: vi
-        .fn()
-        .mockImplementation((id: string) => ({
-          id,
-          name: '',
-          description: '',
-          keywords: [],
-          instructions: '',
-          manifest: { instructions: 'Step 1' },
-        })),
+      getById: vi.fn().mockImplementation((id: string) => ({
+        id,
+        name: '',
+        description: '',
+        keywords: [],
+        instructions: '',
+        manifest: { instructions: 'Step 1' },
+      })),
     };
     const result = findLearnedSkills(svc, 'deploy to production');
     expect(result.length).toBeGreaterThan(0);
@@ -206,27 +202,23 @@ describe('findLearnedSkills', () => {
   it('excludes short tokens and deduplicates', () => {
     // 'ab' (len=2) is filtered out, 'xyz' (len=3) remains and appears in name
     const svc = {
-      getEnabledMetadata: vi
-        .fn()
-        .mockReturnValue([
-          {
-            id: 's1',
-            name: 'ab xyz ef',
-            description: 'gh ij',
-            keywords: [LEARNED_SKILL_TAG],
-            instructions: 'Step 1',
-          },
-        ]),
-      getById: vi
-        .fn()
-        .mockReturnValue({
+      getEnabledMetadata: vi.fn().mockReturnValue([
+        {
           id: 's1',
-          name: '',
-          description: '',
-          keywords: [],
-          instructions: '',
-          manifest: { instructions: '' },
-        }),
+          name: 'ab xyz ef',
+          description: 'gh ij',
+          keywords: [LEARNED_SKILL_TAG],
+          instructions: 'Step 1',
+        },
+      ]),
+      getById: vi.fn().mockReturnValue({
+        id: 's1',
+        name: '',
+        description: '',
+        keywords: [],
+        instructions: '',
+        manifest: { instructions: '' },
+      }),
     };
     const result = findLearnedSkills(svc, 'ab ab xyz');
     expect(result).toHaveLength(1);

--- a/packages/gateway/src/services/skill/agentskills-parser.ts
+++ b/packages/gateway/src/services/skill/agentskills-parser.ts
@@ -54,6 +54,12 @@ export function parseSkillMdFrontmatter(content: string): {
   return { frontmatter, body };
 }
 
+// Keys that must never be written into a parsed object — assigning them can
+// reparent the object's prototype (prototype pollution). Skipped defensively
+// even though untrusted SKILL.md frontmatter only ever reaches a single object
+// instance here.
+const RESERVED_YAML_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 /**
  * Parse simple YAML (flat key-value pairs, one level of nesting).
  * Supports: strings, quoted strings, arrays (flow/block), nested maps (one level).
@@ -101,8 +107,9 @@ function parseSimpleYaml(yaml: string): Record<string, unknown> {
       if (currentMap) {
         const match = trimmed.match(/^([^:]+):\s*(.*)$/);
         if (match) {
+          const mapKey = match[1]!.trim();
           const val = unquote(match[2]!.trim());
-          currentMap[match[1]!.trim()] = val;
+          if (!RESERVED_YAML_KEYS.has(mapKey)) currentMap[mapKey] = val;
         }
       }
       continue;
@@ -117,6 +124,9 @@ function parseSimpleYaml(yaml: string): Record<string, unknown> {
 
     const key = kvMatch[1]!.trim();
     const rawValue = kvMatch[2]!.trim();
+
+    // Drop prototype-polluting keys (and any nested block they would open).
+    if (RESERVED_YAML_KEYS.has(key)) continue;
 
     if (!rawValue) {
       // Start of a nested map or block sequence

--- a/packages/gateway/src/utils/ui-session-cookie.test.ts
+++ b/packages/gateway/src/utils/ui-session-cookie.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Hono } from 'hono';
+import { setUiSessionCookie, UI_SESSION_COOKIE } from './ui-session-cookie.js';
+
+/**
+ * Focused coverage for the session-cookie Secure-flag policy. The cookie must
+ * be Secure when the operator opts into HTTPS (explicit flag or HTTPS_ONLY) and
+ * must stay non-Secure on plain-HTTP localhost so the browser still sends it.
+ */
+function appThatSetsCookie() {
+  const app = new Hono();
+  app.get('/set', (c) => {
+    setUiSessionCookie(c, 'tok-123', new Date(Date.now() + 60_000));
+    return c.text('ok');
+  });
+  return app;
+}
+
+async function getSetCookie(): Promise<string> {
+  const res = await appThatSetsCookie().request('http://localhost/set');
+  return res.headers.get('set-cookie') ?? '';
+}
+
+describe('setUiSessionCookie Secure policy', () => {
+  const ENV_KEYS = ['UI_SESSION_COOKIE_SECURE', 'HTTPS_ONLY', 'TRUSTED_PROXY'] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  // Restore an env var to its exact prior state. Assigning `undefined` to a
+  // process.env key coerces to the string "undefined" (truthy!) and would leak
+  // to later test files sharing the same worker — delete instead when unset.
+  const restore = (key: string, value: string | undefined) => {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  };
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) restore(key, saved[key]);
+  });
+
+  it('omits Secure on a plain-HTTP request by default', async () => {
+    const cookie = await getSetCookie();
+    expect(cookie).toContain(`${UI_SESSION_COOKIE}=`);
+    expect(cookie).toContain('HttpOnly');
+    expect(cookie).not.toMatch(/;\s*Secure/i);
+  });
+
+  it('forces Secure when HTTPS_ONLY=true even on a plain-HTTP hop', async () => {
+    process.env.HTTPS_ONLY = 'true';
+    const cookie = await getSetCookie();
+    expect(cookie).toMatch(/;\s*Secure/i);
+  });
+
+  it('forces Secure when UI_SESSION_COOKIE_SECURE=true', async () => {
+    process.env.UI_SESSION_COOKIE_SECURE = 'true';
+    const cookie = await getSetCookie();
+    expect(cookie).toMatch(/;\s*Secure/i);
+  });
+
+  it('explicit UI_SESSION_COOKIE_SECURE=false wins over HTTPS_ONLY', async () => {
+    process.env.UI_SESSION_COOKIE_SECURE = 'false';
+    process.env.HTTPS_ONLY = 'true';
+    const cookie = await getSetCookie();
+    expect(cookie).not.toMatch(/;\s*Secure/i);
+  });
+});

--- a/packages/gateway/src/utils/ui-session-cookie.ts
+++ b/packages/gateway/src/utils/ui-session-cookie.ts
@@ -16,6 +16,12 @@ interface UiSessionAuthOptions {
 function isSecureCookie(c: Context): boolean {
   if (process.env.UI_SESSION_COOKIE_SECURE === 'true') return true;
   if (process.env.UI_SESSION_COOKIE_SECURE === 'false') return false;
+  // When the operator has opted into HTTPS-only mode, the session cookie must
+  // always carry the Secure flag — even if TLS is terminated by an upstream
+  // proxy and this hop looks like plain HTTP. Without this, a deployment that
+  // sets HTTPS_ONLY but forgets TRUSTED_PROXY would silently ship the session
+  // cookie without Secure, allowing capture on the plain-HTTP leg (CWE-614).
+  if (process.env.HTTPS_ONLY === 'true') return true;
   // H-S8: X-Forwarded-Proto trusted only behind TRUSTED_PROXY config.
   return isSecureRequest(c.req);
 }

--- a/packages/ui/Dockerfile.dev
+++ b/packages/ui/Dockerfile.dev
@@ -1,6 +1,8 @@
 FROM node:22-alpine
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Pin pnpm to the same version as the production images (reproducible builds;
+# avoids silently pulling a new pnpm major into the dev image).
+RUN corepack enable && corepack prepare pnpm@10.29.3 --activate
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Fixes a **Critical authentication bypass** plus a batch of Low/Info hardening items surfaced by a full `security-check` scan (Recon → Hunt → Verify → Report) of the gateway HTTP API, core sandbox/crypto, and infra.

### 🔴 Critical — `/api/v2/*` reachable without authentication (CWE-306)
The auth + UI-session middleware were scoped to `/api/v1/*` (`app.ts`), but `registerV2Routes()` mounts the **same handler instances** at `/api/v2/*`. Hono matches the prefix literally, so no auth runs for v2 — and the route handlers carry no internal guard. When `auth.type` is `api-key`/`jwt` (default), the entire v2 API (memories, config/credentials, chat, claws/agentic, coding-agents, mcp, extensions, browser) was reachable with **zero credentials** whenever the gateway is network-exposed (tunnel / `0.0.0.0`). Only `/api/v2/debug` and `/api/v2/db` survived (own admin-key guard).

**Fix:** broaden `uiSessionMiddleware` + `createAuthMiddleware` (and cache-control) from `/api/v1/*` → `/api/*`. The unprefixed `/health` route (used by the Docker healthcheck) stays public. Adds 4 regression tests asserting auth runs on `/api/v2/*` and `/api/v1/*`, **not** on `/health`, and isn't mounted when `auth.type: 'none'`.

### 🔵 Hardening
- **SSRF per-hop redirect** — new `safeFetch()` follows redirects manually, re-validating every hop against the block-list instead of only the final URL (`web-fetch.ts`, `file-system.ts` download). +2 tests.
- **Expense amount** — reject NaN/Infinity/negative on POST **and** PUT. +3 tests.
- **Session cookie `Secure`** — forced when `HTTPS_ONLY=true` even on a plain-HTTP upstream hop. +new test file.
- **`release.yml`** — workflow token dropped to `contents: read`; write scopes moved to the job (least privilege).
- **`Dockerfile.dev`** — pnpm pinned to `10.29.3` (was `@latest`).
- **`schema.ts`** — spawn `npx.cmd` directly instead of `shell: true` on Windows.
- **`agentskills-parser`** — skip `__proto__`/`constructor`/`prototype` keys (prototype-pollution defense-in-depth).
- **`database/index.ts`** — accept `ADMIN_API_KEY` (canonical) with `ADMIN_KEY` fallback.
- **`SECURITY.md`** — added a Deployment Hardening section (TRUSTED_PROXY, cookie Secure, MQTT creds, API auth).

### Already-mitigated / N-A (verified, no change)
- WS `event:publish` is already namespace-restricted (`external.*`/`client.*`) + blocklist + length cap.
- `custom_data_records` has no owner column (global, single-tenant by design).

## Test plan
- Full **gateway** suite: 17,608 pass (453 files, 0 fail)
- Full **core** suite: 9,509 pass (147 files, 0 fail)
- Gateway + core typecheck clean; ESLint clean on changed files

> Note: a `process.env` restore in the new cookie test was assigning the string `"undefined"` and polluting sibling test files under the reshuffled worker sharding — fixed to `delete` when originally unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)