### PR TITLE
fix: channel_users.status column missing — Telegram/WhatsApp 500 error (GH#108)

### DIFF
--- a/packages/gateway/src/db/migrations/postgres/001_initial_schema.sql
+++ b/packages/gateway/src/db/migrations/postgres/001_initial_schema.sql
@@ -1,7 +1,7 @@
 -- OwnPilot PostgreSQL Schema
 -- Squashed migration: single file for Docker first-time init.
 -- Generated from TypeScript schema modules (source of truth).
--- Generated: 2026-07-10T10:25:34.057Z
+-- Generated: 2026-07-10T10:38:21.059Z
 -- Do not edit manually — regenerate via: tsx scripts/generate-squashed-migration.ts
 
 -- =====================================================
@@ -1329,6 +1329,7 @@ CREATE TABLE IF NOT EXISTS channel_users (
   verified_at TIMESTAMP,
   verification_method TEXT,
   is_blocked BOOLEAN NOT NULL DEFAULT FALSE,
+  status TEXT NOT NULL DEFAULT 'active',
   metadata JSONB DEFAULT '{}',
   first_seen_at TIMESTAMP NOT NULL DEFAULT NOW(),
   last_seen_at TIMESTAMP NOT NULL DEFAULT NOW(),
@@ -1965,6 +1966,16 @@ CREATE INDEX IF NOT EXISTS idx_agent_souls_skill_access ON agent_souls USING GIN
 DO $$ BEGIN
   IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'heartbeat_log' AND column_name = 'tool_calls') THEN
     ALTER TABLE heartbeat_log ADD COLUMN tool_calls JSONB DEFAULT '[]';
+  END IF;
+END $$;
+
+-- =====================================================
+-- MIGRATION: Add status column to channel_users (missing from initial schema, GH#108)
+-- =====================================================
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'channel_users' AND column_name = 'status') THEN
+    ALTER TABLE channel_users ADD COLUMN status TEXT NOT NULL DEFAULT 'active';
   END IF;
 END $$;
 

--- a/packages/gateway/src/db/schema/channels.ts
+++ b/packages/gateway/src/db/schema/channels.ts
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS channel_users (
   verified_at TIMESTAMP,
   verification_method TEXT,
   is_blocked BOOLEAN NOT NULL DEFAULT FALSE,
+  status TEXT NOT NULL DEFAULT 'active',
   metadata JSONB DEFAULT '{}',
   first_seen_at TIMESTAMP NOT NULL DEFAULT NOW(),
   last_seen_at TIMESTAMP NOT NULL DEFAULT NOW(),
@@ -74,6 +75,16 @@ CREATE TABLE IF NOT EXISTS channel_assets (
 `;
 
 export const CHANNELS_MIGRATIONS_SQL = `
+-- =====================================================
+-- MIGRATION: Add status column to channel_users (missing from initial schema, GH#108)
+-- =====================================================
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'channel_users' AND column_name = 'status') THEN
+    ALTER TABLE channel_users ADD COLUMN status TEXT NOT NULL DEFAULT 'active';
+  END IF;
+END $$;
+
 -- =====================================================
 -- MIGRATION: Rename skill_packages -> user_extensions (MUST run BEFORE CREATE TABLE)
 -- =====================================================


### PR DESCRIPTION
## Fixes #108

**Root cause:** The `channel_users` table's CREATE TABLE statement was missing the `status` column that the repository code has always expected. This caused a 500 error on incoming messages on fresh Docker installs.

## Changes

### `packages/gateway/src/db/schema/channels.ts`
- **CREATE TABLE**: Added `status TEXT NOT NULL DEFAULT 'active'` to `channel_users`
- **Migration**: Added idempotent ALTER TABLE for existing databases

### `packages/gateway/src/db/migrations/postgres/001_initial_schema.sql`
- **Regenerated** via `generate-squashed-migration.ts` to include the new column

## Workaround
Existing databases can fix with:
```sql
ALTER TABLE channel_users ADD COLUMN status TEXT NOT NULL DEFAULT 'active';
```
The migration in this PR does this automatically on next boot.

## Verification
- Gateway typecheck ✅
- Schema test (3/3) ✅
- Channels repo tests (257/257) ✅