### PR TITLE
security: production auth guard — AUTH_TYPE=none + exposed host fatal

### DIFF
--- a/packages/gateway/src/config/validation.test.ts
+++ b/packages/gateway/src/config/validation.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+// The module uses process.env directly — test by mutating the env and re-importing
+
+function getModule() {
+  // Clear any cached module
+  const modPath = '../config/validation.js';
+  const fullPath = new URL(modPath, import.meta.url).pathname;
+  delete require?.cache?.[fullPath];
+  // Dynamic import gets fresh module state
+  return import('../config/validation.js') as Promise<{
+    assertBootConfig: () => void;
+  }>;
+}
+
+describe('validateBootConfig', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    // Reset NODE_ENV for each test
+    process.env.NODE_ENV = 'production';
+  });
+
+  afterEach(() => {
+    // Restore original env
+    Object.assign(process.env, originalEnv);
+  });
+
+  describe('production auth guard', () => {
+    it('passes when HOST is localhost (default) with AUTH_TYPE=none', async () => {
+      process.env.HOST = '127.0.0.1';
+      process.env.AUTH_TYPE = 'none';
+      // Should not throw — localhost is safe
+      const { assertBootConfig } = await getModule();
+      expect(() => assertBootConfig()).not.toThrow();
+    });
+
+    it('fails fatally when HOST is exposed and AUTH_TYPE=none in production', async () => {
+      process.env.HOST = '0.0.0.0';
+      process.env.AUTH_TYPE = 'none';
+      process.env.NODE_ENV = 'production';
+
+      const { assertBootConfig } = await getModule();
+      expect(() => assertBootConfig()).toThrow(); // process.exit is not called in test, but errors cause exit
+    });
+
+    it('passes when HOST is exposed but AUTH_TYPE=api-key and API_KEYS set', async () => {
+      process.env.HOST = '0.0.0.0';
+      process.env.AUTH_TYPE = 'api-key';
+      process.env.API_KEYS = 'sk-test-key';
+
+      const { assertBootConfig } = await getModule();
+      expect(() => assertBootConfig()).not.toThrow();
+    });
+  });
+
+  describe('non-production', () => {
+    it('allows AUTH_TYPE=none on exposed host in dev', async () => {
+      process.env.HOST = '0.0.0.0';
+      process.env.AUTH_TYPE = 'none';
+      process.env.NODE_ENV = 'development';
+
+      const { assertBootConfig } = await getModule();
+      // Should not exit in dev — just warn
+      expect(() => assertBootConfig()).not.toThrow();
+    });
+  });
+});

--- a/packages/gateway/src/config/validation.ts
+++ b/packages/gateway/src/config/validation.ts
@@ -193,7 +193,32 @@ function validateBootConfig(): ValidationResult {
     }
   }
 
-  // 5. Warn about CORS_ORIGINS in production if it looks like a template
+  // 5. Production auth guard: non-loopback host + no auth = fatal
+  const host = process.env.HOST ?? '127.0.0.1';
+  const isExposed = host !== '127.0.0.1' && host !== 'localhost' && host !== '::1' && host !== '';
+  if (isExposed && isProduction) {
+    // 5a. Explicit auth disabled on exposed host
+    const authType = process.env.AUTH_TYPE ?? '';
+    if (authType === 'none') {
+      errors.push(
+        `[FATAL] AUTH_TYPE=none with HOST=${host} — the server is exposed on the network without authentication.\n` +
+          `         Set AUTH_TYPE=api-key and API_KEYS, or restrict HOST to 127.0.0.1.`
+      );
+    }
+
+    // 5b. No credentials configured on exposed host
+    const apiKeys = process.env.API_KEYS ?? '';
+    const jwtSecret = process.env.JWT_SECRET ?? '';
+    const hasNoCredentials = !apiKeys && !jwtSecret;
+    if (hasNoCredentials && authType !== 'jwt') {
+      warnings.push(
+        `[WARN] HOST=${host} is exposed on the network but no API_KEYS or JWT_SECRET are configured.\n` +
+          `         In production this will prevent secure remote access — set API_KEYS or JWT_SECRET.`
+      );
+    }
+  }
+
+  // 6. Warn about CORS_ORIGINS in production if it looks like a template
   const corsOrigins = process.env.CORS_ORIGINS;
   if (isProduction && corsOrigins && corsOrigins.includes('localhost')) {
     warnings.push(


### PR DESCRIPTION
## Summary

Production auth guard: when the server is configured to listen on a network interface (non-loopback HOST) with authentication explicitly disabled (AUTH_TYPE=none), the boot process now exits with a fatal error in production mode.

## Changes

### `packages/gateway/src/config/validation.ts`
- **New check 5a**: `AUTH_TYPE=none` + non-loopback `HOST` = fatal boot error in production
- **New check 5b**: Exposed host + no `API_KEYS` or `JWT_SECRET` configured = boot warning
- Safe on localhost (127.0.0.1, localhost, ::1) — no change for dev defaults

### `packages/gateway/src/config/validation.test.ts` (new)
- Test scaffolding for config validation (first test file for this module)

## Why

The security audit identified that running with AUTH_TYPE=none on a non-loopback interface (e.g., 0.0.0.0) exposes all APIs without authentication. In production, this should be a hard block — not just a warning.

## Verification
- Gateway typecheck ✅